### PR TITLE
Reorder cc_index field and update WaybackMachineProvider URL to HTTPS

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,11 +23,6 @@ pub struct Args {
     #[clap(long)]
     pub merge_endpoint: bool,
 
-    #[clap(help_heading = "Provider Options")]
-    /// Common Crawl index to use (e.g., CC-MAIN-2025-08)
-    #[clap(long, default_value = "CC-MAIN-2025-08")]
-    pub cc_index: String,
-
     /// Providers to use (comma-separated, e.g., "wayback,cc,otx")
     #[clap(help_heading = "Provider Options")]
     #[clap(long, value_delimiter = ',', default_value = "wayback,cc,otx")]
@@ -37,6 +32,11 @@ pub struct Args {
     #[clap(help_heading = "Provider Options")]
     #[clap(long)]
     pub subs: bool,
+
+    #[clap(help_heading = "Provider Options")]
+    /// Common Crawl index to use (e.g., CC-MAIN-2025-08)
+    #[clap(long, default_value = "CC-MAIN-2025-08")]
+    pub cc_index: String,
 
     #[clap(help_heading = "Display Options")]
     /// Show verbose output

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -38,6 +38,9 @@ pub struct Args {
     #[clap(long, default_value = "CC-MAIN-2025-08")]
     pub cc_index: String,
 
+    #[clap(long)]
+    pub subs: bool,
+
     #[clap(help_heading = "Display Options")]
     /// Show verbose output
     #[clap(short, long)]

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -45,12 +45,12 @@ impl Provider for WaybackMachineProvider {
             // Handle subdomain inclusion in URL construction
             let url = if self.include_subdomains {
                 format!(
-                    "http://web.archive.org/cdx/search/cdx?url=*.{}/*&output=json&fl=original",
+                    "https://web.archive.org/cdx/search/cdx?url=*.{}/*&output=json&fl=original",
                     domain
                 )
             } else {
                 format!(
-                    "http://web.archive.org/cdx/search/cdx?url={}/*&output=json&fl=original",
+                    "https://web.archive.org/cdx/search/cdx?url={}/*&output=json&fl=original",
                     domain
                 )
             };


### PR DESCRIPTION
Reorder the `cc_index` field in the `Args` struct for better organization and update the WaybackMachineProvider URL to use HTTPS for improved security.