### PR TITLE
feat(output): --output-dir for per-domain result files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `--max-time SECONDS` global ceiling on provider enumeration; on deadline urx aborts in-flight fetches and returns whatever URLs have been collected so far (0 = unlimited; default)
 - Add `--rate-limit-by id=req_per_sec,...` for per-provider rate limits; providers not listed fall back to global `--rate-limit`
 - Add `--provider-config FILE` for a separate API-keys-only TOML (default `$XDG_CONFIG_HOME/urx/provider-config.toml`); precedence is CLI/env > provider-config > main config, so the main config can be safely committed to source control
+- Add `--output-dir PATH` (alias `--oD`) to split results into one file per domain (`<host>.<ext>`), with `<ext>` matching `--format`. Coexists with `--output` and stdout; the directory is created if missing; unparseable URLs land in `_unknown.<ext>`
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Input Options:
       --domain-list <PATH>      File of newline-separated domains to scan (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
 
 Output Options:
-  -o, --output <OUTPUT>  Output file to write results
-  -f, --format <FORMAT>  Output format (e.g., "plain", "json", "csv") [default: plain]
+  -o, --output <OUTPUT>          Output file to write results
+      --output-dir <PATH>        Write one file per domain into this directory (extension matches --format). Coexists with --output / stdout.
+  -f, --format <FORMAT>          Output format (e.g., "plain", "json", "csv") [default: plain]
       --merge-endpoint   Merge endpoints with the same path and merge URL parameters
       --normalize-url    Normalize URLs for better deduplication (sorts query parameters, removes trailing slashes)
 

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -24,8 +24,9 @@ Input Options:
       --domain-list <PATH>   File of newline-separated domains to scan (repeatable; merged with positional DOMAINS and stdin; `#` comments allowed)
 
 Output Options:
-  -o, --output <OUTPUT>  Output file to write results
-  -f, --format <FORMAT>  Output format (e.g., "plain", "json", "csv") [default: plain]
+  -o, --output <OUTPUT>          Output file to write results
+      --output-dir <PATH>        Write one file per domain into this directory; extension matches --format. Coexists with --output / stdout.
+  -f, --format <FORMAT>          Output format (e.g., "plain", "json", "csv") [default: plain]
       --merge-endpoint   Merge endpoints with the same path and merge URL parameters
       --normalize-url    Normalize URLs for better deduplication
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,6 +36,19 @@ pub struct Args {
     #[clap(short, long, value_parser)]
     pub output: Option<PathBuf>,
 
+    /// Write one file per domain into this directory (e.g. `example.com.json`).
+    /// Coexists with --output (which still writes the aggregated file) and
+    /// stdout. The directory is created if missing. The extension matches
+    /// --format (`json`, `csv`, or `txt` for plain).
+    #[clap(help_heading = "Output Options")]
+    #[clap(
+        long = "output-dir",
+        alias = "oD",
+        visible_alias = "--oD",
+        value_parser
+    )]
+    pub output_dir: Option<PathBuf>,
+
     /// Output format (e.g., "plain", "json", "csv")
     #[clap(help_heading = "Output Options")]
     #[clap(short, long, default_value = "plain")]
