### PR TITLE
feat(providers): source attribution, list/exclude/all flags, stats summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix Wayback Machine timeouts on large domains: switch CDX to plain-text response with `collapse=urlkey` server-side dedup, raise default timeout to 60s, and filter non-URL response bodies
 - Bump default Common Crawl index to `CC-MAIN-2026-17`, and add `--cc-index latest` to auto-resolve the newest index via `collinfo.json` (cached per run, validated against `CC-MAIN-YYYY-WW` shape)
+- Track provider attribution per URL and surface it via `--show-sources` (JSON adds a `sources` field, CSV adds a `sources` column, plain text appends `[provider1,provider2]`)
+- Add `--list-providers` to enumerate every supported provider, `--exclude-providers` for negative selection, and `--all-providers` to enable every catalog entry (API-keyed providers only activate when a key is set)
+- Add `--stats` to print a per-provider summary (URLs found, errors, elapsed) to stderr at end of run
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Output Options:
 Provider Options:
       --providers <PROVIDERS>
           Providers to use (comma-separated, e.g., "wayback,cc,otx,vt,urlscan") [default: wayback,cc,otx]
+      --exclude-providers <EXCLUDE_PROVIDERS>
+          Providers to exclude (comma-separated). Wins on conflict with --providers / --all-providers.
+      --all-providers
+          Enable every supported provider. API-keyed providers only activate when a key is available.
+      --list-providers
+          List every supported provider then exit.
       --subs
           Include subdomains when searching
       --cc-index <CC_INDEX>
@@ -119,9 +125,11 @@ Discovery Options:
       --exclude-sitemap  Exclude sitemap.xml discovery
 
 Display Options:
-  -v, --verbose      Show verbose output
-      --silent       Silent mode (no output)
-      --no-progress  No progress bar
+  -v, --verbose       Show verbose output
+      --silent        Silent mode (no output)
+      --no-progress   No progress bar
+      --show-sources  Annotate output URLs with the providers that returned them
+      --stats         Print a per-provider summary to stderr at end of run
 
 Filter Options:
   -p, --preset <PRESET>

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -29,6 +29,9 @@ Output Options:
 
 Provider Options:
   --providers <PROVIDERS>                Providers to use (comma-separated) [default: wayback,cc,otx]
+  --exclude-providers <PROVIDERS>        Providers to exclude (wins on conflict)
+  --all-providers                        Enable every supported provider (API-keyed ones only if a key is available)
+  --list-providers                       List every supported provider then exit
   --subs                                 Include subdomains when searching
   --cc-index <CC_INDEX>                  Common Crawl index to use, or "latest" to auto-resolve [default: CC-MAIN-2026-17]
   --vt-api-key <VT_API_KEY>             API key for VirusTotal
@@ -40,9 +43,11 @@ Discovery Options:
   --exclude-sitemap  Exclude sitemap.xml discovery
 
 Display Options:
