### PR TITLE
Update CHANGELOG.md with detailed descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added Discovery Options(`--exclude-robots` and `--exclude-sitemap` flags) - Options to disable robots.txt and sitemap.xml discovery which are now enabled by default
 - Changed robots.txt and sitemap.xml discovery to be enabled by default
+- Added a feature to highlight HTTP response statuses using the `--check-status` flag. This was inspired by a feature request from the community (related to issue #59).
+- Adjusted default timeout and retry values for fetching URLs. Timeout was increased from 30s to 120s, and retries were reduced from 3 to 2 to improve reliability and performance (related to issue #68).
+- Fixed a parsing bug in the OTX provider that occurred when encountering unexpected null values in the API response (related to issue #70).
+- Resolved issues with fetching URLs from Wayback Machine, Common Crawl, and OTX providers. This included fixing timeouts, premature connection closures, and response parsing errors (related to issue #62).
 
 ## 0.5.0
 


### PR DESCRIPTION
This commit updates the Unreleased section of CHANGELOG.md to include detailed descriptions for changes from the 0.6.0 milestone.

The following items were added or updated:
- Added a feature to highlight HTTP response statuses using the `--check-status` flag (inspired by community request #59).
- Adjusted default timeout to 120s (from 30s) and retries to 2 (from 3) for URL fetching to improve reliability and performance (#68).
- Fixed a parsing bug in the OTX provider for null values in API responses (#70).
- Resolved URL fetching issues (timeouts, connection errors, parsing errors) for Wayback Machine, Common Crawl, and OTX providers (#62).