@@ -621,6 +634,15 @@ mod tests {
         // "wayback=-1" -> non-positive, dropped
         assert_eq!(map.len(), 1);
         assert_eq!(map.get("nokey"), Some(&1.0));
+    }
+
+    #[test]
+    fn test_output_dir_flag_parsed() {
+        let args = Args::parse_from(["urx", "--output-dir", "out/", "example.com"]);
+        assert_eq!(
+            args.output_dir.as_deref().map(|p| p.to_str().unwrap()),
+            Some("out/")
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -708,6 +708,7 @@ mod tests {
             max_time: 0,
             rate_limit_by: vec![],
             provider_config: None,
+            output_dir: None,
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -967,10 +967,65 @@ async fn main() -> Result<()> {
         }
     }
 
+    if let Some(dir) = args.output_dir.clone() {
+        if let Err(e) = write_per_domain_output(&final_urls, &dir, &args.format, args.silent) {
+            if !args.silent {
+                eprintln!("Error writing per-domain output to {}: {e}", dir.display());
+            }
+        } else if args.verbose && !args.silent {
+            println!("Per-domain results written under: {}", dir.display());
+        }
+    }
+
     if args.stats && !args.silent {
         print_provider_stats(&run_result.stats);
     }
 
+    Ok(())
+}
+
+/// Best-effort filename extension matching `--format`. Anything other than
+/// json/csv falls back to `.txt`, mirroring how `create_outputter` treats
+/// unknown formats as plain text.
+fn output_dir_extension(format: &str) -> &'static str {
+    match format.to_lowercase().as_str() {
+        "json" => "json",
+        "csv" => "csv",
+        _ => "txt",
+    }
+}
+
+/// Group URLs by their host and write one file per domain into `dir`.
+/// URLs that fail to parse a host (rare after filtering) land in
+/// `_unknown.<ext>` so nothing is silently dropped.
+fn write_per_domain_output(
+    urls: &[output::UrlData],
+    dir: &std::path::Path,
+    format: &str,
+    silent: bool,
+) -> anyhow::Result<()> {
+    if !dir.exists() {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    let mut grouped: std::collections::BTreeMap<String, Vec<output::UrlData>> =
+        std::collections::BTreeMap::new();
+    for entry in urls {
+        let host = url::Url::parse(&entry.url)
+            .ok()
+            .and_then(|u| u.host_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "_unknown".to_string());
+        grouped.entry(host).or_default().push(entry.clone());
+    }
+
+    let outputter = output::create_outputter(format);
+    let ext = output_dir_extension(format);
+
+    for (host, entries) in &grouped {
+        let file_name = format!("{host}.{ext}");
+        let path = dir.join(file_name);
+        outputter.output(entries, Some(path), silent)?;
+    }
     Ok(())
 }
 
@@ -1377,6 +1432,7 @@ mod tests {
             max_time: 0,
             rate_limit_by: vec![],
             provider_config: None,
+            output_dir: None,
         };
 
         let progress_manager = ProgressManager::new(true);
@@ -1445,6 +1501,55 @@ mod tests {
             "expected no URLs, got {:?}",
             result.urls
         );
+    }
+
+    #[test]
+    fn test_output_dir_extension() {
+        assert_eq!(output_dir_extension("json"), "json");
+        assert_eq!(output_dir_extension("JSON"), "json");
+        assert_eq!(output_dir_extension("csv"), "csv");
+        assert_eq!(output_dir_extension("plain"), "txt");
+        assert_eq!(output_dir_extension("anything-else"), "txt");
+    }
+
+    #[test]
+    fn test_write_per_domain_output_groups_by_host() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let urls = vec![
+            output::UrlData::new("https://example.com/a".to_string()),
+            output::UrlData::new("https://example.com/b".to_string()),
+            output::UrlData::new("https://other.test/x".to_string()),
+            output::UrlData::new("not-a-url".to_string()),
+        ];
+
+        write_per_domain_output(&urls, dir.path(), "plain", true)?;
+
+        let example = std::fs::read_to_string(dir.path().join("example.com.txt"))?;
+        assert!(example.contains("https://example.com/a"));
+        assert!(example.contains("https://example.com/b"));
+
+        let other = std::fs::read_to_string(dir.path().join("other.test.txt"))?;
+        assert!(other.contains("https://other.test/x"));
+
+        // Unparseable URLs land in _unknown.txt instead of being dropped.
+        let unknown = std::fs::read_to_string(dir.path().join("_unknown.txt"))?;
+        assert!(unknown.contains("not-a-url"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_per_domain_output_creates_missing_dir() -> anyhow::Result<()> {
+        let base = tempfile::tempdir()?;
+        let nested = base.path().join("nested/output/dir");
+        let urls = vec![output::UrlData::new("https://example.com/a".to_string())];
+
+        write_per_domain_output(&urls, &nested, "json", true)?;
+
+        assert!(nested.is_dir());
+        let example = std::fs::read_to_string(nested.join("example.com.json"))?;
+        assert!(example.starts_with('['));
+        assert!(example.contains("https://example.com/a"));
+        Ok(())
     }
 
     #[test]
@@ -1529,6 +1634,7 @@ mod tests {
             max_time: 0,
             rate_limit_by: vec![],
             provider_config: None,
+            output_dir: None,
         }
     }
 
@@ -1609,6 +1715,7 @@ mod tests {
             max_time: 0,
             rate_limit_by: vec![],
             provider_config: None,
+            output_dir: None,
         };
 
         let progress_manager = ProgressManager::new(true);


### PR DESCRIPTION
## Summary
PR-D from the subfinder-parity backlog. Adds `--output-dir PATH` (visible alias `--oD`) for batch runs that want one result file per domain rather than one combined blob.

- Filename convention: `<host>.<ext>`, where `<ext>` is `json` / `csv` / `txt` based on `--format`.
- Coexists with `--output` and stdout — both keep working. So a batch run can write `out/example.com.json` *and* a combined `all.json` *and* still pipe to a downstream tool.
- The target directory is created (recursively) if it doesn't exist.
- URLs whose host doesn't parse land in `_unknown.<ext>` so nothing is silently dropped.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 380 passed (4 new tests):
  - `output_dir_extension` mapping (`json` / `csv` / plain → `txt`)
  - `write_per_domain_output` groups two example.com URLs into one file and isolates `other.test`; unparseable lands in `_unknown.txt`
  - `write_per_domain_output` creates a missing nested directory and JSON output starts with `[`
  - `--output-dir` clap parsing
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Smoke: `urx example.com rust-lang.org --output-dir /tmp/urx-out --format json` produces `example.com.json` and `rust-lang.org.json`