### PR TITLE
ci(homebrew): fix Ruby interpolation in formula test block

### DIFF
--- a/.github/workflows/publish_homebrew_tap.yml
+++ b/.github/workflows/publish_homebrew_tap.yml
@@ -22,7 +22,7 @@
               install: |
                 system "cargo build --release"
                 bin.install "target/release/urx"
-              test: system "{bin}/urx", "-V"
+              test: system "#{bin}/urx", "-V"
               update_readme_table: true
               skip_commit: false
               debug: false


### PR DESCRIPTION
## Summary
- The current homebrew-releaser config emits a formula whose `test` block reads `system "{bin}/urx", "-V"` — a literal path, which breaks `brew test` and `brew audit`.
- Switched to `#{bin}` so Homebrew interpolates the formula's bin path.
- Next published release will regenerate `Formula/urx.rb` correctly.

Same fix as hahwul/hwaro#518 — caught while sweeping siblings for the same pattern.

## Test plan
- [ ] After next release, verify the published formula contains `system "#{bin}/urx", "-V"` and `brew test urx` succeeds