-  -v, --verbose      Show verbose output
-      --silent       Silent mode (no output)
-      --no-progress  No progress bar
+  -v, --verbose       Show verbose output
+      --silent        Silent mode (no output)
+      --no-progress   No progress bar
+      --show-sources  Annotate output URLs with the providers that returned them
+      --stats         Print a per-provider summary to stderr at end of run
 
 Filter Options:
   -p, --preset <PRESET>                     Filter Presets (e.g., "no-resources,no-images,only-js,only-style")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,6 +42,24 @@ pub struct Args {
     #[clap(long, value_delimiter = ',', default_value = "wayback,cc,otx")]
     pub providers: Vec<String>,
 
+    /// Providers to exclude from enumeration (comma-separated). Applied after
+    /// --providers / --all-providers, so it wins on conflict.
+    #[clap(help_heading = "Provider Options")]
+    #[clap(long, value_delimiter = ',')]
+    pub exclude_providers: Vec<String>,
+
+    /// Enable every supported provider. API-keyed providers only activate
+    /// when a key is available via flag, env, or config file.
+    #[clap(help_heading = "Provider Options")]
+    #[clap(long)]
+    pub all_providers: bool,
+
+    /// List every supported provider (name, API key requirement, summary)
+    /// then exit.
+    #[clap(help_heading = "Provider Options")]
+    #[clap(long)]
+    pub list_providers: bool,
+
     /// Include subdomains when searching
     #[clap(help_heading = "Provider Options")]
     #[clap(long)]
@@ -97,6 +115,19 @@ pub struct Args {
     /// No progress bar
     #[clap(long)]
     pub no_progress: bool,
+
+    /// Annotate each output URL with the providers that returned it.
+    /// For JSON/CSV this adds a `sources` field/column; for plain text it
+    /// appends `[provider1,provider2]` after the URL.
+    #[clap(help_heading = "Display Options")]
+    #[clap(long)]
+    pub show_sources: bool,
+
+    /// Print a per-provider summary (URLs found, errors, elapsed) to stderr
+    /// when the run finishes.
+    #[clap(help_heading = "Display Options")]
+    #[clap(long)]
+    pub stats: bool,
 
     /// Filter Presets (e.g., "no-resources,no-images,only-js,only-style")
     #[clap(help_heading = "Filter Options")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -585,6 +585,11 @@ mod tests {
             redis_url: None,
             cache_ttl: 86400,
             no_cache: false,
+            exclude_providers: vec![],
+            all_providers: false,
+            list_providers: false,
+            show_sources: false,
+            stats: false,
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use providers::{
     VirusTotalProvider, WaybackMachineProvider, ZoomEyeProvider,
 };
 use readers::read_urls_from_file;
-use runner::{add_provider, process_domains};
+use runner::{add_provider, process_domains, ProviderRunResult};
 use tester_manager::{apply_network_settings_to_tester, process_urls_with_testers};
 use testers::{LinkExtractor, StatusChecker, Tester};
 use utils::verbose_print;
@@ -36,6 +36,96 @@ use utils::UrlTransformer;
 
 /// Type alias for provider initialization result
 type ProviderList = (Vec<Box<dyn Provider>>, Vec<String>);
+
+/// Static metadata for one of urx's URL providers.
+struct ProviderInfo {
+    /// Short identifier accepted on the command line (e.g. "wayback").
+    id: &'static str,
+    /// Human-readable display name shown in stats and `--list-providers`.
+    display_name: &'static str,
+    /// True when the provider can only be enabled with an API key.
+    requires_key: bool,
+    /// One-line description shown by `--list-providers`.
+    summary: &'static str,
+}
+
+/// Catalog of every provider urx knows about. The order here drives the
+/// `--list-providers` output and the meaning of `--all-providers`.
+fn provider_catalog() -> &'static [ProviderInfo] {
+    &[
+        ProviderInfo {
+            id: "wayback",
+            display_name: "Wayback Machine",
+            requires_key: false,
+            summary: "Internet Archive CDX index",
+        },
+        ProviderInfo {
+            id: "cc",
+            display_name: "Common Crawl",
+            requires_key: false,
+            summary: "Common Crawl monthly URL index",
+        },
+        ProviderInfo {
+            id: "otx",
+            display_name: "OTX",
+            requires_key: false,
+            summary: "AlienVault Open Threat Exchange passive DNS / URLs",
+        },
+        ProviderInfo {
+            id: "vt",
+            display_name: "VirusTotal",
+            requires_key: true,
+            summary: "VirusTotal observed URLs (URX_VT_API_KEY)",
+        },
+        ProviderInfo {
+            id: "urlscan",
+            display_name: "Urlscan",
+            requires_key: true,
+            summary: "Urlscan.io search (URX_URLSCAN_API_KEY)",
+        },
+        ProviderInfo {
+            id: "zoomeye",
+            display_name: "ZoomEye",
+            requires_key: true,
+            summary: "ZoomEye search (URX_ZOOMEYE_API_KEY)",
+        },
+        ProviderInfo {
+            id: "robots",
+            display_name: "robots.txt",
+            requires_key: false,
+            summary: "Discovery from the target's robots.txt",
+        },
+        ProviderInfo {
+            id: "sitemap",
+            display_name: "sitemap.xml",
+            requires_key: false,
+            summary: "Discovery from the target's sitemap.xml",
+        },
+    ]
+}
+
+/// Print the provider catalog to stdout in a `--list-providers` format.
+fn print_provider_list() {
+    println!("Available providers:");
+    println!("  {:<9}  {:<16}  {:<8}  description", "id", "name", "key");
+    println!(
+        "  {:<9}  {:<16}  {:<8}  -----------",
+        "---------", "----------------", "--------"
+    );
+    for p in provider_catalog() {
+        println!(
+            "  {:<9}  {:<16}  {:<8}  {}",
+            p.id,
+            p.display_name,
+            if p.requires_key { "required" } else { "—" },
+            p.summary
+        );
+    }
+    println!();
+    println!("Use --providers id1,id2 to select. --all-providers enables every entry");
+    println!("(API-keyed providers only activate when a key is available).");
+    println!("--exclude-providers wins on conflict.");
+}
 
 /// Parse API keys from environment variable (comma-separated) and combine with CLI keys
 pub fn parse_api_keys(cli_keys: Vec<String>, env_var_name: &str) -> Vec<String> {
@@ -88,31 +178,70 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
     let urlscan_api_keys = parse_api_keys(args.urlscan_api_key.clone(), "URX_URLSCAN_API_KEY");
     let zoomeye_api_keys = parse_api_keys(args.zoomeye_api_key.clone(), "URX_ZOOMEYE_API_KEY");
 
-    // Auto-enable providers if API keys are provided but not explicitly included in providers
-    let mut providers_list = args.providers.clone();
+    // Build the effective providers list. `--all-providers` expands to every
+    // catalog entry whose required key (if any) is available; otherwise we
+    // start from the user-supplied list and let auto-enable add API-keyed
+    // providers whenever a key is set.
+    let mut providers_list: Vec<String> = if args.all_providers {
+        provider_catalog()
+            .iter()
+            .filter(|p| {
+                if !p.requires_key {
+                    return true;
+                }
+                match p.id {
+                    "vt" => !vt_api_keys.is_empty(),
+                    "urlscan" => !urlscan_api_keys.is_empty(),
+                    "zoomeye" => !zoomeye_api_keys.is_empty(),
+                    _ => false,
+                }
+            })
+            // Robots/sitemap are gated by the dedicated should_use_* flags, so
+            // we leave them out here and let those code paths add them.
+            .filter(|p| p.id != "robots" && p.id != "sitemap")
+            .map(|p| p.id.to_string())
+            .collect()
+    } else {
+        args.providers.clone()
+    };
 
-    // Auto-enable VirusTotal and Urlscan providers
-    auto_enable_provider(
-        &mut providers_list,
-        &vt_api_keys,
-        "vt",
-        args.verbose,
-        args.silent,
-    );
-    auto_enable_provider(
-        &mut providers_list,
-        &urlscan_api_keys,
-        "urlscan",
-        args.verbose,
-        args.silent,
-    );
-    auto_enable_provider(
-        &mut providers_list,
-        &zoomeye_api_keys,
-        "zoomeye",
-        args.verbose,
-        args.silent,
-    );
+    // Auto-enable API-keyed providers when a key is present but the user did
+    // not list them explicitly. Skipped under --all-providers (already
+    // expanded above).
+    if !args.all_providers {
+        auto_enable_provider(
+            &mut providers_list,
+            &vt_api_keys,
+            "vt",
+            args.verbose,
+            args.silent,
+        );
+        auto_enable_provider(
+            &mut providers_list,
+            &urlscan_api_keys,
+            "urlscan",
+            args.verbose,
+            args.silent,
+        );
+        auto_enable_provider(
+            &mut providers_list,
+            &zoomeye_api_keys,
+            "zoomeye",
+            args.verbose,
+            args.silent,
+        );
+    }
+
+    // Apply negative selection: --exclude-providers wins on conflict.
+    if !args.exclude_providers.is_empty() {
+        let excluded: std::collections::HashSet<&str> =
+            args.exclude_providers.iter().map(String::as_str).collect();
+        providers_list.retain(|p| !excluded.contains(p.as_str()));
+    }
+
+    // --all-providers users don't want a noisy error when a key is missing,
+    // so suppress the per-provider "needs API key" messages in that mode.
+    let suppress_key_errors = args.all_providers;
 
     if providers_list.iter().any(|p| p == "wayback") {
         add_provider(
@@ -136,7 +265,10 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
         );
     }
 
-    if args.should_use_robots() {
+    let excluded: std::collections::HashSet<&str> =
+        args.exclude_providers.iter().map(String::as_str).collect();
+
+    if args.should_use_robots() && !excluded.contains("robots") {
         add_provider(
             args,
             network_settings,
@@ -147,7 +279,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
         );
     }
 
-    if args.should_use_sitemap() {
+    if args.should_use_sitemap() && !excluded.contains("sitemap") {
         add_provider(
             args,
             network_settings,
@@ -179,7 +311,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 "VirusTotal".to_string(),
                 || VirusTotalProvider::new_with_keys(vt_api_keys.clone()),
             );
-        } else if !args.silent {
+        } else if !args.silent && !suppress_key_errors {
             eprintln!("Error: The VirusTotal provider (vt) requires an API key. Please use --vt-api-key or set the URX_VT_API_KEY environment variable.");
         }
     }
@@ -194,7 +326,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 "Urlscan".to_string(),
                 || UrlscanProvider::new_with_keys(urlscan_api_keys.clone()),
             );
-        } else if !args.silent {
+        } else if !args.silent && !suppress_key_errors {
             eprintln!("Error: The Urlscan provider (urlscan) requires an API key. Please use --urlscan-api-key or set the URX_URLSCAN_API_KEY environment variable.");
         }
     }
