### PR TITLE
Add network settings module and insecure option for SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-- Empty
+- Added `--insecure`, `--network-scope` flags
 
 ## 0.2.0
 
-- Added `--silent`, `--no-progress` flag
+- Added `--silent`, `--no-progress` flags
 - Added `-p (--preset)` flag
 
 ## 0.1.0

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -103,6 +103,11 @@ pub struct Args {
     #[clap(long = "max-length")]
     pub max_length: Option<usize>,
 
+    /// Control which components network settings apply to (all, providers, testers, or providers,testers)
+    #[clap(help_heading = "Network Options")]
+    #[clap(long, default_value = "all")]
+    pub network_scope: String,
+
     #[clap(help_heading = "Network Options")]
     /// Use proxy for HTTP requests (format: http://proxy.example.com:8080)
     #[clap(long)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,7 +105,7 @@ pub struct Args {
 
     /// Control which components network settings apply to (all, providers, testers, or providers,testers)
     #[clap(help_heading = "Network Options")]
-    #[clap(long, default_value = "all")]
+    #[clap(long, default_value = "all", value_parser = validate_network_scope)]
     pub network_scope: String,
 
     #[clap(help_heading = "Network Options")]
@@ -174,4 +174,11 @@ pub fn read_domains_from_stdin() -> anyhow::Result<Vec<String>> {
     }
 
     Ok(domains)
+}
+
+fn validate_network_scope(s: &str) -> Result<String, String> {
+    match s {
+        "all" | "providers" | "testers" | "providers,testers" | "testers,providers" => Ok(s.to_string()),
+        _ => Err(format!("Invalid network scope: {}. Allowed values are all, providers, testers, or providers,testers", s)),
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -113,6 +113,11 @@ pub struct Args {
     #[clap(long)]
     pub proxy_auth: Option<String>,
 
+    /// Skip SSL certificate verification (accept self-signed certs)
+    #[clap(help_heading = "Network Options")]
+    #[clap(long)]
+    pub insecure: bool,
+
     /// Use a random User-Agent for HTTP requests
     #[clap(help_heading = "Network Options")]
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod url_utils;
 
 use cli::{read_domains_from_stdin, Args};
 use filters::UrlFilter;
-use network::NetworkSettings;
+use network::{NetworkScope, NetworkSettings};
 use output::create_outputter;
 use progress::ProgressManager;
 use providers::{CommonCrawlProvider, OTXProvider, Provider, WaybackMachineProvider};
@@ -537,6 +537,11 @@ async fn main() -> Result<()> {
 
 /// Helper function to apply network settings to a provider
 fn apply_network_settings_to_provider(provider: &mut dyn Provider, settings: &NetworkSettings) {
+    // Skip applying settings if network scope doesn't include providers
+    if settings.scope == NetworkScope::Testers {
+        return;
+    }
+
     provider.with_subdomains(settings.include_subdomains);
     provider.with_timeout(settings.timeout);
     provider.with_retries(settings.retries);
@@ -559,6 +564,11 @@ fn apply_network_settings_to_provider(provider: &mut dyn Provider, settings: &Ne
 
 /// Helper function to apply network settings to a tester
 fn apply_network_settings_to_tester(tester: &mut dyn Tester, settings: &NetworkSettings) {
+    // Skip applying settings if network scope doesn't include testers
+    if settings.scope == NetworkScope::Providers {
+        return;
+    }
+
     tester.with_timeout(settings.timeout);
     tester.with_retries(settings.retries);
     tester.with_random_agent(settings.random_agent);

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,10 +83,7 @@ async fn main() -> Result<()> {
         wayback_provider.with_timeout(args.timeout);
         wayback_provider.with_retries(args.retries);
         wayback_provider.with_random_agent(args.random_agent);
-        wayback_provider.with_parallel(args.parallel);
-        if let Some(rate) = args.rate_limit {
-            wayback_provider.with_rate_limit(Some(rate));
-        }
+        wayback_provider.with_insecure(args.insecure);
 
         if args.verbose && args.random_agent && !args.silent {
             println!("Random User-Agent enabled for Wayback Machine");
@@ -144,6 +141,7 @@ async fn main() -> Result<()> {
         cc_provider.with_timeout(args.timeout);
         cc_provider.with_retries(args.retries);
         cc_provider.with_random_agent(args.random_agent);
+        cc_provider.with_insecure(args.insecure);
         cc_provider.with_parallel(args.parallel);
         if let Some(rate) = args.rate_limit {
             cc_provider.with_rate_limit(Some(rate));
@@ -199,6 +197,7 @@ async fn main() -> Result<()> {
         otx_provider.with_timeout(args.timeout);
         otx_provider.with_retries(args.retries);
         otx_provider.with_random_agent(args.random_agent);
+        otx_provider.with_insecure(args.insecure);
         otx_provider.with_parallel(args.parallel);
         if let Some(rate) = args.rate_limit {
             otx_provider.with_rate_limit(Some(rate));
@@ -432,6 +431,7 @@ async fn main() -> Result<()> {
             status_checker.with_timeout(args.timeout);
             status_checker.with_retries(args.retries);
             status_checker.with_random_agent(args.random_agent);
+            status_checker.with_insecure(args.insecure);
 
             if let Some(proxy) = &args.proxy {
                 status_checker.with_proxy(Some(proxy.clone()));
@@ -455,6 +455,7 @@ async fn main() -> Result<()> {
             link_extractor.with_timeout(args.timeout);
             link_extractor.with_retries(args.retries);
             link_extractor.with_random_agent(args.random_agent);
+            link_extractor.with_insecure(args.insecure);
 
             if let Some(proxy) = &args.proxy {
                 link_extractor.with_proxy(Some(proxy.clone()));

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,8 +1,8 @@
-//! Network configuration module
-//!
-//! This module provides shared network configuration functionality for HTTP requests
-//! across different parts of the application, such as providers and testers.
+// Network configuration module
+//
+// This module provides shared network configuration functionality for HTTP requests
+// across different parts of the application, such as providers and testers.
 
 mod settings;
 
-pub use settings::NetworkSettings;
+pub use settings::{NetworkScope, NetworkSettings};

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,8 @@
+//! Network configuration module
+//!
+//! This module provides shared network configuration functionality for HTTP requests
+//! across different parts of the application, such as providers and testers.
+
+mod settings;
+
+pub use settings::NetworkSettings;

--- a/src/network/settings.rs
+++ b/src/network/settings.rs
@@ -1,0 +1,135 @@
+/// Shared network configuration settings for HTTP requests
+///
+/// This struct centralizes common HTTP request settings used throughout
+/// the application to avoid code duplication between providers and testers.
+#[derive(Clone, Debug)]
+pub struct NetworkSettings {
+    /// Proxy server URL (e.g., "http://proxy.example.com:8080")
+    pub proxy: Option<String>,
+
+    /// Proxy authentication in the format "username:password"
+    pub proxy_auth: Option<String>,
+
+    /// Request timeout in seconds
+    pub timeout: u64,
+
+    /// Number of retry attempts for failed requests
+    pub retries: u32,
+
+    /// Whether to use random User-Agent headers
+    pub random_agent: bool,
+
+    /// Whether to skip SSL certificate verification
+    pub insecure: bool,
+
+    /// Maximum number of parallel requests
+    pub parallel: u32,
+
+    /// Rate limit in requests per second
+    pub rate_limit: Option<f32>,
+
+    /// Whether to include subdomains in search
+    pub include_subdomains: bool,
+}
+
+impl Default for NetworkSettings {
+    fn default() -> Self {
+        Self {
+            proxy: None,
+            proxy_auth: None,
+            timeout: 30,
+            retries: 3,
+            random_agent: false,
+            insecure: false,
+            parallel: 5,
+            rate_limit: None,
+            include_subdomains: false,
+        }
+    }
+}
+
+impl NetworkSettings {
+    /// Creates a new instance with default settings
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable or disable subdomain inclusion
+    pub fn with_subdomains(mut self, include: bool) -> Self {
+        self.include_subdomains = include;
+        self
+    }
+
+    /// Set the proxy server for HTTP requests
+    pub fn with_proxy(mut self, proxy: Option<String>) -> Self {
+        self.proxy = proxy;
+        self
+    }
+
+    /// Set the proxy authentication credentials
+    pub fn with_proxy_auth(mut self, auth: Option<String>) -> Self {
+        self.proxy_auth = auth;
+        self
+    }
+
+    /// Set the request timeout in seconds
+    pub fn with_timeout(mut self, seconds: u64) -> Self {
+        self.timeout = seconds;
+        self
+    }
+
+    /// Set the number of retry attempts for failed requests
+    pub fn with_retries(mut self, count: u32) -> Self {
+        self.retries = count;
+        self
+    }
+
+    /// Enable or disable the use of random User-Agent headers
+    pub fn with_random_agent(mut self, enabled: bool) -> Self {
+        self.random_agent = enabled;
+        self
+    }
+
+    /// Enable or disable SSL certificate verification
+    pub fn with_insecure(mut self, enabled: bool) -> Self {
+        self.insecure = enabled;
+        self
+    }
+
+    /// Set the number of parallel requests
+    pub fn with_parallel(mut self, count: u32) -> Self {
+        self.parallel = count;
+        self
+    }
+
+    /// Set rate limiting to avoid being blocked
+    pub fn with_rate_limit(mut self, requests_per_second: Option<f32>) -> Self {
+        self.rate_limit = requests_per_second;
+        self
+    }
+
+    /// Apply settings from command line arguments
+    pub fn from_args(args: &crate::cli::Args) -> Self {
+        let mut settings = NetworkSettings::new()
+            .with_timeout(args.timeout)
+            .with_retries(args.retries)
+            .with_random_agent(args.random_agent)
+            .with_insecure(args.insecure)
+            .with_parallel(args.parallel)
+            .with_subdomains(args.subs);
+
+        if let Some(rate) = args.rate_limit {
+            settings = settings.with_rate_limit(Some(rate));
+        }
+
+        if let Some(proxy) = &args.proxy {
+            settings = settings.with_proxy(Some(proxy.clone()));
+
+            if let Some(auth) = &args.proxy_auth {
+                settings = settings.with_proxy_auth(Some(auth.clone()));
+            }
+        }
+
+        settings
+    }
+}

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -14,6 +14,7 @@ pub struct CommonCrawlProvider {
     timeout: u64,
     retries: u32,
     random_agent: bool,
+    insecure: bool,
     parallel: u32,
     rate_limit: Option<f32>,
 }
@@ -34,6 +35,7 @@ impl CommonCrawlProvider {
             timeout: 10,
             retries: 3,
             random_agent: true,
+            insecure: false,
             parallel: 1,
             rate_limit: None,
         }
@@ -49,6 +51,7 @@ impl CommonCrawlProvider {
             timeout: 10,
             retries: 3,
             random_agent: true,
+            insecure: false,
             parallel: 1,
             rate_limit: None,
         }
@@ -81,6 +84,11 @@ impl Provider for CommonCrawlProvider {
             // Create client builder with timeout
             let mut client_builder =
                 reqwest::Client::builder().timeout(std::time::Duration::from_secs(self.timeout));
+
+            // Skip SSL verification if insecure is enabled
+            if self.insecure {
+                client_builder = client_builder.danger_accept_invalid_certs(true);
+            }
 
             // Add random user agent if enabled
             if self.random_agent {
@@ -213,6 +221,10 @@ impl Provider for CommonCrawlProvider {
 
     fn with_random_agent(&mut self, enabled: bool) {
         self.random_agent = enabled;
+    }
+
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
     }
 
     fn with_parallel(&mut self, parallel: u32) {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -43,6 +43,9 @@ pub trait Provider: Send + Sync {
     /// Enable or disable the use of random User-Agent headers
     fn with_random_agent(&mut self, enabled: bool);
 
+    /// Enable or disable SSL certificate verification (for self-signed certificates)
+    fn with_insecure(&mut self, enabled: bool);
+
     /// Set the number of parallel requests
     fn with_parallel(&mut self, count: u32);
 

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -14,6 +14,7 @@ pub struct OTXProvider {
     timeout: u64,
     retries: u32,
     random_agent: bool,
+    insecure: bool,
     parallel: u32,
     rate_limit: Option<f32>,
 }
@@ -51,6 +52,7 @@ impl OTXProvider {
             timeout: 30,
             retries: 3,
             random_agent: false,
+            insecure: false,
             parallel: 1,
             rate_limit: None,
         }
@@ -111,6 +113,11 @@ impl Provider for OTXProvider {
                 // Create client builder with proxy support
                 let mut client_builder = reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(self.timeout));
+
+                // Skip SSL verification if insecure is enabled
+                if self.insecure {
+                    client_builder = client_builder.danger_accept_invalid_certs(true);
+                }
 
                 // Add random user agent if enabled
                 if self.random_agent {
@@ -227,6 +234,10 @@ impl Provider for OTXProvider {
 
     fn with_random_agent(&mut self, enabled: bool) {
         self.random_agent = enabled;
+    }
+
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
     }
 
     fn with_parallel(&mut self, parallel: u32) {

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -13,6 +13,7 @@ pub struct WaybackMachineProvider {
     timeout: u64,
     retries: u32,
     random_agent: bool,
+    insecure: bool,
     parallel: u32,
     rate_limit: Option<f32>,
 }
@@ -26,6 +27,7 @@ impl WaybackMachineProvider {
             timeout: 30,
             retries: 3,
             random_agent: false,
+            insecure: false,
             parallel: 5,
             rate_limit: None,
         }
@@ -58,6 +60,11 @@ impl Provider for WaybackMachineProvider {
             // Create client builder with proxy support
             let mut client_builder =
                 reqwest::Client::builder().timeout(std::time::Duration::from_secs(self.timeout));
+
+            // Skip SSL verification if insecure is enabled
+            if self.insecure {
+                client_builder = client_builder.danger_accept_invalid_certs(true);
+            }
 
             // Add random user agent if enabled
             if self.random_agent {
@@ -210,6 +217,10 @@ impl Provider for WaybackMachineProvider {
 
     fn with_random_agent(&mut self, enabled: bool) {
         self.random_agent = enabled;
+    }
+
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
     }
 
     fn with_parallel(&mut self, parallel: u32) {

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -15,6 +15,7 @@ pub struct LinkExtractor {
     timeout: u64,
     retries: u32,
     random_agent: bool,
+    insecure: bool,
 }
 
 impl LinkExtractor {
@@ -26,6 +27,7 @@ impl LinkExtractor {
             timeout: 30,
             retries: 3,
             random_agent: false,
+            insecure: false,
         }
     }
 }
@@ -44,6 +46,11 @@ impl Tester for LinkExtractor {
             // Create client builder with proxy support
             let mut client_builder =
                 reqwest::Client::builder().timeout(std::time::Duration::from_secs(self.timeout));
+
+            // Skip SSL verification if insecure is enabled
+            if self.insecure {
+                client_builder = client_builder.danger_accept_invalid_certs(true);
+            }
 
             // Add random user agent if enabled
             if self.random_agent {
@@ -142,6 +149,11 @@ impl Tester for LinkExtractor {
     /// Enables or disables the use of random User-Agent headers
     fn with_random_agent(&mut self, enabled: bool) {
         self.random_agent = enabled;
+    }
+
+    /// Enables or disables SSL certificate verification
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
     }
 
     /// Sets the proxy server for HTTP requests

--- a/src/testers/mod.rs
+++ b/src/testers/mod.rs
@@ -32,6 +32,9 @@ pub trait Tester: Send + Sync {
     /// Enable or disable the use of random User-Agent headers
     fn with_random_agent(&mut self, enabled: bool);
 
+    /// Enable or disable SSL certificate verification (for self-signed certificates)
+    fn with_insecure(&mut self, enabled: bool);
+
     /// Set the proxy server for HTTP requests
     fn with_proxy(&mut self, proxy: Option<String>);
 

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -13,6 +13,7 @@ pub struct StatusChecker {
     timeout: u64,
     retries: u32,
     random_agent: bool,
+    insecure: bool,
 }
 
 impl StatusChecker {
@@ -24,6 +25,7 @@ impl StatusChecker {
             timeout: 30,
             retries: 3,
             random_agent: false,
+            insecure: false,
         }
     }
 }
@@ -42,6 +44,11 @@ impl Tester for StatusChecker {
             // Create client builder with proxy support
             let mut client_builder =
                 reqwest::Client::builder().timeout(std::time::Duration::from_secs(self.timeout));
+
+            // Skip SSL verification if insecure is enabled
+            if self.insecure {
+                client_builder = client_builder.danger_accept_invalid_certs(true);
+            }
 
             // Add random user agent if enabled
             if self.random_agent {
@@ -119,6 +126,11 @@ impl Tester for StatusChecker {
     /// Enables or disables the use of random User-Agent headers
     fn with_random_agent(&mut self, enabled: bool) {
         self.random_agent = enabled;
+    }
+
+    /// Enables or disables SSL certificate verification
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
     }
 
     /// Sets the proxy server for HTTP requests


### PR DESCRIPTION
Introduce a network settings module for shared HTTP configuration and add options to control the application of these settings. Include an 'insecure' option to skip SSL certificate verification for self-signed certificates.