### PR TITLE
feat(input/runtime): --domain-list and --max-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Track provider attribution per URL and surface it via `--show-sources` (JSON adds a `sources` field, CSV adds a `sources` column, plain text appends `[provider1,provider2]`)
 - Add `--list-providers` to enumerate every supported provider, `--exclude-providers` for negative selection, and `--all-providers` to enable every catalog entry (API-keyed providers only activate when a key is set)
 - Add `--stats` to print a per-provider summary (URLs found, errors, elapsed) to stderr at end of run
+- Add `--domain-list FILE` (alias `--dL`) to read newline-separated domains from a file (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
+- Add `--max-time SECONDS` global ceiling on provider enumeration; on deadline urx aborts in-flight fetches and returns whatever URLs have been collected so far (0 = unlimited; default)
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Options:
   -V, --version          Print version
 
 Input Options:
-      --files <FILES>...  Read URLs directly from files (supports WARC, URLTeam compressed, and text files). Use multiple --files flags or space-separate multiple files
+      --files <FILES>...        Read URLs directly from files (supports WARC, URLTeam compressed, and text files)
+      --domain-list <PATH>      File of newline-separated domains to scan (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
 
 Output Options:
   -o, --output <OUTPUT>  Output file to write results
@@ -165,6 +166,7 @@ Network Options:
       --retries <RETRIES>              Number of retries for failed requests [default: 2]
       --parallel <PARALLEL>            Maximum number of parallel requests per provider and maximum concurrent domain processing [default: 5]
       --rate-limit <RATE_LIMIT>        Rate limit (requests per second)
+      --max-time <MAX_TIME>            Global ceiling on provider enumeration time in seconds (0 = unlimited) [default: 0]
 
 Testing Options:
       --check-status

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -19,7 +19,8 @@ Options:
   -V, --version          Print version
 
 Input Options:
-      --files <FILES>...  Read URLs directly from files (supports WARC, URLTeam compressed, and text files)
+      --files <FILES>...     Read URLs directly from files (supports WARC, URLTeam compressed, and text files)
+      --domain-list <PATH>   File of newline-separated domains to scan (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
 
 Output Options:
   -o, --output <OUTPUT>  Output file to write results
@@ -72,6 +73,7 @@ Network Options:
   --retries <RETRIES>            Retries for failed requests [default: 2]
   --parallel <PARALLEL>          Max parallel requests per provider [default: 5]
   --rate-limit <RATE_LIMIT>      Requests per second
+  --max-time <SECONDS>           Global ceiling on provider enumeration time in seconds; in-flight fetches are aborted at deadline (0 = unlimited) [default: 0]
 
 Testing Options:
   --check-status                     Check HTTP status code of collected URLs

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,13 @@ pub struct Args {
     #[clap(long, action = clap::ArgAction::Append, num_args = 1.., value_parser)]
     pub files: Vec<PathBuf>,
 
+    /// File(s) containing newline-separated domains to scan. Repeatable;
+    /// merged with positional DOMAINS and stdin. Blank lines and `#` comments
+    /// are ignored.
+    #[clap(help_heading = "Input Options")]
+    #[clap(long = "domain-list", alias = "dL", visible_alias = "--dL", action = clap::ArgAction::Append, value_parser)]
+    pub domain_list: Vec<PathBuf>,
+
     #[clap(help_heading = "Output Options")]
     /// Output file to write results
     #[clap(short, long, value_parser)]
@@ -229,6 +236,14 @@ pub struct Args {
     #[clap(long)]
     pub rate_limit: Option<f32>,
 
+    /// Global ceiling on provider enumeration time, in seconds. When the
+    /// deadline elapses, in-flight provider fetches are aborted and urx
+    /// proceeds with whatever URLs have been collected so far. `0` (the
+    /// default) means no ceiling.
+    #[clap(help_heading = "Network Options")]
+    #[clap(long, default_value = "0")]
+    pub max_time: u64,
+
     /// Check HTTP status code of collected URLs
     #[clap(help_heading = "Testing Options")]
     #[clap(long, alias = "cs", visible_alias = "--cs")]
@@ -289,12 +304,43 @@ pub fn read_domains_from_stdin() -> anyhow::Result<Vec<String>> {
 
     for line in stdin.lock().lines() {
         let domain = line.context("Failed to read line from stdin")?;
-        if !domain.trim().is_empty() {
-            domains.push(domain.trim().to_string());
+        let domain = parse_domain_line(&domain);
+        if let Some(d) = domain {
+            domains.push(d);
         }
     }
 
     Ok(domains)
+}
+
+/// Read newline-separated domains from a file. Blank lines and lines that
+/// start with `#` (after trimming) are skipped so users can keep notes
+/// alongside the list.
+pub fn read_domains_from_file(path: &std::path::Path) -> anyhow::Result<Vec<String>> {
+    use anyhow::Context;
+    use std::io::{BufRead, BufReader};
+
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open domain list: {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut domains = Vec::new();
+    for line in reader.lines() {
+        let raw = line.with_context(|| format!("Failed to read {}", path.display()))?;
+        if let Some(d) = parse_domain_line(&raw) {
+            domains.push(d);
+        }
+    }
+    Ok(domains)
+}
+
+/// Trim whitespace and drop blank / comment lines from a single text line.
+fn parse_domain_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 impl Args {
@@ -459,6 +505,53 @@ mod tests {
         assert_eq!(args.files.len(), 2);
         assert_eq!(args.files[0].to_str().unwrap(), "file1.txt");
         assert_eq!(args.files[1].to_str().unwrap(), "file2.warc");
+    }
+
+    #[test]
+    fn test_parse_domain_line_skips_blank_and_comments() {
+        assert_eq!(parse_domain_line(""), None);
+        assert_eq!(parse_domain_line("   "), None);
+        assert_eq!(parse_domain_line("# comment"), None);
+        assert_eq!(parse_domain_line("  # leading-space comment"), None);
+        assert_eq!(
+            parse_domain_line("  example.com  "),
+            Some("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_domains_from_file() -> anyhow::Result<()> {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new()?;
+        writeln!(
+            file,
+            "example.com\n  # comment\n\n  another.test  \n#trailing"
+        )?;
+        let domains = read_domains_from_file(file.path())?;
+        assert_eq!(domains, vec!["example.com", "another.test"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_domain_list_flag_parsed() {
+        let args = Args::parse_from([
+            "urx",
+            "--domain-list",
+            "domains.txt",
+            "--domain-list",
+            "more.txt",
+        ]);
+        assert_eq!(args.domain_list.len(), 2);
+        assert_eq!(args.domain_list[0].to_str().unwrap(), "domains.txt");
+        assert_eq!(args.domain_list[1].to_str().unwrap(), "more.txt");
+    }
+
+    #[test]
+    fn test_max_time_defaults_to_zero() {
+        let args = Args::parse_from(["urx", "example.com"]);
+        assert_eq!(args.max_time, 0);
+        let args = Args::parse_from(["urx", "--max-time", "300", "example.com"]);
+        assert_eq!(args.max_time, 300);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -590,6 +590,8 @@ mod tests {
             list_providers: false,
             show_sources: false,
             stats: false,
+            domain_list: vec![],
+            max_time: 0,
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod testers;
 mod utils;
 
 use cache::{CacheEntry, CacheFilters, CacheKey, CacheManager};
-use cli::{read_domains_from_stdin, Args};
+use cli::{read_domains_from_file, read_domains_from_stdin, Args};
 use config::Config;
 use filters::{HostValidator, UrlFilter};
 use network::NetworkSettings;
@@ -125,6 +125,35 @@ fn print_provider_list() {
     println!("Use --providers id1,id2 to select. --all-providers enables every entry");
     println!("(API-keyed providers only activate when a key is available).");
     println!("--exclude-providers wins on conflict.");
+}
+
+/// Collect the effective domain list from CLI positional args, `--domain-list`
+/// files, and (when both are empty) stdin. Duplicates are removed while
+/// preserving first-seen order so the run order is predictable.
+fn collect_domains(args: &Args) -> Result<Vec<String>> {
+    let mut domains: Vec<String> = args.domains.clone();
+
+    for path in &args.domain_list {
+        let file_domains = read_domains_from_file(path)?;
+        if args.verbose && !args.silent {
+            println!(
+                "Loaded {} domains from {}",
+                file_domains.len(),
+                path.display()
+            );
+        }
+        domains.extend(file_domains);
+    }
+
+    // Only fall back to stdin when no domains were supplied via flags/files,
+    // otherwise piped data would silently get appended on every invocation.
+    if domains.is_empty() {
+        domains.extend(read_domains_from_stdin()?);
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    domains.retain(|d| seen.insert(d.clone()));
+    Ok(domains)
 }
 
 /// Parse API keys from environment variable (comma-separated) and combine with CLI keys
@@ -442,12 +471,15 @@ fn apply_url_filters(
         if args.verbose && !args.silent {
             println!("Enforcing strict host validation...");
         }
-        // We need to get domains from the original input
-        let domains = if args.domains.is_empty() {
-            read_domains_from_stdin().unwrap_or_default()
-        } else {
-            args.domains.clone()
-        };
+        // Re-resolve the original domain list. We can't read stdin a second
+        // time, so the host validator falls back to whatever positional args
+        // and --domain-list files supplied.
+        let mut domains: Vec<String> = args.domains.clone();
+        for path in &args.domain_list {
+            if let Ok(more) = read_domains_from_file(path) {
+                domains.extend(more);
+            }
+        }
 
         if !domains.is_empty() {
             let host_validator = HostValidator::new(&domains, args.subs);
@@ -772,17 +804,12 @@ async fn main() -> Result<()> {
         }
     } else {
         // No file input - use traditional domain-based approach
-        // Collect domains either from arguments or stdin
-        let domains = if args.domains.is_empty() {
-            read_domains_from_stdin()?
-        } else {
-            args.domains.clone()
-        };
+        let domains = collect_domains(&args)?;
 
         if domains.is_empty() {
             if !args.silent {
                 eprintln!(
-                    "No domains provided. Please specify domains or pipe them through stdin."
+                    "No domains provided. Pass DOMAINS positionally, use --domain-list FILE, or pipe them through stdin."
                 );
             }
             return Ok(());
@@ -1155,6 +1182,7 @@ mod tests {
     struct MockProvider {
         urls: Vec<String>,
         should_fail: bool,
+        delay_ms: u64,
         calls: Arc<Mutex<Vec<String>>>,
     }
 
@@ -1163,8 +1191,14 @@ mod tests {
             MockProvider {
                 urls,
                 should_fail,
+                delay_ms: 0,
                 calls: Arc::new(Mutex::new(vec![])),
             }
+        }
+
+        fn with_delay_ms(mut self, ms: u64) -> Self {
+            self.delay_ms = ms;
+            self
         }
     }
 
@@ -1181,9 +1215,14 @@ mod tests {
             let should_fail = self.should_fail;
             let calls = self.calls.clone();
 
+            let delay = self.delay_ms;
             Box::pin(async move {
                 // Record the call
                 calls.lock().unwrap().push(domain.to_string());
+
+                if delay > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                }
 
                 if should_fail {
                     Err(anyhow::anyhow!("Mock provider failure"))
@@ -1308,6 +1347,8 @@ mod tests {
             list_providers: false,
             show_sources: false,
             stats: false,
+            domain_list: vec![],
+            max_time: 0,
         };
 
         let progress_manager = ProgressManager::new(true);
@@ -1338,6 +1379,127 @@ mod tests {
         assert_eq!(result.stats[0].name, "MockProvider");
         assert_eq!(result.stats[0].url_count, 2);
         assert_eq!(result.stats[0].error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_max_time_aborts_slow_provider() {
+        // A provider that sleeps for 5s should be cut off when max_time=1.
+        let slow = MockProvider::new(vec!["https://example.com/never".to_string()], false)
+            .with_delay_ms(5_000);
+
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(slow)];
+        let provider_names = vec!["SlowProvider".to_string()];
+
+        let mut args = build_test_args();
+        args.max_time = 1;
+        let progress_manager = ProgressManager::new(true);
+
+        let started = std::time::Instant::now();
+        let result = process_domains(
+            vec!["example.com".to_string()],
+            &args,
+            &progress_manager,
+            &providers,
+            &provider_names,
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        // Should bail out well before the provider's 5s sleep finishes.
+        assert!(
+            elapsed.as_secs() < 4,
+            "expected --max-time to abort within ~1s, got {:?}",
+            elapsed
+        );
+        // No URLs were produced because the provider was cut off mid-await.
+        assert!(
+            result.urls.is_empty(),
+            "expected no URLs, got {:?}",
+            result.urls
+        );
+    }
+
+    #[test]
+    fn test_collect_domains_merges_inputs_and_dedupes() -> anyhow::Result<()> {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new()?;
+        writeln!(file, "from-file.test\nexample.com")?; // example.com overlaps positional
+
+        let mut args = build_test_args();
+        args.domains = vec!["example.com".to_string(), "another.test".to_string()];
+        args.domain_list = vec![file.path().to_path_buf()];
+
+        let domains = collect_domains(&args)?;
+        // Positional first, file second, dedupe keeps first occurrence.
+        assert_eq!(
+            domains,
+            vec!["example.com", "another.test", "from-file.test"]
+        );
+        Ok(())
+    }
+
+    /// Helper to build a fully-defaulted Args for tests that only care about
+    /// a couple of fields. Keep this in sync with the `Args` struct.
+    fn build_test_args() -> Args {
+        Args {
+            domains: vec![],
+            config: None,
+            files: vec![],
+            output: None,
+            format: "plain".to_string(),
+            merge_endpoint: false,
+            normalize_url: false,
+            providers: vec!["mock".to_string()],
+            subs: false,
+            cc_index: "CC-MAIN-2026-17".to_string(),
+            vt_api_key: vec![],
+            urlscan_api_key: vec![],
+            zoomeye_api_key: vec![],
+            verbose: false,
+            silent: true,
+            no_progress: true,
+            preset: vec![],
+            extensions: vec![],
+            exclude_extensions: vec![],
+            patterns: vec![],
+            exclude_patterns: vec![],
+            show_only_host: false,
+            show_only_path: false,
+            show_only_param: false,
+            min_length: None,
+            max_length: None,
+            strict: false,
+            network_scope: "all".to_string(),
+            proxy: None,
+            proxy_auth: None,
+            insecure: false,
+            random_agent: false,
+            timeout: 30,
+            retries: 3,
+            parallel: Some(5),
+            rate_limit: None,
+            check_status: false,
+            include_status: vec![],
+            exclude_status: vec![],
+            extract_links: false,
+            include_robots: false,
+            include_sitemap: false,
+            exclude_robots: true,
+            exclude_sitemap: true,
+            incremental: false,
+            cache_type: "sqlite".to_string(),
+            cache_path: None,
+            redis_url: None,
+            cache_ttl: 86400,
+            no_cache: false,
+            exclude_providers: vec![],
+            all_providers: false,
+            list_providers: false,
+            show_sources: false,
+            stats: false,
+            domain_list: vec![],
+            max_time: 0,
+        }
     }
 
     #[tokio::test]
@@ -1413,6 +1575,8 @@ mod tests {
             list_providers: false,
             show_sources: false,
             stats: false,
+            domain_list: vec![],
+            max_time: 0,
         };
 
         let progress_manager = ProgressManager::new(true);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -408,12 +408,50 @@ pub async fn process_domains(
         provider_futures.push(provider_future);
     }
 
-    // Wait for all provider tasks to finish
-    join_all(provider_futures).await;
+    // Wait for all provider tasks to finish, honouring --max-time when set.
+    // We grab abort handles up front so a timeout can cancel in-flight tasks
+    // while we keep whatever URLs they've already pushed into the shared map.
+    let abort_handles: Vec<_> = provider_futures.iter().map(|h| h.abort_handle()).collect();
+    let join_future = join_all(provider_futures);
+    let deadline = (args.max_time > 0).then(|| std::time::Duration::from_secs(args.max_time));
 
-    overall_bar.finish_with_message("All domains processed");
+    let finished_within_deadline = if let Some(d) = deadline {
+        match tokio::time::timeout(d, join_future).await {
+            Ok(_) => true,
+            Err(_) => {
+                for h in abort_handles {
+                    h.abort();
+                }
+                if !args.silent {
+                    eprintln!(
+                        "[urx] --max-time {}s elapsed; aborting in-flight provider fetches and returning partial results",
+                        d.as_secs()
+                    );
+                }
+                false
+            }
+        }
+    } else {
+        join_future.await;
+        true
+    };
 
-    let urls = Arc::try_unwrap(all_urls).unwrap().into_inner().unwrap();
-    let stats = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
+    if finished_within_deadline {
+        overall_bar.finish_with_message("All domains processed");
+    } else {
+        overall_bar.finish_with_message("Stopped by --max-time deadline");
+    }
+
+    // Reclaim the shared state. If tasks were aborted the inner Arc may still
+    // have outstanding strong counts for a brief moment; drain via clone in
+    // that case rather than panicking.
+    let urls = match Arc::try_unwrap(all_urls) {
+        Ok(m) => m.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
+    let stats = match Arc::try_unwrap(stats) {
+        Ok(s) => s.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
     ProviderRunResult { urls, stats }
 }


### PR DESCRIPTION
## Summary
PR-B from the subfinder-parity plan. Two independent quality-of-life additions:

- **`--domain-list FILE`** (alias `--dL`): newline-separated domain file input. Repeatable. Merged with positional `DOMAINS` and stdin. Blank lines and `#` comments are skipped. Stdin only kicks in when nothing else supplied a domain — piped data won't silently get appended to a list given on the CLI.
- **`--max-time SECONDS`**: global ceiling on provider enumeration. When the deadline elapses, `join_all` is cancelled, the per-task abort handles fire, and urx proceeds with whatever URLs have already been collected. Default `0` = unlimited.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 370 passed (6 new tests):
  - `parse_domain_line` skips blank / `#` comments
  - `read_domains_from_file` end-to-end
  - `--domain-list` clap parsing (repeated flag)
  - `--max-time` clap default + custom
  - `collect_domains` merges positional + file + dedupes
  - `test_max_time_aborts_slow_provider` — runner aborts a 5s sleep when max_time=1, finishes in <4s
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Smoke: `printf 'example.com\nrust-lang.org\n' > /tmp/d.txt && urx --domain-list /tmp/d.txt --silent | head`
- [ ] Smoke: `urx --max-time 2 --providers wayback some-huge-domain.com` returns within ~2s with a warning line