### PR TITLE
Add silent mode and no progress options to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Added --silent, --no-progress flag
+
+## 0.1.0
+
+- Initial release
+- Project foundation established

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Provider Options:
       --subs                   Include subdomains when searching
 
 Display Options:
-  -v, --verbose  Show verbose output
+  -v, --verbose      Show verbose output
+      --silent       Silent mode (no output)
+      --no-progress  No progress bar
 
 Filter Options:
   -e, --extensions <EXTENSIONS>

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,10 +2,7 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[clap(
-    name = "urx",
-    version
-)]
+#[clap(name = "urx", version)]
 pub struct Args {
     /// Domains to fetch URLs for
     #[clap(name = "DOMAINS")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[clap(
     name = "urx",
-    about = "Extracts URLs from OSINT Archives for Security Insights.",
     version
 )]
 pub struct Args {
@@ -46,6 +45,16 @@ pub struct Args {
     /// Show verbose output
     #[clap(short, long)]
     pub verbose: bool,
+
+    #[clap(help_heading = "Display Options")]
+    /// Silent mode (no output)
+    #[clap(long)]
+    pub silent: bool,
+
+    #[clap(help_heading = "Display Options")]
+    /// No progress bar
+    #[clap(long)]
+    pub no_progress: bool,
 
     #[clap(help_heading = "Filter Options")]
     /// Filter URLs to only include those with specific extensions (comma-separated, e.g., "js,php,aspx")

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,13 @@ use providers::{CommonCrawlProvider, OTXProvider, Provider, WaybackMachineProvid
 use testers::{LinkExtractor, StatusChecker, Tester};
 use url_utils::{UrlFilter, UrlTransformer};
 
+/// Helper function to print verbose messages
+fn verbose_print(args: &Args, message: impl AsRef<str>) {
+    if args.verbose && !args.silent {
+        println!("{}", message.as_ref());
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
@@ -231,14 +238,15 @@ async fn main() -> Result<()> {
         domain_bar.set_position(idx as u64);
         domain_bar.set_message(format!("Processing {}", domain));
 
-        if args.verbose && !args.silent {
-            println!(
+        verbose_print(
+            &args,
+            format!(
                 "Processing domain [{}/{}]: {}",
                 idx + 1,
                 total_domains,
                 domain
-            );
-        }
+            ),
+        );
 
         let mut tasks = Vec::new();
         let provider_bars = progress_manager.create_provider_bars(&provider_names);
@@ -393,9 +401,7 @@ async fn main() -> Result<()> {
     let mut final_urls = transformed_urls.clone();
 
     if args.check_status || args.extract_links {
-        if args.verbose && !args.silent {
-            println!("Applying testing options...");
-        }
+        verbose_print(&args, "Applying testing options...");
 
         // Create progress bar for testing
         let test_bar = progress_manager.create_test_bar(transformed_urls.len());
@@ -405,10 +411,9 @@ async fn main() -> Result<()> {
         let mut testers: Vec<Box<dyn Tester>> = Vec::new();
 
         if args.check_status {
-            if args.verbose && !args.silent {
-                println!("Checking HTTP status codes for URLs");
-            }
+            verbose_print(&args, "Checking HTTP status codes for URLs");
 
+            // Apply network settings
             let mut status_checker = StatusChecker::new();
 
             // Apply network settings

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,7 +9,7 @@ pub use writer::*;
 
 pub trait Outputter: Send + Sync {
     fn format(&self, url: &str, is_last: bool) -> String;
-    fn output(&self, urls: &[String], output_path: Option<PathBuf>) -> Result<()>;
+    fn output(&self, urls: &[String], output_path: Option<PathBuf>, silent: bool) -> Result<()>;
 }
 
 pub fn create_outputter(format: &str) -> Box<dyn Outputter> {

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -25,7 +25,7 @@ impl Outputter for PlainOutputter {
         self.formatter.format(url, is_last)
     }
 
-    fn output(&self, urls: &[String], output_path: Option<PathBuf>) -> Result<()> {
+    fn output(&self, urls: &[String], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
@@ -38,6 +38,10 @@ impl Outputter for PlainOutputter {
                 Ok(())
             }
             None => {
+                if silent {
+                    return Ok(());
+                };
+
                 for (i, url) in urls.iter().enumerate() {
                     let formatted = self.format(url, i == urls.len() - 1);
                     print!("{}", formatted);
@@ -66,7 +70,7 @@ impl Outputter for JsonOutputter {
         self.formatter.format(url, is_last)
     }
 
-    fn output(&self, urls: &[String], output_path: Option<PathBuf>) -> Result<()> {
+    fn output(&self, urls: &[String], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
@@ -85,6 +89,10 @@ impl Outputter for JsonOutputter {
                 Ok(())
             }
             None => {
+                if silent {
+                    return Ok(());
+                };
+
                 print!("[");
 
                 for (i, url) in urls.iter().enumerate() {
@@ -117,7 +125,7 @@ impl Outputter for CsvOutputter {
         self.formatter.format(url, is_last)
     }
 
-    fn output(&self, urls: &[String], output_path: Option<PathBuf>) -> Result<()> {
+    fn output(&self, urls: &[String], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
@@ -134,6 +142,10 @@ impl Outputter for CsvOutputter {
                 Ok(())
             }
             None => {
+                if silent {
+                    return Ok(());
+                };
+
                 println!("url");
 
                 for (i, url) in urls.iter().enumerate() {
@@ -203,7 +215,7 @@ mod tests {
         let temp_file = NamedTempFile::new()?;
         let temp_path = temp_file.path().to_path_buf();
 
-        outputter.output(&urls, Some(temp_path.clone()))?;
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
 
         let mut content = String::new();
         let mut file = File::open(&temp_path)?;
@@ -228,7 +240,7 @@ mod tests {
         let temp_file = NamedTempFile::new()?;
         let temp_path = temp_file.path().to_path_buf();
 
-        outputter.output(&urls, Some(temp_path.clone()))?;
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
 
         let mut content = String::new();
         let mut file = File::open(&temp_path)?;
@@ -253,7 +265,7 @@ mod tests {
         let temp_file = NamedTempFile::new()?;
         let temp_path = temp_file.path().to_path_buf();
 
-        outputter.output(&urls, Some(temp_path.clone()))?;
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
 
         let mut content = String::new();
         let mut file = File::open(&temp_path)?;
@@ -275,7 +287,7 @@ mod tests {
         let temp_file = NamedTempFile::new()?;
         let temp_path = temp_file.path().to_path_buf();
 
-        outputter.output(&urls, Some(temp_path.clone()))?;
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
 
         let mut content = String::new();
         let mut file = File::open(&temp_path)?;

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_progress_manager_creation() {
-        let manager = ProgressManager::new(false);
+        let _manager = ProgressManager::new(false);
         // Just verify it can be created without error
         assert!(true);
     }

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -2,16 +2,25 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 pub struct ProgressManager {
     multi_progress: MultiProgress,
+    no_progress: bool,
 }
 
 impl ProgressManager {
-    pub fn new() -> Self {
+    pub fn new(no_progress: bool) -> Self {
         ProgressManager {
             multi_progress: MultiProgress::new(),
+            no_progress,
         }
     }
 
     pub fn create_domain_bar(&self, total: usize) -> ProgressBar {
+        if self.no_progress {
+            // Return a hidden progress bar when progress is disabled
+            let bar = ProgressBar::hidden();
+            bar.set_length(total as u64);
+            return bar;
+        }
+
         let style = ProgressStyle::with_template(
             "{prefix:.bold.dim} [{bar:40.cyan/blue}] {pos}/{len} {wide_msg}",
         )
@@ -27,6 +36,18 @@ impl ProgressManager {
     }
 
     pub fn create_provider_bars(&self, provider_names: &[String]) -> Vec<ProgressBar> {
+        if self.no_progress {
+            // Return hidden progress bars when progress is disabled
+            return provider_names
+                .iter()
+                .map(|_| {
+                    let bar = ProgressBar::hidden();
+                    bar.set_length(100);
+                    bar
+                })
+                .collect();
+        }
+
         let style = ProgressStyle::with_template(
             "{prefix:.bold.dim} [{bar:30.green/white}] {spinner} {wide_msg}",
         )
@@ -57,6 +78,13 @@ impl ProgressManager {
     }
 
     pub fn create_filter_bar(&self) -> ProgressBar {
+        if self.no_progress {
+            // Return a hidden progress bar when progress is disabled
+            let bar = ProgressBar::hidden();
+            bar.set_length(100);
+            return bar;
+        }
+
         let style =
             ProgressStyle::with_template("{prefix:.bold.dim} [{bar:40.yellow/white}] {wide_msg}")
                 .unwrap()
@@ -71,6 +99,13 @@ impl ProgressManager {
     }
 
     pub fn create_transform_bar(&self) -> ProgressBar {
+        if self.no_progress {
+            // Return a hidden progress bar when progress is disabled
+            let bar = ProgressBar::hidden();
+            bar.set_length(100);
+            return bar;
+        }
+
         let style =
             ProgressStyle::with_template("{prefix:.bold.dim} [{bar:40.magenta/white}] {wide_msg}")
                 .unwrap()
@@ -85,6 +120,13 @@ impl ProgressManager {
     }
 
     pub fn create_test_bar(&self, total: usize) -> ProgressBar {
+        if self.no_progress {
+            // Return a hidden progress bar when progress is disabled
+            let bar = ProgressBar::hidden();
+            bar.set_length(total as u64);
+            return bar;
+        }
+
         let style = ProgressStyle::with_template(
             "{prefix:.bold.dim} [{bar:40.blue/white}] {pos}/{len} {wide_msg}",
         )
@@ -106,14 +148,14 @@ mod tests {
 
     #[test]
     fn test_progress_manager_creation() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         // Just verify it can be created without error
         assert!(true);
     }
 
     #[test]
     fn test_create_domain_bar() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         let bar = manager.create_domain_bar(10);
 
         assert_eq!(bar.length(), Some(10));
@@ -122,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_create_provider_bars() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         let provider_names = vec!["wayback".to_string(), "cc".to_string(), "otx".to_string()];
 
         let bars = manager.create_provider_bars(&provider_names);
@@ -136,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_create_filter_bar() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         let bar = manager.create_filter_bar();
 
         assert_eq!(bar.length(), Some(100));
@@ -145,7 +187,7 @@ mod tests {
 
     #[test]
     fn test_create_transform_bar() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         let bar = manager.create_transform_bar();
 
         assert_eq!(bar.length(), Some(100));
@@ -154,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_create_test_bar() {
-        let manager = ProgressManager::new();
+        let manager = ProgressManager::new(false);
         let bar = manager.create_test_bar(50);
 
         assert_eq!(bar.length(), Some(50));


### PR DESCRIPTION
Introduce silent mode to suppress output and a no progress option to disable progress bars in the CLI. These enhancements improve user experience by allowing for quieter operations.