### PR TITLE
Add Dockerfile and GitHub Actions workflow for GHCR publishing

### DIFF
--- a/.github/workflows/ghcr_publish.yml
+++ b/.github/workflows/ghcr_publish.yml
@@ -1,0 +1,79 @@
+---
+    name: GHCR Publish
+    # This workflow uses actions that are not certified by GitHub.
+    # They are provided by a third-party and are governed by
+    # separate terms of service, privacy policy, and support
+    # documentation.
+    on:
+      push:
+        branches: [main]
+      release:
+        types: [published]
+      workflow_dispatch:
+    
+    env:
+      # Use docker.io for Docker Hub if empty
+      REGISTRY: ghcr.io
+      # github.repository as <account>/<repo>
+      IMAGE_NAME: ${{ github.repository }}
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
+          # This is used to complete the identity challenge
+          # with sigstore/fulcio when running outside of PRs.
+          id-token: write
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+    
+          # Install the cosign tool except on PR
+          # https://github.com/sigstore/cosign-installer
+          - name: Install cosign
+            if: github.event_name != 'pull_request'
+            uses: sigstore/cosign-installer@v3.1.1
+            with:
+              cosign-release: v2.1.1
+    
+          # Using QEME for multiple platforms
+          # https://github.com/docker/build-push-action?tab=readme-ov-file#usage
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v3
+    
+          # Workaround: https://github.com/docker/build-push-action/issues/461
+          - name: Setup Docker buildx
+            uses: docker/setup-buildx-action@v3
+    
+          # Login against a Docker registry except on PR
+          # https://github.com/docker/login-action
+          - name: Log into registry ${{ env.REGISTRY }}
+            if: github.event_name != 'pull_request'
+            uses: docker/login-action@v3
+            with:
+              registry: ${{ env.REGISTRY }}
+              username: ${{ github.actor }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+    
+          # Extract metadata (tags, labels) for Docker
+          # https://github.com/docker/metadata-action
+          - name: Extract Docker metadata
+            id: meta
+            uses: docker/metadata-action@v5
+            with:
+              images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    
+          # Build and push Docker image with Buildx (don't push on PR)
+          # https://github.com/docker/build-push-action
+          - name: Build and push Docker image
+            id: build-and-push
+            uses: docker/build-push-action@v5
+            with:
+              context: .
+              push: true
+              tags: ${{ steps.meta.outputs.tags }}
+              labels: ${{ steps.meta.outputs.labels }}
+              platforms: linux/amd64, linux/arm64
+              cache-from: type=gha
+              cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+FROM rust:alpine3.21 AS chef
+
+WORKDIR /usr/src/project
+
+RUN set -eux; \
+    apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconfig; \
+    cargo install cargo-chef; \
+    rm -rf $CARGO_HOME/registry
+
+FROM chef as planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+COPY --from=planner /usr/src/project/recipe.json .
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release
+
+FROM alpine:3.21
+
+WORKDIR /usr/local/bin
+
+# Install runtime dependencies
+RUN apk add --no-cache openssl libgcc
+
+COPY --from=builder /usr/src/project/target/release/urx .
+
+CMD ["./urx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:alpine3.21 AS chef
+FROM rust:1.85.1-alpine3.20 AS chef
 
 WORKDIR /usr/src/project
 
@@ -23,11 +23,20 @@ RUN cargo build --release
 
 FROM alpine:3.21
 
-WORKDIR /usr/local/bin
+# Create a non-root user and group
+RUN addgroup -S app && adduser -S -G app app
+
+WORKDIR /app
 
 # Install runtime dependencies
 RUN apk add --no-cache openssl libgcc
 
 COPY --from=builder /usr/src/project/target/release/urx .
+
+# Change ownership of the binary to the non-root user
+RUN chown -R app:app .
+
+# Switch to the non-root user
+USER app
 
 CMD ["./urx"]


### PR DESCRIPTION
Introduce a Dockerfile for building the project and a GitHub Actions workflow to automate the publishing of Docker images to GitHub Container Registry. This setup enhances the CI/CD process for the repository.