### PR TITLE
Add VirusTotal provider with API key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Empty
+- Added `--config` - Load configuration from a specified file
+- Support to vt provider(Virustotal) - Search URLs from Virustotal API
+  - Added `--vt-api-key` flag and `URX_VT_API_KEY` - Specify API key for Virustotal integration
 
 ## 0.3.0
 

--- a/example/config.toml
+++ b/example/config.toml
@@ -14,6 +14,7 @@ merge_endpoint = false
 providers = ["wayback", "cc", "otx"]
 subs = false  # Include subdomains when searching
 cc_index = "CC-MAIN-2025-08"  # Common Crawl index to use
+vt_api_key = ""  # VirusTotal API key (If using VirusTotal)
 
 # Display options
 verbose = false

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,7 +27,7 @@ pub struct Args {
     #[clap(long)]
     pub merge_endpoint: bool,
 
-    /// Providers to use (comma-separated, e.g., "wayback,cc,otx")
+    /// Providers to use (comma-separated, e.g., "wayback,cc,otx,vt")
     #[clap(help_heading = "Provider Options")]
     #[clap(long, value_delimiter = ',', default_value = "wayback,cc,otx")]
     pub providers: Vec<String>,
@@ -41,6 +41,11 @@ pub struct Args {
     /// Common Crawl index to use (e.g., CC-MAIN-2025-08)
     #[clap(long, default_value = "CC-MAIN-2025-08")]
     pub cc_index: String,
+
+    #[clap(help_heading = "Provider Options")]
+    /// API key for VirusTotal (can also use URX_VT_KEY environment variable)
+    #[clap(long)]
+    pub vt_api_key: Option<String>,
 
     #[clap(help_heading = "Display Options")]
     /// Show verbose output

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -43,7 +43,7 @@ pub struct Args {
     pub cc_index: String,
 
     #[clap(help_heading = "Provider Options")]
-    /// API key for VirusTotal (can also use URX_VT_KEY environment variable)
+    /// API key for VirusTotal (can also use URX_VT_API_KEY environment variable)
     #[clap(long)]
     pub vt_api_key: Option<String>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,6 +37,7 @@ pub struct ProviderConfig {
     pub providers: Option<Vec<String>>,
     pub subs: Option<bool>,
     pub cc_index: Option<String>,
+    pub vt_api_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -190,6 +191,10 @@ impl Config {
 
         if args.cc_index == "CC-MAIN-2025-08" && self.provider.cc_index.is_some() {
             args.cc_index = self.provider.cc_index.unwrap();
+        }
+
+        if args.vt_api_key.is_none() && self.provider.vt_api_key.is_some() {
+            args.vt_api_key = self.provider.vt_api_key;
         }
 
         // Filter options
@@ -406,6 +411,7 @@ mod tests {
             providers: vec!["wayback".to_string(), "cc".to_string(), "otx".to_string()],
             subs: false,
             cc_index: "CC-MAIN-2025-08".to_string(),
+            vt_api_key: None,
             verbose: false,
             silent: false,
             no_progress: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
         let api_key = args
             .vt_api_key
             .clone()
-            .or_else(|| std::env::var("URX_VT_KEY").ok());
+            .or_else(|| std::env::var("URX_VT_API_KEY").ok());
 
         if let Some(api_key) = api_key {
             add_provider(
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
                 || VirusTotalProvider::new(api_key.clone()),
             );
         } else if !args.silent {
-            eprintln!("Error: The VirusTotal provider (vt) requires an API key. Please use --vt-api-key or set the URX_VT_KEY environment variable.");
+            eprintln!("Error: The VirusTotal provider (vt) requires an API key. Please use --vt-api-key or set the URX_VT_API_KEY environment variable.");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use filters::UrlFilter;
 use network::{NetworkScope, NetworkSettings};
 use output::create_outputter;
 use progress::ProgressManager;
-use providers::{CommonCrawlProvider, OTXProvider, Provider, WaybackMachineProvider};
+use providers::{
+    CommonCrawlProvider, OTXProvider, Provider, VirusTotalProvider, WaybackMachineProvider,
+};
 use testers::{LinkExtractor, StatusChecker, Tester};
 use url_utils::UrlTransformer;
 
@@ -98,9 +100,30 @@ async fn main() -> Result<()> {
         );
     }
 
+    if args.providers.iter().any(|p| p == "vt") {
+        // First check command-line argument, then fall back to environment variable
+        let api_key = args
+            .vt_api_key
+            .clone()
+            .or_else(|| std::env::var("URX_VT_KEY").ok());
+
+        if let Some(api_key) = api_key {
+            add_provider(
+                &args,
+                &network_settings,
+                &mut providers,
+                &mut provider_names,
+                "VirusTotal".to_string(),
+                || VirusTotalProvider::new(api_key.clone()),
+            );
+        } else if !args.silent {
+            eprintln!("Error: The VirusTotal provider (vt) requires an API key. Please use --vt-api-key or set the URX_VT_KEY environment variable.");
+        }
+    }
+
     if providers.is_empty() {
         if !args.silent {
-            eprintln!("Error: No valid providers specified. Please use --providers with valid provider names (wayback, cc, otx)");
+            eprintln!("Error: No valid providers specified. Please use --providers with valid provider names (wayback, cc, otx, vt)");
         }
         return Ok(());
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -4,10 +4,12 @@ use std::pin::Pin;
 
 mod commoncrawl;
 mod otx;
+mod vt;
 mod wayback;
 
 pub use commoncrawl::CommonCrawlProvider;
 pub use otx::OTXProvider;
+pub use vt::VirusTotalProvider;
 pub use wayback::WaybackMachineProvider;
 
 /// Provider trait for URL discovery services

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -64,7 +64,8 @@ impl Provider for VirusTotalProvider {
                 return Ok(Vec::new());
             }
 
-            let encoded_domain = urlencoding::encode(domain);
+            // Use the url crate for encoding the domain
+            let encoded_domain = url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
             let url = format!(
                 "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
                 self.api_key, encoded_domain

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -1,0 +1,215 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::pin::Pin;
+
+use super::Provider;
+
+#[derive(Clone)]
+pub struct VirusTotalProvider {
+    api_key: String,
+    include_subdomains: bool,
+    proxy: Option<String>,
+    proxy_auth: Option<String>,
+    timeout: u64,
+    retries: u32,
+    random_agent: bool,
+    insecure: bool,
+    parallel: u32,
+    rate_limit: Option<f32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VTUrl {
+    url: String,
+    // We could add scan_date parsing if needed in the future
+    // scan_date: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VTResponse {
+    #[serde(default)]
+    detected_urls: Vec<VTUrl>,
+}
+
+impl VirusTotalProvider {
+    pub fn new(api_key: String) -> Self {
+        VirusTotalProvider {
+            api_key,
+            include_subdomains: false,
+            proxy: None,
+            proxy_auth: None,
+            timeout: 30,
+            retries: 3,
+            random_agent: false,
+            insecure: false,
+            parallel: 1,
+            rate_limit: None,
+        }
+    }
+}
+
+impl Provider for VirusTotalProvider {
+    fn clone_box(&self) -> Box<dyn Provider> {
+        Box::new(self.clone())
+    }
+
+    fn fetch_urls<'a>(
+        &'a self,
+        domain: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        Box::pin(async move {
+            // Skip if no API key is provided
+            if self.api_key.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let url = format!(
+                "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
+                self.api_key, domain
+            );
+
+            // Create client builder with proxy support
+            let mut client_builder =
+                reqwest::Client::builder().timeout(std::time::Duration::from_secs(self.timeout));
+
+            // Skip SSL verification if insecure is enabled
+            if self.insecure {
+                client_builder = client_builder.danger_accept_invalid_certs(true);
+            }
+
+            // Add random user agent if enabled
+            if self.random_agent {
+                let user_agents = [
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36",
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15",
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0",
+                    "Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Mobile Safari/537.36",
+                    "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.77 Mobile/15E148 Safari/604.1",
+                ];
+                let random_index = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as usize
+                    % user_agents.len();
+                client_builder = client_builder.user_agent(user_agents[random_index]);
+            }
+
+            // Add proxy if configured
+            if let Some(proxy_url) = &self.proxy {
+                let mut proxy = reqwest::Proxy::all(proxy_url)
+                    .context(format!("Invalid proxy URL: {}", proxy_url))?;
+
+                // Add proxy authentication if provided
+                if let Some(auth) = &self.proxy_auth {
+                    if let Some((username, password)) = auth.split_once(':') {
+                        proxy = proxy.basic_auth(username, password);
+                    }
+                }
+
+                client_builder = client_builder.proxy(proxy);
+            }
+
+            let client = client_builder
+                .build()
+                .context("Failed to build HTTP client")?;
+
+            // Implement retry logic
+            let mut last_error = None;
+            let mut attempt = 0;
+
+            while attempt <= self.retries {
+                if attempt > 0 {
+                    // Wait before retrying, with increasing backoff
+                    tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64))
+                        .await;
+                }
+
+                match client.get(&url).send().await {
+                    Ok(response) => {
+                        // Check if response is successful
+                        if !response.status().is_success() {
+                            attempt += 1;
+                            last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
+                            continue;
+                        }
+
+                        // Parse response
+                        match response.json::<VTResponse>().await {
+                            Ok(vt_response) => {
+                                let mut urls = Vec::new();
+                                for vt_url in vt_response.detected_urls {
+                                    urls.push(vt_url.url);
+                                }
+                                return Ok(urls);
+                            }
+                            Err(e) => {
+                                attempt += 1;
+                                last_error = Some(anyhow::anyhow!(
+                                    "Failed to parse VirusTotal response: {}",
+                                    e
+                                ));
+                                continue;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        attempt += 1;
+                        last_error = Some(e.into());
+                        continue;
+                    }
+                }
+            }
+
+            // If we got here, all attempts failed
+            if let Some(e) = last_error {
+                Err(anyhow::anyhow!(
+                    "Failed after {} attempts: {}",
+                    self.retries + 1,
+                    e
+                ))
+            } else {
+                Err(anyhow::anyhow!(
+                    "Failed after {} attempts",
+                    self.retries + 1
+                ))
+            }
+        })
+    }
+
+    fn with_subdomains(&mut self, include: bool) {
+        self.include_subdomains = include;
+    }
+
+    fn with_proxy(&mut self, proxy: Option<String>) {
+        self.proxy = proxy;
+    }
+
+    fn with_proxy_auth(&mut self, auth: Option<String>) {
+        self.proxy_auth = auth;
+    }
+
+    fn with_timeout(&mut self, seconds: u64) {
+        self.timeout = seconds;
+    }
+
+    fn with_retries(&mut self, count: u32) {
+        self.retries = count;
+    }
+
+    fn with_random_agent(&mut self, enabled: bool) {
+        self.random_agent = enabled;
+    }
+
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
+    }
+
+    fn with_parallel(&mut self, parallel: u32) {
+        self.parallel = parallel;
+    }
+
+    fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
+        self.rate_limit = rate_limit;
+    }
+}

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -64,9 +64,10 @@ impl Provider for VirusTotalProvider {
                 return Ok(Vec::new());
             }
 
+            let encoded_domain = urlencoding::encode(domain);
             let url = format!(
                 "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
-                self.api_key, domain
+                self.api_key, encoded_domain
             );
 
             // Create client builder with proxy support

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -65,7 +65,8 @@ impl Provider for VirusTotalProvider {
             }
 
             // Use the url crate for encoding the domain
-            let encoded_domain = url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
+            let encoded_domain =
+                url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
             let url = format!(
                 "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
                 self.api_key, encoded_domain


### PR DESCRIPTION
Introduce a new VirusTotal provider and enable configuration for an API key. This allows users to utilize VirusTotal's services for URL discovery. Update command-line arguments and configuration structures accordingly.