### PR TITLE
Add --strict flag for exact host validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `--include-robots` flag - Extract URLs from robots.txt files by [@Adesoji1](https://github.com/Adesoji1)
 - Added `--include-sitemap` flag - Extract URLs from sitemap
+- Added `--strict` flag - Enforce exact host validation (default is true)
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Filter Options:
           Minimum URL length to include
       --max-length <MAX_LENGTH>
           Maximum URL length to include
+      --strict
+          Enforce exact host validation (default)
 
 Network Options:
   --network-scope <NETWORK_SCOPE>  Control which components network settings apply to (all, providers, testers, or providers,testers) [default: all]
@@ -198,6 +200,9 @@ urx example.com -e js,php --patterns admin,login --exclude-patterns logout,stati
 
 # HTTP Status code based filtering
 urx example.com --include-status 200,30x,405 --exclude-status 20x
+
+# Disable host validation
+urx example.com --strict false
 ```
 
 ## Integration with Other Tools

--- a/example/config.toml
+++ b/example/config.toml
@@ -35,6 +35,7 @@ show_only_path = false
 show_only_param = false
 min_length = 10  # Minimum URL length to include
 max_length = 500  # Maximum URL length to include
+strict = true  # Strict mode for host validation
 
 # Network options
 [network]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,6 +127,11 @@ pub struct Args {
     #[clap(long = "max-length")]
     pub max_length: Option<usize>,
 
+    /// Enforce exact host validation (default)
+    #[clap(help_heading = "Filter Options")]
+    #[clap(long, default_value = "true")]
+    pub strict: bool,
+
     /// Control which components network settings apply to (all, providers, testers, or providers,testers)
     #[clap(help_heading = "Network Options")]
     #[clap(long, default_value = "all", value_parser = validate_network_scope)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -431,6 +431,7 @@ mod tests {
             show_only_param: false,
             min_length: None,
             max_length: None,
+            strict: true,
             network_scope: "all".to_string(),
             proxy: None,
             proxy_auth: None,

--- a/src/filters/host_validation.rs
+++ b/src/filters/host_validation.rs
@@ -8,24 +8,16 @@ pub struct HostValidator {
 
 impl HostValidator {
     /// Create a new host validator with the given domains
-    pub fn new(domains: &[String]) -> Self {
-        // Create a normalized set of domains for comparison
-        let normalized_domains: HashSet<String> = domains
-            .iter()
-            .map(|domain| {
-                domain
-                    .trim()
-                    .trim_start_matches("http://")
-                    .trim_start_matches("https://")
-                    .trim_end_matches('/')
-                    .to_lowercase()
-            })
-            .collect();
+   pub fn new(domains: &[String]) -> Self {  
+        let normalized_domains: HashSet<String> = domains  
+            .iter()  
+            .map(|domain| domain.trim().to_lowercase())  
+            .collect();  
 
-        HostValidator {
-            domains: normalized_domains,
-        }
-    }
+        HostValidator {  
+            domains: normalized_domains,  
+        }  
+    }  
 
     /// Validate that the URL's host matches one of the provided domains
     pub fn is_valid_host(&self, url_str: &str) -> bool {
@@ -67,10 +59,21 @@ mod tests {
         assert!(validator.is_valid_host("http://example.com"));
         assert!(validator.is_valid_host("https://test.org/page?query=value"));
 
-        // Test invalid URLs
-        assert!(!validator.is_valid_host("https://subdomain.example.com/path"));
-        assert!(!validator.is_valid_host("https://other-domain.com"));
-        assert!(!validator.is_valid_host("https://test.com"));
+        // Test edge cases with unusual characters in the host
+        assert!(!validator.is_valid_host("https://example.com.")); // Trailing dot
+        assert!(!validator.is_valid_host("https://.example.com")); // Leading dot
+        assert!(!validator.is_valid_host("https://-example.com")); // Leading hyphen
+        assert!(!validator.is_valid_host("https://example-.com")); // Trailing hyphen
+
+        // Test URLs with no host
+        assert!(!validator.is_valid_host("file:///path/to/file"));
+        assert!(!validator.is_valid_host("mailto:user@example.com"));
+        assert!(!validator.is_valid_host("data:text/plain,Hello%20World"));
+
+        // Test malformed URLs
+        assert!(!validator.is_valid_host("https://"));
+        assert!(!validator.is_valid_host("http://"));
+        assert!(!validator.is_valid_host("not-a-url"));
 
         // Test URL filtering
         let urls = HashSet::from([

--- a/src/filters/host_validation.rs
+++ b/src/filters/host_validation.rs
@@ -1,0 +1,91 @@
+use std::collections::HashSet;
+use url::Url;
+
+/// Validates whether URLs have the same host as the provided domains
+pub struct HostValidator {
+    domains: HashSet<String>,
+}
+
+impl HostValidator {
+    /// Create a new host validator with the given domains
+    pub fn new(domains: &[String]) -> Self {
+        // Create a normalized set of domains for comparison
+        let normalized_domains: HashSet<String> = domains
+            .iter()
+            .map(|domain| {
+                domain
+                    .trim()
+                    .trim_start_matches("http://")
+                    .trim_start_matches("https://")
+                    .trim_end_matches('/')
+                    .to_lowercase()
+            })
+            .collect();
+
+        HostValidator {
+            domains: normalized_domains,
+        }
+    }
+
+    /// Validate that the URL's host matches one of the provided domains
+    pub fn is_valid_host(&self, url_str: &str) -> bool {
+        if let Ok(url) = Url::parse(url_str) {
+            if let Some(host) = url.host_str() {
+                // Normalize the host for comparison
+                let normalized_host = host.to_lowercase();
+
+                // Check if the host exactly matches any of our domains
+                return self.domains.contains(&normalized_host);
+            }
+        }
+
+        // If we can't parse the URL or it has no host, consider it invalid
+        false
+    }
+
+    /// Filter URLs to only include those with valid hosts
+    pub fn filter_urls(&self, urls: &HashSet<String>) -> HashSet<String> {
+        urls.iter()
+            .filter(|url| self.is_valid_host(url))
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_validation() {
+        // Create a validator with specific domains
+        let domains = vec!["example.com".to_string(), "test.org".to_string()];
+        let validator = HostValidator::new(&domains);
+
+        // Test valid URLs
+        assert!(validator.is_valid_host("https://example.com/path"));
+        assert!(validator.is_valid_host("http://example.com"));
+        assert!(validator.is_valid_host("https://test.org/page?query=value"));
+
+        // Test invalid URLs
+        assert!(!validator.is_valid_host("https://subdomain.example.com/path"));
+        assert!(!validator.is_valid_host("https://other-domain.com"));
+        assert!(!validator.is_valid_host("https://test.com"));
+
+        // Test URL filtering
+        let urls = HashSet::from([
+            "https://example.com/page1".to_string(),
+            "https://subdomain.example.com/page2".to_string(),
+            "https://test.org/page3".to_string(),
+            "https://invalid.com/page4".to_string(),
+        ]);
+
+        let filtered = validator.filter_urls(&urls);
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.contains("https://example.com/page1"));
+        assert!(filtered.contains("https://test.org/page3"));
+        assert!(!filtered.contains("https://subdomain.example.com/page2"));
+        assert!(!filtered.contains("https://invalid.com/page4"));
+    }
+}

--- a/src/filters/host_validation.rs
+++ b/src/filters/host_validation.rs
@@ -8,16 +8,16 @@ pub struct HostValidator {
 
 impl HostValidator {
     /// Create a new host validator with the given domains
-   pub fn new(domains: &[String]) -> Self {  
-        let normalized_domains: HashSet<String> = domains  
-            .iter()  
-            .map(|domain| domain.trim().to_lowercase())  
-            .collect();  
+    pub fn new(domains: &[String]) -> Self {
+        let normalized_domains: HashSet<String> = domains
+            .iter()
+            .map(|domain| domain.trim().to_lowercase())
+            .collect();
 
-        HostValidator {  
-            domains: normalized_domains,  
-        }  
-    }  
+        HostValidator {
+            domains: normalized_domains,
+        }
+    }
 
     /// Validate that the URL's host matches one of the provided domains
     pub fn is_valid_host(&self, url_str: &str) -> bool {
@@ -33,14 +33,6 @@ impl HostValidator {
 
         // If we can't parse the URL or it has no host, consider it invalid
         false
-    }
-
-    /// Filter URLs to only include those with valid hosts
-    pub fn filter_urls(&self, urls: &HashSet<String>) -> HashSet<String> {
-        urls.iter()
-            .filter(|url| self.is_valid_host(url))
-            .cloned()
-            .collect()
     }
 }
 
@@ -74,21 +66,5 @@ mod tests {
         assert!(!validator.is_valid_host("https://"));
         assert!(!validator.is_valid_host("http://"));
         assert!(!validator.is_valid_host("not-a-url"));
-
-        // Test URL filtering
-        let urls = HashSet::from([
-            "https://example.com/page1".to_string(),
-            "https://subdomain.example.com/page2".to_string(),
-            "https://test.org/page3".to_string(),
-            "https://invalid.com/page4".to_string(),
-        ]);
-
-        let filtered = validator.filter_urls(&urls);
-
-        assert_eq!(filtered.len(), 2);
-        assert!(filtered.contains("https://example.com/page1"));
-        assert!(filtered.contains("https://test.org/page3"));
-        assert!(!filtered.contains("https://subdomain.example.com/page2"));
-        assert!(!filtered.contains("https://invalid.com/page4"));
     }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,4 +1,6 @@
+mod host_validation;
 mod preset;
 mod url_filter;
 
+pub use host_validation::HostValidator;
 pub use url_filter::UrlFilter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,14 +221,13 @@ async fn main() -> Result<()> {
         if args.verbose && !args.silent {
             println!("Enforcing strict host validation...");
         }
-        // Convert Vec to HashSet before calling filter_urls
-        let sorted_urls_set: std::collections::HashSet<String> = sorted_urls.into_iter().collect();
+    if args.strict {
+        if args.verbose && !args.silent {
+            println!("Enforcing strict host validation...");
+        }
         let host_validator = HostValidator::new(&domains);
-        // Call filter_urls with HashSet and convert result back to Vec
-        sorted_urls = host_validator
-            .filter_urls(&sorted_urls_set)
-            .into_iter()
-            .collect();
+        sorted_urls.retain(|url| host_validator.is_valid_host(url));
+    }
     }
 
     if let Some(bar) = filter_bar {

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,13 +221,15 @@ async fn main() -> Result<()> {
         if args.verbose && !args.silent {
             println!("Enforcing strict host validation...");
         }
-    if args.strict {
-        if args.verbose && !args.silent {
-            println!("Enforcing strict host validation...");
-        }
         let host_validator = HostValidator::new(&domains);
         sorted_urls.retain(|url| host_validator.is_valid_host(url));
-    }
+
+        if args.verbose && !args.silent {
+            println!(
+                "Number of valid URLs after host validation: {}",
+                sorted_urls.len()
+            );
+        }
     }
 
     if let Some(bar) = filter_bar {


### PR DESCRIPTION
Introduce a `--strict` flag to enforce exact host validation for URLs. Implement a `HostValidator` to filter URLs based on their host, ensuring only valid hosts are included when strict mode is enabled.