@@ -209,7 +341,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 "ZoomEye".to_string(),
                 || ZoomEyeProvider::new_with_keys(zoomeye_api_keys.clone()),
             );
-        } else if !args.silent {
+        } else if !args.silent && !suppress_key_errors {
             eprintln!("Error: The ZoomEye provider (zoomeye) requires an API key. Please use --zoomeye-api-key or set the URX_ZOOMEYE_API_KEY environment variable.");
         }
     }
@@ -457,10 +589,10 @@ async fn process_domains_with_cache(
     providers: &[Box<dyn Provider>],
     provider_names: &[String],
     cache_manager: Option<&CacheManager>,
-) -> std::collections::HashSet<String> {
-    use std::collections::HashSet;
+) -> ProviderRunResult {
+    use std::collections::{HashMap, HashSet};
 
-    let mut final_urls = HashSet::new();
+    let mut final_result = ProviderRunResult::default();
 
     // If caching is disabled, use normal processing
     if cache_manager.is_none() {
@@ -469,7 +601,7 @@ async fn process_domains_with_cache(
 
     let cache = cache_manager.unwrap();
     let mut domains_to_process = Vec::new();
-    let mut cached_urls = HashSet::new();
+    let mut cached_urls: HashMap<String, HashSet<String>> = HashMap::new();
 
     // Check cache for each domain
     for domain in &domains {
@@ -487,8 +619,12 @@ async fn process_domains_with_cache(
                     // For incremental mode, we still need to fetch fresh URLs to compare
                     domains_to_process.push(domain.clone());
                 } else {
-                    // Use cached results directly
-                    cached_urls.extend(cached_entry.urls);
+                    // Use cached results directly. Source attribution isn't
+                    // persisted in the cache, so cached URLs surface with an
+                    // empty provider set.
+                    for url in cached_entry.urls {
+                        cached_urls.entry(url).or_default();
+                    }
                     continue;
                 }
             }
@@ -499,7 +635,9 @@ async fn process_domains_with_cache(
     }
 
     // Add cached URLs to final result
-    final_urls.extend(cached_urls);
+    for (url, sources) in cached_urls {
+        final_result.urls.entry(url).or_default().extend(sources);
+    }
 
     // Process domains that need fresh data
     if !domains_to_process.is_empty() {
@@ -511,7 +649,7 @@ async fn process_domains_with_cache(
             ),
         );
 
-        let fresh_urls = process_domains(
+        let fresh_run = process_domains(
             domains_to_process.clone(),
             args,
             progress_manager,
@@ -520,14 +658,18 @@ async fn process_domains_with_cache(
         )
         .await;
 
+        // Carry the provider stats from the fresh run through to the caller.
+        final_result.stats = fresh_run.stats;
+
         // Handle incremental scanning and cache updates
         if args.incremental {
             for domain in &domains_to_process {
                 let cache_key = create_cache_key(domain, args);
 
                 // Get domain-specific URLs (this is a simplification - in reality we'd need to track per-domain)
-                let domain_fresh_urls: HashSet<String> = fresh_urls
-                    .iter()
+                let domain_fresh_urls: HashSet<String> = fresh_run
+                    .urls
+                    .keys()
                     .filter(|url| url.contains(domain))
                     .cloned()
                     .collect();
@@ -542,7 +684,17 @@ async fn process_domains_with_cache(
                         args,
                         format!("Found {} new URLs for domain: {}", new_urls.len(), domain),
                     );
-                    final_urls.extend(new_urls);
+                    for url in new_urls {
+                        if let Some(sources) = fresh_run.urls.get(&url) {
+                            final_result
+                                .urls
+                                .entry(url)
+                                .or_default()
+                                .extend(sources.iter().cloned());
+                        } else {
+                            final_result.urls.entry(url).or_default();
+                        }
+                    }
                 }
 
                 // Update cache with all fresh URLs for this domain
@@ -550,14 +702,21 @@ async fn process_domains_with_cache(
                 let _ = cache.store_urls(&cache_key, &entry).await;
             }
         } else {
-            // Normal mode: add all fresh URLs and update cache
-            final_urls.extend(fresh_urls.clone());
+            // Normal mode: merge all fresh URLs (and their providers) into the result.
+            for (url, sources) in &fresh_run.urls {
+                final_result
+                    .urls
+                    .entry(url.clone())
+                    .or_default()
+                    .extend(sources.iter().cloned());
+            }
 
             // For simplicity, store all URLs for each domain (this could be optimized)
             for domain in &domains_to_process {
                 let cache_key = create_cache_key(domain, args);
-                let domain_urls: Vec<String> = fresh_urls
-                    .iter()
+                let domain_urls: Vec<String> = fresh_run
+                    .urls
+                    .keys()
                     .filter(|url| url.contains(domain))
                     .cloned()
                     .collect();
@@ -573,12 +732,18 @@ async fn process_domains_with_cache(
     // Clean up expired cache entries
     let _ = cache.cleanup_expired(args.cache_ttl * 2).await;
 
-    final_urls
+    final_result
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut args = Args::parse();
+
+    // Short-circuit: list providers and exit without doing any I/O.
+    if args.list_providers {
+        print_provider_list();
+        return Ok(());
+    }
 
     // Load configuration and apply it to args
     // This ensures command line options take precedence over config file
@@ -593,9 +758,18 @@ async fn main() -> Result<()> {
     // Check if file input is provided
     let urls_from_file = read_urls_from_files(&args)?;
 
-    let all_urls = if let Some(urls) = urls_from_file {
-        // URLs read from file(s) - skip provider processing
-        urls.into_iter().collect()
+    let run_result = if let Some(urls) = urls_from_file {
+        // URLs read from file(s) - skip provider processing. Mark every URL
+        // as coming from "file" so downstream `--show-sources` is consistent.
+        let mut url_map: std::collections::HashMap<String, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
+        for url in urls {
+            url_map.entry(url).or_default().insert("file".to_string());
+        }
+        ProviderRunResult {
+            urls: url_map,
+            stats: Vec::new(),
+        }
     } else {
         // No file input - use traditional domain-based approach
         // Collect domains either from arguments or stdin
@@ -632,6 +806,9 @@ async fn main() -> Result<()> {
         .await
     };
 
+    // URL-only view for filters (they don't care about sources).
+    let all_urls: std::collections::HashSet<String> = run_result.urls.keys().cloned().collect();
+
     // Apply URL filtering
     let sorted_urls = apply_url_filters(&args, &all_urls, &progress_manager);
 
@@ -644,7 +821,7 @@ async fn main() -> Result<()> {
     let should_check_status =
         args.check_status || !args.include_status.is_empty() || !args.exclude_status.is_empty();
 
-    let final_urls = if should_check_status || args.extract_links {
+    let mut final_urls = if should_check_status || args.extract_links {
         // Initialize appropriate testers
         let mut testers: Vec<Box<dyn Tester>> = Vec::new();
 
@@ -708,6 +885,20 @@ async fn main() -> Result<()> {
             .collect()
     };
 
+    // Attach provider attribution to each surviving UrlData record when the
+    // user opted in. URLs introduced by the link extractor — not present in
+    // the run result — keep an empty `sources` list.
+    if args.show_sources {
+        for entry in final_urls.iter_mut() {
+            if let Some(providers) = run_result.urls.get(&entry.url) {
+                let mut sources: Vec<String> = providers.iter().cloned().collect();
+                sources.sort();
+                sources.dedup();
+                entry.sources = sources;
+            }
+        }
+    }
+
     match outputter.output(&final_urls, args.output.clone(), args.silent) {
         Ok(_) => {
             if args.verbose && !args.silent {
@@ -723,7 +914,41 @@ async fn main() -> Result<()> {
         }
     }
 
+    if args.stats && !args.silent {
+        print_provider_stats(&run_result.stats);
+    }
+
     Ok(())
+}
+
+/// Render the per-provider summary table to stderr (so it doesn't pollute
+/// stdout when callers pipe URL results into other tools).
+fn print_provider_stats(stats: &[runner::ProviderStats]) {
+    if stats.is_empty() {
+        return;
+    }
+    eprintln!();
+    eprintln!("Provider stats:");
+    eprintln!(
+        "  {:<18}  {:>8}  {:>7}  {:>10}",
+        "provider", "urls", "errors", "elapsed"
+    );
+    eprintln!(
+        "  {:<18}  {:>8}  {:>7}  {:>10}",
+        "------------------", "--------", "-------", "----------"
+    );
+    for s in stats {
+        let elapsed_ms = s.elapsed.as_millis();
+        let elapsed_label = if elapsed_ms >= 1000 {
+            format!("{:.2}s", s.elapsed.as_secs_f64())
+        } else {
+            format!("{}ms", elapsed_ms)
+        };
+        eprintln!(
+            "  {:<18}  {:>8}  {:>7}  {:>10}",
+            s.name, s.url_count, s.error_count, elapsed_label
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1078,12 +1303,17 @@ mod tests {
             redis_url: None,
             cache_ttl: 86400,
             no_cache: false,
+            exclude_providers: vec![],
+            all_providers: false,
+            list_providers: false,
+            show_sources: false,
+            stats: false,
         };
 
         let progress_manager = ProgressManager::new(true);
 
         // Process domains with mock provider
-        let urls = process_domains(
+        let result = process_domains(
             vec!["example.com".to_string()],
             &args,
             &progress_manager,
@@ -1097,10 +1327,17 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0], "example.com");
 
-        // Verify that the URLs were correctly returned
-        assert_eq!(urls.len(), 2);
-        assert!(urls.contains("https://example.com/page1"));
-        assert!(urls.contains("https://example.com/page2"));
+        // Verify that the URLs were correctly returned and attributed.
+        assert_eq!(result.urls.len(), 2);
+        assert!(result.urls.contains_key("https://example.com/page1"));
+        assert!(result.urls.contains_key("https://example.com/page2"));
+        assert!(result.urls["https://example.com/page1"].contains("MockProvider"));
+
+        // Stats reflect the provider's URL count.
+        assert_eq!(result.stats.len(), 1);
+        assert_eq!(result.stats[0].name, "MockProvider");
+        assert_eq!(result.stats[0].url_count, 2);
+        assert_eq!(result.stats[0].error_count, 0);
     }
 
     #[tokio::test]
@@ -1171,6 +1408,11 @@ mod tests {
             redis_url: None,
             cache_ttl: 86400,
             no_cache: false,
+            exclude_providers: vec![],
+            all_providers: false,
+            list_providers: false,
+            show_sources: false,
+            stats: false,
         };
 
         let progress_manager = ProgressManager::new(true);

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -4,12 +4,16 @@ use colored::*;
 use serde::Serialize;
 use std::fmt;
 
-/// Helper struct for JSON serialization with guaranteed field order (url first, then status).
+/// Helper struct for JSON serialization with guaranteed field order
+/// (url, status, sources). `sources` is omitted when empty so the output
+/// stays backward-compatible with callers that don't ask for attribution.
 #[derive(Serialize)]
 struct JsonUrlEntry<'a> {
     url: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<&'a str>,
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    sources: &'a [String],
 }
 
 /// Formatter trait for converting URL data to different output formats
@@ -43,7 +47,7 @@ impl PlainFormatter {
 
 impl Formatter for PlainFormatter {
     fn format(&self, url_data: &UrlData, _is_last: bool) -> String {
-        match &url_data.status {
+        let mut line = match &url_data.status {
             Some(status) => {
                 let status_code_str = status.split_whitespace().next().unwrap_or("");
                 let colored_status = match status_code_str.parse::<u16>() {
@@ -56,10 +60,15 @@ impl Formatter for PlainFormatter {
                     },
                     Err(_) => status.normal(),
                 };
-                format!("{} [{}]\n", url_data.url, colored_status)
+                format!("{} [{}]", url_data.url, colored_status)
             }
-            None => format!("{}\n", url_data.url),
+            None => url_data.url.clone(),
+        };
+        if !url_data.sources.is_empty() {
+            line.push_str(&format!(" [{}]", url_data.sources.join(",").cyan()));
         }
+        line.push('\n');
+        line
     }
 
     fn clone_box(&self) -> Box<dyn Formatter> {
@@ -83,6 +92,7 @@ impl Formatter for JsonFormatter {
         let entry = JsonUrlEntry {
             url: &url_data.url,
             status: url_data.status.as_deref(),
+            sources: &url_data.sources,
         };
         let json = serde_json::to_string(&entry).unwrap_or_default();
 
@@ -112,12 +122,16 @@ impl CsvFormatter {
 impl Formatter for CsvFormatter {
     fn format(&self, url_data: &UrlData, _is_last: bool) -> String {
         let escaped_url = csv_escape(&url_data.url);
-        match &url_data.status {
-            Some(status) => {
-                let escaped_status = csv_escape(status);
-                format!("{escaped_url},{escaped_status}\n")
-            }
-            None => format!("{escaped_url},\n"),
+        let status_field = url_data
+            .status
+            .as_deref()
+            .map(csv_escape)
+            .unwrap_or_default();
+        if url_data.sources.is_empty() {
+            format!("{escaped_url},{status_field}\n")
+        } else {
+            let sources_field = csv_escape(&url_data.sources.join("|"));
+            format!("{escaped_url},{status_field},{sources_field}\n")
         }
     }
 
@@ -340,6 +354,47 @@ mod tests {
             formatter.format(&url_data, false),
             "\"https://example.com/path?a=1,2&b=3\",\n"
         );
+    }
+
+    #[test]
+    fn test_json_formatter_with_sources() {
+        let formatter = JsonFormatter::new();
+        let url_data = UrlData::new("https://example.com".to_string()).with_sources(vec![
+            "wayback".into(),
+            "otx".into(),
+            "wayback".into(),
+        ]);
+        // Sources are sorted and deduped; field appears after url/status.
+        assert_eq!(
+            formatter.format(&url_data, true),
+            "{\"url\":\"https://example.com\",\"sources\":[\"otx\",\"wayback\"]}\n"
+        );
+    }
+
+    #[test]
+    fn test_csv_formatter_with_sources() {
+        let formatter = CsvFormatter::new();
+        let url_data =
+            UrlData::with_status("https://example.com".to_string(), "200 OK".to_string())
+                .with_sources(vec!["wayback".into(), "cc".into()]);
+        // Sources column is pipe-separated when present.
+        assert_eq!(
+            formatter.format(&url_data, true),
+            "https://example.com,200 OK,cc|wayback\n"
+        );
+    }
+
+    #[test]
+    fn test_plain_formatter_with_sources() {
+        let formatter = PlainFormatter::new();
+        let url_data = UrlData::new("https://example.com".to_string())
+            .with_sources(vec!["wayback".into(), "cc".into()]);
+        let out = formatter.format(&url_data, true);
+        // Plain output appends [provider,provider] (ANSI codes may be present).
+        assert!(out.starts_with("https://example.com "));
+        assert!(out.contains("cc"));
+        assert!(out.contains("wayback"));
+        assert!(out.ends_with('\n'));
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -14,12 +14,18 @@ pub struct UrlData {
     pub url: String,
     /// Optional status information (e.g., HTTP status code)
     pub status: Option<String>,
+    /// Providers that reported this URL (sorted, deduped). Empty when unknown.
+    pub sources: Vec<String>,
 }
 
 impl UrlData {
     /// Create a new URL data entry without status information
     pub fn new(url: String) -> Self {
-        UrlData { url, status: None }
+        UrlData {
+            url,
+            status: None,
+            sources: Vec::new(),
+        }
     }
 
     /// Create a new URL data entry with status information
@@ -27,7 +33,17 @@ impl UrlData {
         UrlData {
             url,
             status: Some(status),
+            sources: Vec::new(),
         }
+    }
+
+    /// Attach the list of providers that reported this URL. The input is
+    /// sorted and deduplicated so output ordering is deterministic.
+    pub fn with_sources(mut self, mut sources: Vec<String>) -> Self {
+        sources.sort();
+        sources.dedup();
+        self.sources = sources;
+        self
     }
 
     /// Parse a URL data entry from a string
@@ -42,12 +58,14 @@ impl UrlData {
             UrlData {
                 url: url.to_string(),
                 status: Some(status),
+                sources: Vec::new(),
             }
         } else {
             // No status information found
             UrlData {
                 url: data,
                 status: None,
+                sources: Vec::new(),
             }
         }
     }
@@ -196,6 +214,17 @@ mod tests {
         let url_data = UrlData::new("https://example.com".to_string());
         let debug_str = format!("{:?}", url_data);
         assert!(debug_str.contains("https://example.com"));
+    }
+
+    #[test]
+    fn test_url_data_with_sources_sorts_and_dedupes() {
+        let data = UrlData::new("https://example.com".to_string()).with_sources(vec![
+            "wayback".into(),
+            "otx".into(),
+            "wayback".into(),
+            "cc".into(),
+        ]);
+        assert_eq!(data.sources, vec!["cc", "otx", "wayback"]);
     }
 
     #[test]

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -126,19 +126,19 @@ impl Outputter for CsvOutputter {
     }
 
     fn output(&self, urls: &[UrlData], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
+        let has_status = urls.iter().any(|url| url.status.is_some());
+        let has_sources = urls.iter().any(|url| !url.sources.is_empty());
+        let header: &[u8] = match (has_status, has_sources) {
+            (false, false) => b"url\n",
+            (true, false) => b"url,status\n",
+            (false, true) => b"url,status,sources\n",
+            (true, true) => b"url,status,sources\n",
+        };
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
-
-                // Write CSV header (including status if any URLs have status info)
-                let has_status = urls.iter().any(|url| url.status.is_some());
-                if has_status {
-                    file.write_all(b"url,status\n")
-                        .context("Failed to write CSV header")?;
-                } else {
-                    file.write_all(b"url\n")
-                        .context("Failed to write CSV header")?;
-                }
+                file.write_all(header)
+                    .context("Failed to write CSV header")?;
 
                 for (i, url_data) in urls.iter().enumerate() {
                     let formatted = self.format(url_data, i == urls.len() - 1);
@@ -153,13 +153,7 @@ impl Outputter for CsvOutputter {
                     return Ok(());
                 };
 
-                // Determine if we should include status in header
-                let has_status = urls.iter().any(|url| url.status.is_some());
-                if has_status {
-                    println!("url,status");
-                } else {
-                    println!("url");
-                }
+                print!("{}", std::str::from_utf8(header).unwrap_or(""));
 
                 for (i, url_data) in urls.iter().enumerate() {
                     let formatted = self.format(url_data, i == urls.len() - 1);
@@ -305,6 +299,30 @@ mod tests {
             "url,status\nhttps://example.com/page1,\nhttps://example.com/page2,200 OK\n"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_csv_outputter_with_sources_header() -> Result<()> {
+        let outputter = CsvOutputter::new();
+        let urls = vec![
+            UrlData::new("https://example.com/a".to_string()).with_sources(vec!["wayback".into()]),
+            UrlData::with_status("https://example.com/b".to_string(), "200 OK".to_string())
+                .with_sources(vec!["cc".into(), "otx".into()]),
+        ];
+
+        let temp_file = NamedTempFile::new()?;
+        let temp_path = temp_file.path().to_path_buf();
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
+
+        let mut content = String::new();
+        let mut file = File::open(&temp_path)?;
+        file.read_to_string(&mut content)?;
+
+        assert_eq!(
+            content,
+            "url,status,sources\nhttps://example.com/a,,wayback\nhttps://example.com/b,200 OK,cc|otx\n"
+        );
         Ok(())
     }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -124,18 +124,54 @@ pub fn add_provider<T: Provider + 'static>(
     provider_names.push(provider_name);
 }
 
-/// Process domains using a provider-based concurrency pattern
+/// Per-provider tally for end-of-run summaries (`--stats`).
+#[derive(Debug, Clone, Default)]
+pub struct ProviderStats {
+    /// Provider name (e.g. "Wayback Machine").
+    pub name: String,
+    /// Cumulative URLs returned across all domains.
+    pub url_count: usize,
+    /// Number of domain fetches that failed.
+    pub error_count: usize,
+    /// Total wall-clock time spent in fetch_urls across domains.
+    pub elapsed: std::time::Duration,
+}
+
+/// Result of a provider run: URLs mapped to the providers that reported them,
+/// plus per-provider stats indexed in the same order as `provider_names`.
+#[derive(Debug, Default)]
+pub struct ProviderRunResult {
+    pub urls: HashMap<String, HashSet<String>>,
+    pub stats: Vec<ProviderStats>,
+}
+
+/// Process domains using a provider-based concurrency pattern.
+///
+/// Returns each discovered URL along with the set of providers that reported
+/// it. Order within each source set is preserved by the caller via sort+dedup.
 pub async fn process_domains(
     domains: Vec<String>,
     args: &Args,
     progress_manager: &ProgressManager,
     providers: &[Box<dyn Provider>],
     provider_names: &[String],
-) -> HashSet<String> {
-    // Create a shared set to collect all URLs
-    let all_urls = Arc::new(Mutex::new(HashSet::new()));
+) -> ProviderRunResult {
+    // Map URL -> set of provider names that reported it.
+    let all_urls: Arc<Mutex<HashMap<String, HashSet<String>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
     let total_domains = domains.len();
     let total_providers = providers.len();
+
+    // Per-provider stats, indexed identically to `provider_names`.
+    let stats: Arc<Mutex<Vec<ProviderStats>>> = Arc::new(Mutex::new(
+        provider_names
+            .iter()
+            .map(|n| ProviderStats {
+                name: n.clone(),
+                ..Default::default()
+            })
+            .collect(),
+    ));
 
     // Create a progress bar for overall progress
     let overall_bar = progress_manager.create_domain_bar(total_domains);
@@ -185,6 +221,7 @@ pub async fn process_domains(
         provider_data.into_iter().enumerate()
     {
         let all_urls_clone = Arc::clone(&all_urls);
+        let stats_clone = Arc::clone(&stats);
         let queue = Arc::clone(&provider_queues[p_idx]);
         let provider_bar = provider_bars[original_idx].clone();
 
@@ -265,7 +302,10 @@ pub async fn process_domains(
                 });
 
                 // Fetch URLs for this domain using this provider
-                match provider_clone.fetch_urls(&domain).await {
+                let fetch_start = std::time::Instant::now();
+                let fetch_result = provider_clone.fetch_urls(&domain).await;
+                let fetch_elapsed = fetch_start.elapsed();
+                match fetch_result {
                     Ok(urls) => {
                         provider_bar.set_position(100);
                         provider_bar.set_message(format!(
@@ -287,12 +327,24 @@ pub async fn process_domains(
                         // Force refresh to maintain line position
                         provider_bar.tick();
 
-                        // Add URLs to the shared set
+                        let url_count = urls.len();
+
+                        // Add URLs to the shared map (URL -> set of providers).
                         {
-                            let mut url_set = all_urls_clone.lock().unwrap();
-                            for url in &urls {
-                                url_set.insert(url.clone());
+                            let mut url_map = all_urls_clone.lock().unwrap();
+                            for url in urls {
+                                url_map
+                                    .entry(url)
+                                    .or_default()
+                                    .insert(provider_name.clone());
                             }
+                        }
+
+                        // Update per-provider stats.
+                        {
+                            let mut s = stats_clone.lock().unwrap();
+                            s[original_idx].url_count += url_count;
+                            s[original_idx].elapsed += fetch_elapsed;
                         }
 
                         completion_ctx.track(&domain);
@@ -300,9 +352,7 @@ pub async fn process_domains(
                         if verbose && !silent {
                             println!(
                                 "  - {}: Found {} URLs for {}",
-                                provider_name,
-                                urls.len(),
-                                domain
+                                provider_name, url_count, domain
                             );
                         }
                     }
@@ -322,6 +372,12 @@ pub async fn process_domains(
 
                         // Force refresh to maintain line position
                         provider_bar.tick();
+
+                        {
+                            let mut s = stats_clone.lock().unwrap();
+                            s[original_idx].error_count += 1;
+                            s[original_idx].elapsed += fetch_elapsed;
+                        }
 
                         completion_ctx.track(&domain);
 
@@ -357,6 +413,7 @@ pub async fn process_domains(
 
     overall_bar.finish_with_message("All domains processed");
 
-    // Return the collected URLs
-    Arc::try_unwrap(all_urls).unwrap().into_inner().unwrap()
+    let urls = Arc::try_unwrap(all_urls).unwrap().into_inner().unwrap();
+    let stats = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
+    ProviderRunResult { urls, stats }
 }


### PR DESCRIPTION
## Summary
Implements subfinder-parity features for source visibility and provider selection. All additions are opt-in — default output and provider behaviour are unchanged.

### New flags
- `--show-sources` — annotate each URL with the providers that returned it. JSON gets a `sources` field, CSV gets a `sources` column, plain output appends `[wayback,otx]` after the URL.
- `--list-providers` — print the provider catalog (id, name, key requirement, summary) and exit.
- `--exclude-providers wayback,vt` — negative selection. Wins on conflict with `--providers` / `--all-providers` / auto-enable. Also accepts `robots` / `sitemap`.
- `--all-providers` — enable every catalog entry. API-keyed providers are silently skipped when no key is configured (no noisy error like the explicit form).
- `--stats` — per-provider summary table to stderr at end of run (urls / errors / elapsed). Stays off stdout so pipelines don't break.

### Internal changes
- Runner now returns a `ProviderRunResult { urls: HashMap<String, HashSet<String>>, stats: Vec<ProviderStats> }`. URLs carry their provider set through dedupe; stats accumulate per-provider counts and timings.
- `UrlData.sources: Vec<String>` is populated in main only when `--show-sources` is set, so JSON/CSV schemas remain backward compatible.
- Cached URLs surface with empty sources (attribution isn't persisted in the cache today — could be added later).
- File-input URLs are tagged `"file"` so `--show-sources` is consistent.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 364 passed (5 new tests: UrlData dedup, JSON/CSV/plain formatter with sources, CSV writer header)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke: `urx --list-providers` renders the catalog table correctly
- [ ] Smoke: `urx --show-sources --format json example.com` end-to-end
- [ ] Smoke: `urx --all-providers --stats example.com`
- [ ] Smoke: `urx --providers wayback,vt --exclude-providers vt example.com` (vt excluded)