### PR TITLE
feat(config): per-provider rate limits and separate provider-config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Add `--stats` to print a per-provider summary (URLs found, errors, elapsed) to stderr at end of run
 - Add `--domain-list FILE` (alias `--dL`) to read newline-separated domains from a file (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
 - Add `--max-time SECONDS` global ceiling on provider enumeration; on deadline urx aborts in-flight fetches and returns whatever URLs have been collected so far (0 = unlimited; default)
+- Add `--rate-limit-by id=req_per_sec,...` for per-provider rate limits; providers not listed fall back to global `--rate-limit`
+- Add `--provider-config FILE` for a separate API-keys-only TOML (default `$XDG_CONFIG_HOME/urx/provider-config.toml`); precedence is CLI/env > provider-config > main config, so the main config can be safely committed to source control
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Arguments:
   [DOMAINS]...  Domains to fetch URLs for
 
 Options:
-  -c, --config <CONFIG>  Config file to load
+  -c, --config <CONFIG>           Config file to load
+      --provider-config <PATH>    Separate provider config file holding only API keys (default: $XDG_CONFIG_HOME/urx/provider-config.toml). CLI/env > provider-config > main config.
   -h, --help             Print help
   -V, --version          Print version
 
@@ -166,6 +167,7 @@ Network Options:
       --retries <RETRIES>              Number of retries for failed requests [default: 2]
       --parallel <PARALLEL>            Maximum number of parallel requests per provider and maximum concurrent domain processing [default: 5]
       --rate-limit <RATE_LIMIT>        Rate limit (requests per second)
+      --rate-limit-by <PAIRS>          Per-provider rate overrides (e.g. `vt=1,wayback=10`); falls back to --rate-limit for unlisted providers
       --max-time <MAX_TIME>            Global ceiling on provider enumeration time in seconds (0 = unlimited) [default: 0]
 
 Testing Options:

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -14,7 +14,8 @@ Arguments:
   [DOMAINS]...  Domains to fetch URLs for
 
 Options:
-  -c, --config <CONFIG>  Config file to load
+  -c, --config <CONFIG>           Config file to load
+      --provider-config <PATH>    Separate provider config holding only API keys (default: $XDG_CONFIG_HOME/urx/provider-config.toml)
   -h, --help             Print help
   -V, --version          Print version
 
@@ -73,6 +74,7 @@ Network Options:
   --retries <RETRIES>            Retries for failed requests [default: 2]
   --parallel <PARALLEL>          Max parallel requests per provider [default: 5]
   --rate-limit <RATE_LIMIT>      Requests per second
+  --rate-limit-by <PAIRS>        Per-provider rate overrides (e.g. `vt=1,wayback=10`); falls back to --rate-limit for unlisted providers
   --max-time <SECONDS>           Global ceiling on provider enumeration time in seconds; in-flight fetches are aborted at deadline (0 = unlimited) [default: 0]
 
 Testing Options:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,13 @@ pub struct Args {
     #[clap(short, long, value_parser)]
     pub config: Option<PathBuf>,
 
+    /// Path to a separate provider config file holding only API keys
+    /// (default: $XDG_CONFIG_HOME/urx/provider-config.toml). Keeping keys in
+    /// a dedicated file makes the main config safe to share.
+    /// Precedence: CLI/env keys > provider-config > main config.
+    #[clap(long = "provider-config", value_parser)]
+    pub provider_config: Option<PathBuf>,
+
     #[clap(help_heading = "Input Options")]
     /// Read URLs directly from files (supports WARC, URLTeam compressed, and text files). Use multiple --files flags or space-separate multiple files.
     #[clap(long, action = clap::ArgAction::Append, num_args = 1.., value_parser)]
@@ -236,6 +243,13 @@ pub struct Args {
     #[clap(long)]
     pub rate_limit: Option<f32>,
 
+    /// Per-provider rate limit overrides as comma-separated `id=req_per_sec`
+    /// pairs (e.g. `--rate-limit-by vt=1,wayback=10`). Providers not listed
+    /// fall back to the global --rate-limit (if set).
+    #[clap(help_heading = "Network Options")]
+    #[clap(long, value_delimiter = ',')]
+    pub rate_limit_by: Vec<String>,
+
     /// Global ceiling on provider enumeration time, in seconds. When the
     /// deadline elapses, in-flight provider fetches are aborted and urx
     /// proceeds with whatever URLs have been collected so far. `0` (the
@@ -344,6 +358,28 @@ fn parse_domain_line(line: &str) -> Option<String> {
 }
 
 impl Args {
+    /// Parse `--rate-limit-by` entries into a `provider_id -> requests/sec`
+    /// map. Malformed entries are dropped and reported via `parse_errors`
+    /// when verbose; the caller decides whether to surface them.
+    pub fn rate_limit_overrides(&self) -> std::collections::HashMap<String, f32> {
+        let mut map = std::collections::HashMap::new();
+        for raw in &self.rate_limit_by {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some((k, v)) = trimmed.split_once('=') {
+                let id = k.trim().to_string();
+                if let Ok(rate) = v.trim().parse::<f32>() {
+                    if !id.is_empty() && rate > 0.0 {
+                        map.insert(id, rate);
+                    }
+                }
+            }
+        }
+        map
+    }
+
     /// Check if robots.txt discovery should be used
     pub fn should_use_robots(&self) -> bool {
         !self.exclude_robots && self.include_robots
@@ -552,6 +588,48 @@ mod tests {
         assert_eq!(args.max_time, 0);
         let args = Args::parse_from(["urx", "--max-time", "300", "example.com"]);
         assert_eq!(args.max_time, 300);
+    }
+
+    #[test]
+    fn test_rate_limit_overrides_parses_valid_entries() {
+        let args = Args::parse_from([
+            "urx",
+            "--rate-limit-by",
+            "vt=2,wayback=10.5",
+            "--rate-limit-by",
+            "otx=1",
+            "example.com",
+        ]);
+        let map = args.rate_limit_overrides();
+        assert_eq!(map.get("vt"), Some(&2.0));
+        assert_eq!(map.get("wayback"), Some(&10.5));
+        assert_eq!(map.get("otx"), Some(&1.0));
+    }
+
+    #[test]
+    fn test_rate_limit_overrides_skips_malformed() {
+        let args = Args::parse_from([
+            "urx",
+            "--rate-limit-by",
+            "vt=oops,nokey=1,=2,wayback=-1",
+            "example.com",
+        ]);
+        let map = args.rate_limit_overrides();
+        // "vt=oops" -> not a number, dropped
+        // "nokey=1" -> kept, "nokey" -> 1
+        // "=2" -> empty id, dropped
+        // "wayback=-1" -> non-positive, dropped
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("nokey"), Some(&1.0));
+    }
+
+    #[test]
+    fn test_provider_config_flag_parsed() {
+        let args = Args::parse_from(["urx", "--provider-config", "/tmp/keys.toml", "example.com"]);
+        assert_eq!(
+            args.provider_config.as_deref().map(|p| p.to_str().unwrap()),
+            Some("/tmp/keys.toml")
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,120 @@ pub struct ProviderConfig {
     pub exclude_sitemap: Option<bool>,
 }
 
+/// Provider-config file: a small TOML that holds only API keys so the main
+/// config (filter rules, output formatting, etc.) can be checked into source
+/// control without leaking secrets. Comma-separated values rotate.
+#[derive(Debug, Deserialize, Default)]
+pub struct ProviderKeysConfig {
+    pub vt_api_key: Option<String>,
+    pub urlscan_api_key: Option<String>,
+    pub zoomeye_api_key: Option<String>,
+}
+
+impl ProviderKeysConfig {
+    /// Parse a provider-config TOML file from `path`. Returns the parsed
+    /// struct or an error.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "Failed to read provider-config file: {}",
+                path.as_ref().display()
+            )
+        })?;
+        let parsed: ProviderKeysConfig = toml::from_str(&content).with_context(|| {
+            format!(
+                "Failed to parse provider-config file: {}",
+                path.as_ref().display()
+            )
+        })?;
+        Ok(parsed)
+    }
+
+    /// Default lookup path mirrors the main config: $XDG_CONFIG_HOME/urx or
+    /// %APPDATA%\urx. Returns None when neither exists; unlike `Config`, we
+    /// do NOT auto-create the file because that would land an empty
+    /// "credentials" path the user didn't ask for.
+    pub fn default_path() -> Option<PathBuf> {
+        #[cfg(windows)]
+        {
+            if let Some(app_data) = env::var_os("APPDATA").map(PathBuf::from) {
+                let p = app_data.join("urx").join("provider-config.toml");
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            if let Some(home) = home_dir() {
+                let p = home
+                    .join(".config")
+                    .join("urx")
+                    .join("provider-config.toml");
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+        None
+    }
+
+    /// Load using the same precedence as the main config: --provider-config
+    /// flag wins, then the default path. Returns an empty config when no file
+    /// is found so callers can chain it freely.
+    pub fn load(args: &Args) -> Self {
+        if let Some(path) = &args.provider_config {
+            if let Ok(cfg) = Self::from_file(path) {
+                return cfg;
+            }
+        }
+        if let Some(path) = Self::default_path() {
+            if let Ok(cfg) = Self::from_file(path) {
+                return cfg;
+            }
+        }
+        ProviderKeysConfig::default()
+    }
+
+    /// Apply keys to args, but only for slots not already supplied via CLI
+    /// (or env-via-CLI). The main `Config` runs first and may have filled
+    /// these slots; this method then overwrites them when the provider-config
+    /// has a value, so provider-config beats main config.
+    ///
+    /// `cli_supplied_*` flags carry the original CLI state captured BEFORE
+    /// either config layer ran, so CLI input is preserved.
+    pub fn apply_to_args(
+        &self,
+        args: &mut Args,
+        cli_supplied_vt: bool,
+        cli_supplied_urlscan: bool,
+        cli_supplied_zoomeye: bool,
+    ) {
+        fn split_csv(s: &str) -> Vec<String> {
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect()
+        }
+
+        if !cli_supplied_vt {
+            if let Some(keys) = &self.vt_api_key {
+                args.vt_api_key = split_csv(keys);
+            }
+        }
+        if !cli_supplied_urlscan {
+            if let Some(keys) = &self.urlscan_api_key {
+                args.urlscan_api_key = split_csv(keys);
+            }
+        }
+        if !cli_supplied_zoomeye {
+            if let Some(keys) = &self.zoomeye_api_key {
+                args.zoomeye_api_key = split_csv(keys);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Default)]
 pub struct FilterConfig {
     pub preset: Option<Vec<String>>,
@@ -592,6 +706,8 @@ mod tests {
             stats: false,
             domain_list: vec![],
             max_time: 0,
+            rate_limit_by: vec![],
+            provider_config: None,
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");
@@ -604,5 +720,53 @@ mod tests {
         assert_eq!(args.output, Some(PathBuf::from("output.txt")));
         assert_eq!(args.format, "json");
         assert_eq!(args.providers, vec!["cc"]);
+    }
+
+    #[test]
+    fn test_provider_keys_config_parses_csv() -> Result<()> {
+        let content = r#"
+            vt_api_key = "key1, key2 ,key3"
+            urlscan_api_key = "us1"
+        "#;
+        let file = create_temp_config_file(content);
+        let cfg = ProviderKeysConfig::from_file(file.path())?;
+        assert_eq!(cfg.vt_api_key.as_deref(), Some("key1, key2 ,key3"));
+        assert_eq!(cfg.urlscan_api_key.as_deref(), Some("us1"));
+        assert_eq!(cfg.zoomeye_api_key, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_provider_keys_apply_to_args_respects_cli_supplied() {
+        let cfg = ProviderKeysConfig {
+            vt_api_key: Some("from-file".to_string()),
+            urlscan_api_key: Some("us-from-file".to_string()),
+            zoomeye_api_key: None,
+        };
+        let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
+        // Pretend the user supplied vt via CLI: provider-config should NOT
+        // overwrite that.
+        args.vt_api_key = vec!["cli-key".to_string()];
+
+        cfg.apply_to_args(&mut args, true, false, false);
+
+        assert_eq!(args.vt_api_key, vec!["cli-key".to_string()]);
+        // urlscan was empty and not CLI-supplied -> file value applies and
+        // is split on commas.
+        assert_eq!(args.urlscan_api_key, vec!["us-from-file".to_string()]);
+        // zoomeye not supplied anywhere -> stays empty.
+        assert!(args.zoomeye_api_key.is_empty());
+    }
+
+    #[test]
+    fn test_provider_keys_apply_to_args_splits_csv() {
+        let cfg = ProviderKeysConfig {
+            vt_api_key: Some("k1, k2 , ,k3".to_string()),
+            urlscan_api_key: None,
+            zoomeye_api_key: None,
+        };
+        let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
+        cfg.apply_to_args(&mut args, false, false, false);
+        assert_eq!(args.vt_api_key, vec!["k1", "k2", "k3"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             network_settings,
             &mut providers,
             &mut provider_names,
+            "wayback",
             "Wayback Machine".to_string(),
             WaybackMachineProvider::new,
         );
@@ -289,6 +290,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             network_settings,
             &mut providers,
             &mut provider_names,
+            "cc",
             args.cc_index.to_string(),
             || CommonCrawlProvider::with_index(args.cc_index.clone()),
         );
@@ -303,6 +305,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             network_settings,
             &mut providers,
             &mut provider_names,
+            "robots",
             "Robots.txt".to_string(),
             RobotsProvider::new,
         );
@@ -314,6 +317,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             network_settings,
             &mut providers,
             &mut provider_names,
+            "sitemap",
             "Sitemap".to_string(),
             SitemapProvider::new,
         );
@@ -325,6 +329,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             network_settings,
             &mut providers,
             &mut provider_names,
+            "otx",
             "OTX".to_string(),
             OTXProvider::new,
         );
@@ -337,6 +342,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 network_settings,
                 &mut providers,
                 &mut provider_names,
+                "vt",
                 "VirusTotal".to_string(),
                 || VirusTotalProvider::new_with_keys(vt_api_keys.clone()),
             );
@@ -352,6 +358,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 network_settings,
                 &mut providers,
                 &mut provider_names,
+                "urlscan",
                 "Urlscan".to_string(),
                 || UrlscanProvider::new_with_keys(urlscan_api_keys.clone()),
             );
@@ -367,6 +374,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                 network_settings,
                 &mut providers,
                 &mut provider_names,
+                "zoomeye",
                 "ZoomEye".to_string(),
                 || ZoomEyeProvider::new_with_keys(zoomeye_api_keys.clone()),
             );
@@ -779,8 +787,26 @@ async fn main() -> Result<()> {
 
     // Load configuration and apply it to args
     // This ensures command line options take precedence over config file
+    // Capture whether the user provided API keys directly via CLI/env *before*
+    // either config layer fills them in — this drives the precedence rule
+    // CLI/env > provider-config > main config.
+    let cli_supplied_vt = !args.vt_api_key.is_empty();
+    let cli_supplied_urlscan = !args.urlscan_api_key.is_empty();
+    let cli_supplied_zoomeye = !args.zoomeye_api_key.is_empty();
+
     let config = Config::load(&args);
     config.apply_to_args(&mut args);
+
+    // Provider-config file (separate from main config) loads API keys that
+    // would otherwise live in the shared config. It overrides main-config
+    // values but still loses to anything supplied on the CLI / env.
+    let provider_keys = config::ProviderKeysConfig::load(&args);
+    provider_keys.apply_to_args(
+        &mut args,
+        cli_supplied_vt,
+        cli_supplied_urlscan,
+        cli_supplied_zoomeye,
+    );
 
     // Create common network settings and progress manager once
     let network_settings = NetworkSettings::from_args(&args);
@@ -1349,6 +1375,8 @@ mod tests {
             stats: false,
             domain_list: vec![],
             max_time: 0,
+            rate_limit_by: vec![],
+            provider_config: None,
         };
 
         let progress_manager = ProgressManager::new(true);
@@ -1499,6 +1527,8 @@ mod tests {
             stats: false,
             domain_list: vec![],
             max_time: 0,
+            rate_limit_by: vec![],
+            provider_config: None,
         }
     }
 
@@ -1577,6 +1607,8 @@ mod tests {
             stats: false,
             domain_list: vec![],
             max_time: 0,
+            rate_limit_by: vec![],
+            provider_config: None,
         };
 
         let progress_manager = ProgressManager::new(true);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -88,38 +88,53 @@ pub fn add_provider<T: Provider + 'static>(
     network_settings: &NetworkSettings,
     providers: &mut Vec<Box<dyn Provider>>,
     provider_names: &mut Vec<String>,
+    provider_id: &str,
     provider_name: String,
     provider_builder: impl FnOnce() -> T,
 ) {
+    // Apply a per-provider rate limit override when --rate-limit-by lists this
+    // provider id. Cloning lets us thread the override into the existing
+    // apply_network_settings_to_provider helper without changing its API.
+    let per_provider_rate = args.rate_limit_overrides().get(provider_id).copied();
+    let mut effective_settings = network_settings.clone();
+    if per_provider_rate.is_some() {
+        effective_settings.rate_limit = per_provider_rate;
+    }
+
     if args.verbose && !args.silent {
         let mut config_info = vec![
             format!("Adding {provider_name} provider"),
-            format!("  Timeout: {} seconds", network_settings.timeout),
-            format!("  Retries: {}", network_settings.retries),
-            format!("  Parallel requests: {}", network_settings.parallel),
+            format!("  Timeout: {} seconds", effective_settings.timeout),
+            format!("  Retries: {}", effective_settings.retries),
+            format!("  Parallel requests: {}", effective_settings.parallel),
         ];
 
-        if network_settings.include_subdomains {
+        if effective_settings.include_subdomains {
             config_info.push("  Subdomain inclusion: enabled".to_string());
         }
 
-        if let Some(proxy) = &network_settings.proxy {
+        if let Some(proxy) = &effective_settings.proxy {
             config_info.push(format!("  Proxy: {}", proxy));
         }
 
-        if network_settings.random_agent {
+        if effective_settings.random_agent {
             config_info.push("  Random User-Agent: enabled".to_string());
         }
 
-        if let Some(rate) = network_settings.rate_limit {
-            config_info.push(format!("  Rate limit: {} requests/second", rate));
+        if let Some(rate) = effective_settings.rate_limit {
+            let label = if per_provider_rate.is_some() {
+                " (per-provider override)"
+            } else {
+                ""
+            };
+            config_info.push(format!("  Rate limit: {rate} requests/second{label}"));
         }
 
         println!("{}", config_info.join("\n"));
     }
 
     let mut provider = provider_builder();
-    apply_network_settings_to_provider(&mut provider, network_settings);
+    apply_network_settings_to_provider(&mut provider, &effective_settings);
     providers.push(Box::new(provider));
     provider_names.push(provider_name);
 }


### PR DESCRIPTION
## Summary
PR-C from the subfinder-parity plan. Two related controls for power users:

- **`--rate-limit-by`** — comma-separated `id=req_per_sec` pairs that override the global rate per provider (e.g. `--rate-limit-by vt=1,wayback=10`). Providers not listed fall back to `--rate-limit`. Implemented by cloning `NetworkSettings` per call site inside `add_provider`, so the existing `apply_network_settings_to_provider` API didn't have to change.
- **`--provider-config FILE`** — a separate TOML that holds only API keys, so the main `config.toml` (filter rules, output formatting, etc.) can be checked into source control. Default path `$XDG_CONFIG_HOME/urx/provider-config.toml`. **Precedence: CLI/env > provider-config > main config.** Silently no-op when the file is absent — unlike main config, we do not auto-create it (avoids dropping an empty "credentials" file the user didn't ask for).

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 376 passed (6 new tests):
  - `rate_limit_overrides` parses valid entries
  - `rate_limit_overrides` skips malformed (`vt=oops`, empty key, negative)
  - `--provider-config` clap parsing
  - `ProviderKeysConfig::from_file` reads CSV string values
  - `apply_to_args` respects CLI-supplied flag (CLI wins)
  - `apply_to_args` splits comma-separated CSV when filling from file
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Smoke: `urx --rate-limit-by vt=1 --providers vt --vt-api-key x example.com --verbose` shows `Rate limit: 1 requests/second (per-provider override)`
- [ ] Smoke: drop a `provider-config.toml` with `vt_api_key = "k1"`, run `urx --all-providers example.com`, verify vt activates