### PR TITLE
Add status code filtering options to CLI and StatusChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `--insecure`, `--network-scope` flags
+- Added `--include-status`, `--exclude-status` flags
 
 ## 0.2.0
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,12 +153,12 @@ pub struct Args {
     #[clap(long, alias = "cs", visible_alias = "--cs")]
     pub check_status: bool,
 
-    /// Check HTTP status code of collected URLs with a specific filter (e.g., "200,301,302")
+    /// Include URLs with specific HTTP status codes or patterns (e.g., --is=200,30x)
     #[clap(help_heading = "Testing Options")]
     #[clap(long, alias = "is", visible_alias = "--is")]
     pub include_status: Vec<String>,
 
-    /// Check HTTP status code of collected URLs excluding a specific filter (e.g., "200,301,302")
+    /// Exclude URLs with specific HTTP status codes or patterns (e.g., --es=404,50x,5xx)
     #[clap(help_heading = "Testing Options")]
     #[clap(long, alias = "es", visible_alias = "--es")]
     pub exclude_status: Vec<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -150,8 +150,18 @@ pub struct Args {
 
     /// Check HTTP status code of collected URLs
     #[clap(help_heading = "Testing Options")]
-    #[clap(long)]
+    #[clap(long, alias = "cs", visible_alias = "--cs")]
     pub check_status: bool,
+
+    /// Check HTTP status code of collected URLs with a specific filter (e.g., "200,301,302")
+    #[clap(help_heading = "Testing Options")]
+    #[clap(long, alias = "is", visible_alias = "--is")]
+    pub include_status: Vec<String>,
+
+    /// Check HTTP status code of collected URLs excluding a specific filter (e.g., "200,301,302")
+    #[clap(help_heading = "Testing Options")]
+    #[clap(long, alias = "es", visible_alias = "--es")]
+    pub exclude_status: Vec<String>,
 
     /// Extract additional links from collected URLs (requires HTTP requests)
     #[clap(help_heading = "Testing Options")]

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -260,23 +260,23 @@ mod tests {
         let checker = StatusChecker::new();
 
         // Single pattern test
-        assert!(checker.matches_any_pattern(200, &vec!["200".to_string()]));
-        assert!(!checker.matches_any_pattern(404, &vec!["200".to_string()]));
+        assert!(checker.matches_any_pattern(200, &["200".to_string()]));
+        assert!(!checker.matches_any_pattern(404, &["200".to_string()]));
 
         // Multiple pattern test
-        assert!(checker.matches_any_pattern(200, &vec!["200".to_string(), "404".to_string()]));
-        assert!(checker.matches_any_pattern(404, &vec!["200".to_string(), "404".to_string()]));
-        assert!(!checker.matches_any_pattern(301, &vec!["200".to_string(), "404".to_string()]));
+        assert!(checker.matches_any_pattern(200, &["200".to_string(), "404".to_string()]));
+        assert!(checker.matches_any_pattern(404, &["200".to_string(), "404".to_string()]));
+        assert!(!checker.matches_any_pattern(301, &["200".to_string(), "404".to_string()]));
 
         // Wildcard pattern test
-        assert!(checker.matches_any_pattern(200, &vec!["2xx".to_string()]));
-        assert!(checker.matches_any_pattern(404, &vec!["2xx".to_string(), "4xx".to_string()]));
+        assert!(checker.matches_any_pattern(200, &["2xx".to_string()]));
+        assert!(checker.matches_any_pattern(404, &["2xx".to_string(), "4xx".to_string()]));
 
         // Comma-separated pattern test
-        assert!(checker.matches_any_pattern(200, &vec!["200,404".to_string()]));
-        assert!(checker.matches_any_pattern(404, &vec!["200,404".to_string()]));
-        assert!(checker.matches_any_pattern(200, &vec!["2xx,404".to_string()]));
-        assert!(!checker.matches_any_pattern(301, &vec!["200,404".to_string()]));
+        assert!(checker.matches_any_pattern(200, &["200,404".to_string()]));
+        assert!(checker.matches_any_pattern(404, &["200,404".to_string()]));
+        assert!(checker.matches_any_pattern(200, &["2xx,404".to_string()]));
+        assert!(!checker.matches_any_pattern(301, &["200,404".to_string()]));
     }
 
     #[test]

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -229,3 +229,84 @@ impl Tester for StatusChecker {
         self.proxy_auth = auth;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_matches_pattern() {
+        let checker = StatusChecker::new();
+        
+        // Exact match test
+        assert!(checker.status_matches_pattern(200, "200"));
+        assert!(!checker.status_matches_pattern(200, "404"));
+        
+        // Wildcard match test
+        assert!(checker.status_matches_pattern(200, "2xx"));
+        assert!(checker.status_matches_pattern(200, "20x"));
+        assert!(checker.status_matches_pattern(201, "20x"));
+        assert!(checker.status_matches_pattern(404, "4xx"));
+        assert!(!checker.status_matches_pattern(200, "3xx"));
+        assert!(!checker.status_matches_pattern(200, "4xx"));
+        
+        // Case insensitivity test
+        assert!(checker.status_matches_pattern(200, "2XX"));
+        assert!(checker.status_matches_pattern(404, "4XX"));
+    }
+
+    #[test]
+    fn test_matches_any_pattern() {
+        let checker = StatusChecker::new();
+        
+        // Single pattern test
+        assert!(checker.matches_any_pattern(200, &vec!["200".to_string()]));
+        assert!(!checker.matches_any_pattern(404, &vec!["200".to_string()]));
+        
+        // Multiple pattern test
+        assert!(checker.matches_any_pattern(200, &vec!["200".to_string(), "404".to_string()]));
+        assert!(checker.matches_any_pattern(404, &vec!["200".to_string(), "404".to_string()]));
+        assert!(!checker.matches_any_pattern(301, &vec!["200".to_string(), "404".to_string()]));
+        
+        // Wildcard pattern test
+        assert!(checker.matches_any_pattern(200, &vec!["2xx".to_string()]));
+        assert!(checker.matches_any_pattern(404, &vec!["2xx".to_string(), "4xx".to_string()]));
+        
+        // Comma-separated pattern test
+        assert!(checker.matches_any_pattern(200, &vec!["200,404".to_string()]));
+        assert!(checker.matches_any_pattern(404, &vec!["200,404".to_string()]));
+        assert!(checker.matches_any_pattern(200, &vec!["2xx,404".to_string()]));
+        assert!(!checker.matches_any_pattern(301, &vec!["200,404".to_string()]));
+    }
+
+    #[test]
+    fn test_should_include_status() {
+        let mut checker = StatusChecker::new();
+        
+        // Include all status codes when no filters are set
+        assert!(checker.should_include_status(200));
+        assert!(checker.should_include_status(404));
+        assert!(checker.should_include_status(500));
+        
+        // include_status filter test
+        checker.with_include_status(Some(vec!["200".to_string(), "3xx".to_string()]));
+        assert!(checker.should_include_status(200));
+        assert!(checker.should_include_status(301));
+        assert!(!checker.should_include_status(404));
+        assert!(!checker.should_include_status(500));
+        
+        // exclude_status filter test
+        checker.with_include_status(None);
+        checker.with_exclude_status(Some(vec!["4xx".to_string(), "500".to_string()]));
+        assert!(checker.should_include_status(200));
+        assert!(checker.should_include_status(301));
+        assert!(!checker.should_include_status(404));
+        assert!(!checker.should_include_status(500));
+        
+        // include_status has higher priority than exclude_status
+        checker.with_include_status(Some(vec!["200".to_string()]));
+        checker.with_exclude_status(Some(vec!["2xx".to_string()]));
+        assert!(checker.should_include_status(200));
+        assert!(!checker.should_include_status(201));
+    }
+}

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -79,9 +79,9 @@ impl StatusChecker {
 
         patterns.iter().any(|pattern| {
             // Split the pattern by commas and check if any subpattern matches
-            pattern.split(',').any(|subpattern| {
-                self.status_matches_pattern(status_code, subpattern.trim())
-            })
+            pattern
+                .split(',')
+                .any(|subpattern| self.status_matches_pattern(status_code, subpattern.trim()))
         })
     }
 
@@ -237,11 +237,11 @@ mod tests {
     #[test]
     fn test_status_matches_pattern() {
         let checker = StatusChecker::new();
-        
+
         // Exact match test
         assert!(checker.status_matches_pattern(200, "200"));
         assert!(!checker.status_matches_pattern(200, "404"));
-        
+
         // Wildcard match test
         assert!(checker.status_matches_pattern(200, "2xx"));
         assert!(checker.status_matches_pattern(200, "20x"));
@@ -249,7 +249,7 @@ mod tests {
         assert!(checker.status_matches_pattern(404, "4xx"));
         assert!(!checker.status_matches_pattern(200, "3xx"));
         assert!(!checker.status_matches_pattern(200, "4xx"));
-        
+
         // Case insensitivity test
         assert!(checker.status_matches_pattern(200, "2XX"));
         assert!(checker.status_matches_pattern(404, "4XX"));
@@ -258,20 +258,20 @@ mod tests {
     #[test]
     fn test_matches_any_pattern() {
         let checker = StatusChecker::new();
-        
+
         // Single pattern test
         assert!(checker.matches_any_pattern(200, &vec!["200".to_string()]));
         assert!(!checker.matches_any_pattern(404, &vec!["200".to_string()]));
-        
+
         // Multiple pattern test
         assert!(checker.matches_any_pattern(200, &vec!["200".to_string(), "404".to_string()]));
         assert!(checker.matches_any_pattern(404, &vec!["200".to_string(), "404".to_string()]));
         assert!(!checker.matches_any_pattern(301, &vec!["200".to_string(), "404".to_string()]));
-        
+
         // Wildcard pattern test
         assert!(checker.matches_any_pattern(200, &vec!["2xx".to_string()]));
         assert!(checker.matches_any_pattern(404, &vec!["2xx".to_string(), "4xx".to_string()]));
-        
+
         // Comma-separated pattern test
         assert!(checker.matches_any_pattern(200, &vec!["200,404".to_string()]));
         assert!(checker.matches_any_pattern(404, &vec!["200,404".to_string()]));
@@ -282,19 +282,19 @@ mod tests {
     #[test]
     fn test_should_include_status() {
         let mut checker = StatusChecker::new();
-        
+
         // Include all status codes when no filters are set
         assert!(checker.should_include_status(200));
         assert!(checker.should_include_status(404));
         assert!(checker.should_include_status(500));
-        
+
         // include_status filter test
         checker.with_include_status(Some(vec!["200".to_string(), "3xx".to_string()]));
         assert!(checker.should_include_status(200));
         assert!(checker.should_include_status(301));
         assert!(!checker.should_include_status(404));
         assert!(!checker.should_include_status(500));
-        
+
         // exclude_status filter test
         checker.with_include_status(None);
         checker.with_exclude_status(Some(vec!["4xx".to_string(), "500".to_string()]));
@@ -302,7 +302,7 @@ mod tests {
         assert!(checker.should_include_status(301));
         assert!(!checker.should_include_status(404));
         assert!(!checker.should_include_status(500));
-        
+
         // include_status has higher priority than exclude_status
         checker.with_include_status(Some(vec!["200".to_string()]));
         checker.with_exclude_status(Some(vec!["2xx".to_string()]));


### PR DESCRIPTION
Introduce `--include-status` and `--exclude-status` flags to filter HTTP status codes in the CLI and enhance the StatusChecker functionality accordingly. Update the changelog to reflect these new options.