### PR TITLE
Add GitHub Actions workflow for contributors list

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,14 @@
+---
+name: Contributors
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/contributors-list@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          round: true


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automatically generate and update the contributors list on pushes to the main branch.