### PR TITLE
Add configuration support with example file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1654,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1762,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "url",
 ]
 
@@ -2020,6 +2064,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ indicatif = "0.17.7"
 url = "2.5.0"
 rand = "0.8.5"
 scraper = "0.18.1"
+toml = "0.8.8"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/example/config.toml
+++ b/example/config.toml
@@ -1,0 +1,53 @@
+# URX Configuration File Example
+
+# Domain configuration
+domains = ["example.com", "example.org"]
+
+# Output options
+[output]
+output = "results.txt"
+format = "plain"  # Options: plain, json, csv
+merge_endpoint = false
+
+# Provider options
+[provider]
+providers = ["wayback", "cc", "otx"]
+subs = false  # Include subdomains when searching
+cc_index = "CC-MAIN-2025-08"  # Common Crawl index to use
+
+# Display options
+verbose = false
+silent = false
+no_progress = false
+
+# Filter options
+[filter]
+preset = ["no-resources", "no-images"]  # Filter presets
+extensions = ["js", "php", "aspx"]  # Include only these extensions
+exclude_extensions = ["html", "txt"]  # Exclude these extensions
+patterns = ["admin", "api"]  # Only include URLs with these patterns
+exclude_patterns = ["logout", "static"]  # Exclude URLs with these patterns
+show_only_host = false
+show_only_path = false
+show_only_param = false
+min_length = 10  # Minimum URL length to include
+max_length = 500  # Maximum URL length to include
+
+# Network options
+[network]
+network_scope = "all"  # Options: all, providers, testers, providers,testers
+proxy = "http://proxy.example.com:8080"  # HTTP proxy
+proxy_auth = "username:password"  # Proxy authentication
+insecure = false  # Skip SSL certificate verification
+random_agent = true  # Use random User-Agent
+timeout = 30  # Request timeout in seconds
+retries = 3  # Number of retries for failed requests
+parallel = 5  # Maximum number of parallel requests
+rate_limit = 10  # Rate limit (requests per second)
+
+# Testing options
+[testing]
+check_status = false  # Check HTTP status code of collected URLs
+include_status = ["200", "30x"]  # Include URLs with these status codes
+exclude_status = ["404", "50x"]  # Exclude URLs with these status codes
+extract_links = false  # Extract additional links from collected URLs

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,10 @@ pub struct Args {
     #[clap(name = "DOMAINS")]
     pub domains: Vec<String>,
 
+    /// Config file to load
+    #[clap(short, long, value_parser)]
+    pub config: Option<PathBuf>,
+
     #[clap(help_heading = "Output Options")]
     /// Output file to write results
     #[clap(short, long, value_parser)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,297 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::Args;
+
+/// Represents the application configuration loaded from a file
+#[derive(Debug, Deserialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub output: OutputConfig,
+
+    #[serde(default)]
+    pub provider: ProviderConfig,
+
+    #[serde(default)]
+    pub filter: FilterConfig,
+
+    #[serde(default)]
+    pub network: NetworkConfig,
+
+    #[serde(default)]
+    pub testing: TestingConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct OutputConfig {
+    pub output: Option<String>,
+    pub format: Option<String>,
+    pub merge_endpoint: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ProviderConfig {
+    pub providers: Option<Vec<String>>,
+    pub subs: Option<bool>,
+    pub cc_index: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FilterConfig {
+    pub preset: Option<Vec<String>>,
+    pub extensions: Option<Vec<String>>,
+    pub exclude_extensions: Option<Vec<String>>,
+    pub patterns: Option<Vec<String>>,
+    pub exclude_patterns: Option<Vec<String>>,
+    pub show_only_host: Option<bool>,
+    pub show_only_path: Option<bool>,
+    pub show_only_param: Option<bool>,
+    pub min_length: Option<usize>,
+    pub max_length: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct NetworkConfig {
+    pub network_scope: Option<String>,
+    pub proxy: Option<String>,
+    pub proxy_auth: Option<String>,
+    pub insecure: Option<bool>,
+    pub random_agent: Option<bool>,
+    pub timeout: Option<u64>,
+    pub retries: Option<u32>,
+    pub parallel: Option<u32>,
+    pub rate_limit: Option<f32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct TestingConfig {
+    pub check_status: Option<bool>,
+    pub include_status: Option<Vec<String>>,
+    pub exclude_status: Option<Vec<String>>,
+    pub extract_links: Option<bool>,
+}
+
+impl Config {
+    /// Load configuration from a specific file path
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read config file: {}", path.as_ref().display()))?;
+
+        let config: Config = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse config file: {}", path.as_ref().display()))?;
+
+        Ok(config)
+    }
+
+    /// Get the default configuration file path
+    /// - Linux/macOS: ~/.config/urx/config.toml
+    /// - Windows: %AppData%\urx\config.toml
+    pub fn default_path() -> Option<PathBuf> {
+        #[cfg(windows)]
+        {
+            if let Some(app_data) = env::var_os("APPDATA").map(PathBuf::from) {
+                let config_path = app_data.join("urx").join("config.toml");
+                if config_path.exists() {
+                    return Some(config_path);
+                }
+            }
+        }
+
+        #[cfg(not(windows))]
+        {
+            if let Some(home) = home_dir() {
+                let config_path = home.join(".config").join("urx").join("config.toml");
+                if config_path.exists() {
+                    return Some(config_path);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Load configuration based on command line arguments
+    /// Priority: --config flag > default path > default values
+    pub fn load(args: &Args) -> Self {
+        // Try to load from --config flag first
+        if let Some(path) = &args.config {
+            if let Ok(config) = Self::from_file(path) {
+                return config;
+            } else if !args.silent {
+                eprintln!(
+                    "Warning: Failed to load config from {}. Using default values.",
+                    path.display()
+                );
+                // Continue to check default path
+            }
+        }
+
+        // Then try default location
+        if let Some(default_path) = Self::default_path() {
+            if let Ok(config) = Self::from_file(default_path.clone()) {
+                if !args.silent {
+                    println!("Using configuration from {}", default_path.display());
+                }
+                return config;
+            }
+        }
+
+        // Otherwise use default values
+        Config::default()
+    }
+
+    /// Apply configuration values to Args, respecting priority
+    /// Command line arguments take precedence over config file values
+    pub fn apply_to_args(self, args: &mut Args) {
+        // Output options
+        if args.output.is_none() {
+            if let Some(output) = self.output.output {
+                args.output = Some(PathBuf::from(output));
+            }
+        }
+
+        if args.format == "plain" && self.output.format.is_some() {
+            args.format = self.output.format.unwrap();
+        }
+
+        if !args.merge_endpoint && self.output.merge_endpoint.unwrap_or(false) {
+            args.merge_endpoint = true;
+        }
+
+        // Provider options
+        if args.providers == vec!["wayback", "cc", "otx"] && self.provider.providers.is_some() {
+            args.providers = self.provider.providers.unwrap();
+        }
+
+        if !args.subs && self.provider.subs.unwrap_or(false) {
+            args.subs = true;
+        }
+
+        if args.cc_index == "CC-MAIN-2025-08" && self.provider.cc_index.is_some() {
+            args.cc_index = self.provider.cc_index.unwrap();
+        }
+
+        // Filter options
+        if args.preset.is_empty() && self.filter.preset.is_some() {
+            args.preset = self.filter.preset.unwrap();
+        }
+
+        if args.extensions.is_empty() && self.filter.extensions.is_some() {
+            args.extensions = self.filter.extensions.unwrap();
+        }
+
+        if args.exclude_extensions.is_empty() && self.filter.exclude_extensions.is_some() {
+            args.exclude_extensions = self.filter.exclude_extensions.unwrap();
+        }
+
+        if args.patterns.is_empty() && self.filter.patterns.is_some() {
+            args.patterns = self.filter.patterns.unwrap();
+        }
+
+        if args.exclude_patterns.is_empty() && self.filter.exclude_patterns.is_some() {
+            args.exclude_patterns = self.filter.exclude_patterns.unwrap();
+        }
+
+        if !args.show_only_host && self.filter.show_only_host.unwrap_or(false) {
+            args.show_only_host = true;
+        }
+
+        if !args.show_only_path && self.filter.show_only_path.unwrap_or(false) {
+            args.show_only_path = true;
+        }
+
+        if !args.show_only_param && self.filter.show_only_param.unwrap_or(false) {
+            args.show_only_param = true;
+        }
+
+        if args.min_length.is_none() && self.filter.min_length.is_some() {
+            args.min_length = self.filter.min_length;
+        }
+
+        if args.max_length.is_none() && self.filter.max_length.is_some() {
+            args.max_length = self.filter.max_length;
+        }
+
+        // Network options
+        if args.network_scope == "all" && self.network.network_scope.is_some() {
+            args.network_scope = self.network.network_scope.unwrap();
+        }
+
+        if args.proxy.is_none() && self.network.proxy.is_some() {
+            args.proxy = self.network.proxy;
+        }
+
+        if args.proxy_auth.is_none() && self.network.proxy_auth.is_some() {
+            args.proxy_auth = self.network.proxy_auth;
+        }
+
+        if !args.insecure && self.network.insecure.unwrap_or(false) {
+            args.insecure = true;
+        }
+
+        if !args.random_agent && self.network.random_agent.unwrap_or(false) {
+            args.random_agent = true;
+        }
+
+        if args.timeout == 30 && self.network.timeout.is_some() {
+            args.timeout = self.network.timeout.unwrap();
+        }
+
+        if args.retries == 3 && self.network.retries.is_some() {
+            args.retries = self.network.retries.unwrap();
+        }
+
+        if args.parallel == 5 && self.network.parallel.is_some() {
+            args.parallel = self.network.parallel.unwrap();
+        }
+
+        if args.rate_limit.is_none() && self.network.rate_limit.is_some() {
+            args.rate_limit = self.network.rate_limit;
+        }
+
+        // Testing options
+        if !args.check_status && self.testing.check_status.unwrap_or(false) {
+            args.check_status = true;
+        }
+
+        if args.include_status.is_empty() && self.testing.include_status.is_some() {
+            args.include_status = self.testing.include_status.unwrap();
+        }
+
+        if args.exclude_status.is_empty() && self.testing.exclude_status.is_some() {
+            args.exclude_status = self.testing.exclude_status.unwrap();
+        }
+
+        if !args.extract_links && self.testing.extract_links.unwrap_or(false) {
+            args.extract_links = true;
+        }
+    }
+}
+
+/// Helper function to get the home directory
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from).or({
+        #[cfg(windows)]
+        {
+            // On Windows, try USERPROFILE first, then HOMEDRIVE + HOMEPATH
+            if let Some(profile) = env::var_os("USERPROFILE").map(PathBuf::from) {
+                return Some(profile);
+            }
+
+            match (env::var_os("HOMEDRIVE"), env::var_os("HOMEPATH")) {
+                (Some(drive), Some(path)) => {
+                    let mut drive_path = PathBuf::from(drive);
+                    drive_path.push(path);
+                    Some(drive_path)
+                }
+                _ => None,
+            }
+        }
+
+        #[cfg(not(windows))]
+        None
+    })
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -346,20 +346,29 @@ mod tests {
         "#;
 
         let temp_file = create_temp_config_file(config_content);
-        
+
         // Load the config from the temp file
         let config = Config::from_file(temp_file.path()).unwrap();
-        
+
         // Verify the loaded config values
         assert_eq!(config.output.output, Some("test-output.txt".to_string()));
         assert_eq!(config.output.format, Some("json".to_string()));
         assert_eq!(config.output.merge_endpoint, Some(true));
-        
-        assert_eq!(config.provider.providers, Some(vec!["wayback".to_string(), "cc".to_string()]));
+
+        assert_eq!(
+            config.provider.providers,
+            Some(vec!["wayback".to_string(), "cc".to_string()])
+        );
         assert_eq!(config.provider.subs, Some(true));
-        assert_eq!(config.provider.cc_index, Some("CC-MAIN-2025-04".to_string()));
-        
-        assert_eq!(config.filter.extensions, Some(vec!["php".to_string(), "js".to_string()]));
+        assert_eq!(
+            config.provider.cc_index,
+            Some("CC-MAIN-2025-04".to_string())
+        );
+
+        assert_eq!(
+            config.filter.extensions,
+            Some(vec!["php".to_string(), "js".to_string()])
+        );
         assert_eq!(config.filter.show_only_host, Some(true));
     }
 
@@ -367,15 +376,15 @@ mod tests {
     fn test_default_config() {
         // Default config should have default values
         let config = Config::default();
-        
+
         assert_eq!(config.output.output, None);
         assert_eq!(config.output.format, None);
         assert_eq!(config.output.merge_endpoint, None);
-        
+
         assert_eq!(config.provider.providers, None);
         assert_eq!(config.provider.subs, None);
         assert_eq!(config.provider.cc_index, None);
-        
+
         assert_eq!(config.filter.extensions, None);
         assert_eq!(config.filter.show_only_host, None);
     }
@@ -387,7 +396,7 @@ mod tests {
         config.output.output = Some("output.txt".to_string());
         config.output.format = Some("json".to_string());
         config.provider.providers = Some(vec!["cc".to_string()]);
-        
+
         // Create default args
         let mut args = Args {
             config: None,
@@ -428,10 +437,10 @@ mod tests {
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");
         assert_eq!(args.providers, vec!["wayback", "cc", "otx"]);
-        
+
         // Apply config to args
         config.apply_to_args(&mut args);
-        
+
         // Verify args were updated correctly
         assert_eq!(args.output, Some(PathBuf::from("output.txt")));
         assert_eq!(args.format, "json");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tokio::task;
 
 mod cli;
+mod config;
 mod filters;
 mod network;
 mod output;
@@ -15,6 +16,7 @@ mod testers;
 mod url_utils;
 
 use cli::{read_domains_from_stdin, Args};
+use config::Config;
 use filters::UrlFilter;
 use network::{NetworkScope, NetworkSettings};
 use output::create_outputter;
@@ -35,7 +37,12 @@ fn verbose_print(args: &Args, message: impl AsRef<str>) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let mut args = Args::parse();
+
+    // Load configuration and apply it to args
+    // This ensures command line options take precedence over config file
+    let config = Config::load(&args);
+    config.apply_to_args(&mut args);
 
     // Collect domains either from arguments or stdin
     let domains = if args.domains.is_empty() {


### PR DESCRIPTION
Introduce configuration support to load settings from a file, allowing command line options to take precedence. An example configuration file is also included.