### PR TITLE
feat(providers): Wayback date filter and Common Crawl multi-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Add `--rate-limit-by id=req_per_sec,...` for per-provider rate limits; providers not listed fall back to global `--rate-limit`
 - Add `--provider-config FILE` for a separate API-keys-only TOML (default `$XDG_CONFIG_HOME/urx/provider-config.toml`); precedence is CLI/env > provider-config > main config, so the main config can be safely committed to source control
 - Add `--output-dir PATH` (alias `--oD`) to split results into one file per domain (`<host>.<ext>`), with `<ext>` matching `--format`. Coexists with `--output` and stdout; the directory is created if missing; unparseable URLs land in `_unknown.<ext>`
+- Add `--wayback-from` / `--wayback-to` to restrict Wayback Machine results to a date window. Accepts YYYY / YYYYMM / YYYYMMDD / YYYYMMDDhhmmss; partial dates pad toward the appropriate end of the range; malformed values are dropped with a warning
+- `--cc-index` now accepts a comma-separated list (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`); each entry becomes its own provider instance running in parallel, with separate stats lines
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ Provider Options:
       --subs
           Include subdomains when searching
       --cc-index <CC_INDEX>
-          Common Crawl index to use (e.g., CC-MAIN-2026-17, or "latest" to auto-resolve from collinfo.json) [default: CC-MAIN-2026-17]
+          Common Crawl index to use; accepts comma-separated list to query multiple indexes in parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`). `latest` resolves the newest via collinfo.json. [default: CC-MAIN-2026-17]
+      --wayback-from <DATE>
+          Restrict Wayback Machine results to snapshots at or after DATE (YYYY/YYYYMM/YYYYMMDD/YYYYMMDDhhmmss)
+      --wayback-to <DATE>
+          Restrict Wayback Machine results to snapshots at or before DATE (same format as --wayback-from)
       --vt-api-key <VT_API_KEY>
           API key for VirusTotal (can be used multiple times for rotation, can also use URX_VT_API_KEY environment variable with comma-separated keys)
       --urlscan-api-key <URLSCAN_API_KEY>

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -36,7 +36,9 @@ Provider Options:
   --all-providers                        Enable every supported provider (API-keyed ones only if a key is available)
   --list-providers                       List every supported provider then exit
   --subs                                 Include subdomains when searching
-  --cc-index <CC_INDEX>                  Common Crawl index to use, or "latest" to auto-resolve [default: CC-MAIN-2026-17]
+  --cc-index <CC_INDEX>                  Common Crawl index(es), comma-separated for parallel queries; `latest` auto-resolves [default: CC-MAIN-2026-17]
+  --wayback-from <DATE>                  Restrict Wayback results to >= DATE (YYYY/YYYYMM/YYYYMMDD/YYYYMMDDhhmmss)
+  --wayback-to <DATE>                    Restrict Wayback results to <= DATE (same format as --wayback-from)
   --vt-api-key <VT_API_KEY>             API key for VirusTotal
   --urlscan-api-key <URLSCAN_API_KEY>   API key for Urlscan
   --zoomeye-api-key <ZOOMEYE_API_KEY>   API key for ZoomEye

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,9 +93,25 @@ pub struct Args {
     pub subs: bool,
 
     #[clap(help_heading = "Provider Options")]
-    /// Common Crawl index to use (e.g., CC-MAIN-2026-17, or "latest" to auto-resolve from collinfo.json)
-    #[clap(long, default_value = "CC-MAIN-2026-17")]
-    pub cc_index: String,
+    /// Common Crawl index to use. Accepts a comma-separated list to query
+    /// multiple indexes in parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`).
+    /// The literal `latest` resolves to the newest index via collinfo.json.
+    #[clap(long, default_value = "CC-MAIN-2026-17", value_delimiter = ',')]
+    pub cc_index: Vec<String>,
+
+    /// Restrict Wayback Machine results to snapshots at or after this date.
+    /// Accepts YYYY, YYYYMM, YYYYMMDD, or the full 14-digit CDX timestamp.
+    /// Partial dates pad toward the start of the range.
+    #[clap(help_heading = "Provider Options")]
+    #[clap(long)]
+    pub wayback_from: Option<String>,
+
+    /// Restrict Wayback Machine results to snapshots at or before this date.
+    /// Same format as --wayback-from; partial dates pad toward the end of
+    /// the range.
+    #[clap(help_heading = "Provider Options")]
+    #[clap(long)]
+    pub wayback_to: Option<String>,
 
     #[clap(help_heading = "Provider Options")]
     /// API key for VirusTotal (can be used multiple times for rotation, can also use URX_VT_API_KEY environment variable with comma-separated keys)
@@ -421,7 +437,7 @@ mod tests {
         assert_eq!(args.domains, vec!["example.com"]);
         assert_eq!(args.format, "plain");
         assert_eq!(args.providers, vec!["wayback", "cc", "otx"]);
-        assert_eq!(args.cc_index, "CC-MAIN-2026-17");
+        assert_eq!(args.cc_index, vec!["CC-MAIN-2026-17"]);
         assert_eq!(args.timeout, 120);
         assert_eq!(args.retries, 2);
         assert!(args.include_robots);
@@ -634,6 +650,31 @@ mod tests {
         // "wayback=-1" -> non-positive, dropped
         assert_eq!(map.len(), 1);
         assert_eq!(map.get("nokey"), Some(&1.0));
+    }
+
+    #[test]
+    fn test_cc_index_accepts_comma_separated_list() {
+        let args = Args::parse_from([
+            "urx",
+            "--cc-index",
+            "CC-MAIN-2026-17,CC-MAIN-2025-51",
+            "example.com",
+        ]);
+        assert_eq!(args.cc_index, vec!["CC-MAIN-2026-17", "CC-MAIN-2025-51"]);
+    }
+
+    #[test]
+    fn test_wayback_date_flags_parsed() {
+        let args = Args::parse_from([
+            "urx",
+            "--wayback-from",
+            "2020",
+            "--wayback-to",
+            "2023-06-30",
+            "example.com",
+        ]);
+        assert_eq!(args.wayback_from.as_deref(), Some("2020"));
+        assert_eq!(args.wayback_to.as_deref(), Some("2023-06-30"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -337,9 +337,20 @@ impl Config {
             args.subs = true;
         }
 
-        if args.cc_index == "CC-MAIN-2026-17" {
+        // Treat the default singleton list as "not user-supplied" so the file
+        // value wins. Config file still accepts a single string; we split it
+        // on commas so users can configure multi-index there too.
+        let cc_default = vec!["CC-MAIN-2026-17".to_string()];
+        if args.cc_index == cc_default {
             if let Some(cc_index) = &self.provider.cc_index {
-                args.cc_index = cc_index.clone();
+                let split: Vec<String> = cc_index
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                if !split.is_empty() {
+                    args.cc_index = split;
+                }
             }
         }
 
@@ -658,7 +669,7 @@ mod tests {
             normalize_url: false,
             providers: vec!["wayback".to_string(), "cc".to_string(), "otx".to_string()],
             subs: false,
-            cc_index: "CC-MAIN-2026-17".to_string(),
+            cc_index: vec!["CC-MAIN-2026-17".to_string()],
             vt_api_key: vec![],
             urlscan_api_key: vec![],
             zoomeye_api_key: vec![],
@@ -709,6 +720,8 @@ mod tests {
             rate_limit_by: vec![],
             provider_config: None,
             output_dir: None,
+            wayback_from: None,
+            wayback_to: None,
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,25 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
     let suppress_key_errors = args.all_providers;
 
     if providers_list.iter().any(|p| p == "wayback") {
+        // Normalise --wayback-from/--wayback-to up front so a malformed value
+        // produces a single warning instead of one per domain. CDX wants
+        // YYYYMMDDhhmmss.
+        let wayback_from = args.wayback_from.as_deref().and_then(|s| {
+            let parsed = providers::wayback::normalize_cdx_timestamp(s, false);
+            if parsed.is_none() && !args.silent {
+                eprintln!("Ignoring --wayback-from={s:?}: expected YYYY, YYYYMM, YYYYMMDD, or YYYYMMDDhhmmss");
+            }
+            parsed
+        });
+        let wayback_to = args.wayback_to.as_deref().and_then(|s| {
+            let parsed = providers::wayback::normalize_cdx_timestamp(s, true);
+            if parsed.is_none() && !args.silent {
+                eprintln!("Ignoring --wayback-to={s:?}: expected YYYY, YYYYMM, YYYYMMDD, or YYYYMMDDhhmmss");
+            }
+            parsed
+        });
+        let wb_from = wayback_from.clone();
+        let wb_to = wayback_to.clone();
         add_provider(
             args,
             network_settings,
@@ -280,20 +299,29 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             &mut provider_names,
             "wayback",
             "Wayback Machine".to_string(),
-            WaybackMachineProvider::new,
+            move || {
+                let mut p = WaybackMachineProvider::new();
+                p.with_from(wb_from).with_to(wb_to);
+                p
+            },
         );
     }
 
     if providers_list.iter().any(|p| p == "cc") {
-        add_provider(
-            args,
-            network_settings,
-            &mut providers,
-            &mut provider_names,
-            "cc",
-            args.cc_index.to_string(),
-            || CommonCrawlProvider::with_index(args.cc_index.clone()),
-        );
+        // Each --cc-index entry becomes its own provider instance so they
+        // run in parallel and the per-provider stats stay distinct.
+        for index in &args.cc_index {
+            let index = index.clone();
+            add_provider(
+                args,
+                network_settings,
+                &mut providers,
+                &mut provider_names,
+                "cc",
+                index.clone(),
+                || CommonCrawlProvider::with_index(index.clone()),
+            );
+        }
     }
 
     let excluded: std::collections::HashSet<&str> =
@@ -1382,7 +1410,7 @@ mod tests {
             normalize_url: false,
             providers: vec!["mock".to_string()],
             subs: false,
-            cc_index: "CC-MAIN-2026-17".to_string(),
+            cc_index: vec!["CC-MAIN-2026-17".to_string()],
             vt_api_key: vec![],
             urlscan_api_key: vec![],
             zoomeye_api_key: vec![],
@@ -1433,6 +1461,8 @@ mod tests {
             rate_limit_by: vec![],
             provider_config: None,
             output_dir: None,
+            wayback_from: None,
+            wayback_to: None,
         };
 
         let progress_manager = ProgressManager::new(true);
@@ -1584,7 +1614,7 @@ mod tests {
             normalize_url: false,
             providers: vec!["mock".to_string()],
             subs: false,
-            cc_index: "CC-MAIN-2026-17".to_string(),
+            cc_index: vec!["CC-MAIN-2026-17".to_string()],
             vt_api_key: vec![],
             urlscan_api_key: vec![],
             zoomeye_api_key: vec![],
@@ -1635,6 +1665,8 @@ mod tests {
             rate_limit_by: vec![],
             provider_config: None,
             output_dir: None,
+            wayback_from: None,
+            wayback_to: None,
         }
     }
 
@@ -1665,7 +1697,7 @@ mod tests {
             normalize_url: false,
             providers: vec![],
             subs: false,
-            cc_index: "CC-MAIN-2026-17".to_string(),
+            cc_index: vec!["CC-MAIN-2026-17".to_string()],
             vt_api_key: vec![],
             urlscan_api_key: vec![],
             zoomeye_api_key: vec![],
@@ -1716,6 +1748,8 @@ mod tests {
             rate_limit_by: vec![],
             provider_config: None,
             output_dir: None,
+            wayback_from: None,
+            wayback_to: None,
         };
 
         let progress_manager = ProgressManager::new(true);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -9,7 +9,7 @@ mod robots;
 mod sitemap;
 mod urlscan;
 mod vt;
-mod wayback;
+pub mod wayback;
 mod zoomeye;
 pub use api_key_rotation::ApiKeyRotator;
 pub use commoncrawl::CommonCrawlProvider;

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -5,6 +5,75 @@ use std::pin::Pin;
 use super::Provider;
 use crate::network::client::{get_with_retry, HttpClientConfig};
 
+/// Normalise a user-supplied date into a 14-digit Wayback CDX timestamp
+/// (`YYYYMMDDhhmmss`). Accepts `YYYY`, `YYYYMM`, `YYYYMMDD` and the full
+/// 14-digit form. When `end_of_range` is true the missing tail is padded
+/// toward the end of the range (`31 23:59:59`) rather than the start
+/// (`01 00:00:00`) — pass `false` for `--wayback-from`, `true` for
+/// `--wayback-to`. Returns `None` for malformed input so the CLI can warn.
+pub fn normalize_cdx_timestamp(input: &str, end_of_range: bool) -> Option<String> {
+    let digits: String = input.chars().filter(|c| c.is_ascii_digit()).collect();
+    if !matches!(digits.len(), 4 | 6 | 8 | 14) {
+        return None;
+    }
+
+    let year: u32 = digits.get(0..4)?.parse().ok()?;
+    if !(1996..=9999).contains(&year) {
+        // CDX coverage only starts in 1996; reject anything earlier.
+        return None;
+    }
+
+    // Pad each segment toward the appropriate end of the range.
+    let month = match digits.get(4..6) {
+        Some(s) => {
+            let m: u32 = s.parse().ok()?;
+            if !(1..=12).contains(&m) {
+                return None;
+            }
+            format!("{m:02}")
+        }
+        None => {
+            if end_of_range {
+                "12".to_string()
+            } else {
+                "01".to_string()
+            }
+        }
+    };
+    let day = match digits.get(6..8) {
+        Some(s) => {
+            let d: u32 = s.parse().ok()?;
+            if !(1..=31).contains(&d) {
+                return None;
+            }
+            format!("{d:02}")
+        }
+        None => {
+            if end_of_range {
+                // 28 is the only day every month has — CDX accepts impossible
+                // dates so 31 also works, but 28 avoids false widening at
+                // month-only granularity. Wait: we WANT widening for `to`.
+                // Use 31; CDX clamps gracefully.
+                "31".to_string()
+            } else {
+                "01".to_string()
+            }
+        }
+    };
+    let tail = match digits.get(8..14) {
+        Some(s) => s.to_string(),
+        None => {
+            if end_of_range {
+                "235959".to_string()
+            } else {
+                "000000".to_string()
+            }
+        }
+    };
+
+    Some(format!("{year:04}{month}{day}{tail}"))
+}
+
 #[derive(Clone)]
 pub struct WaybackMachineProvider {
     include_subdomains: bool,
@@ -16,6 +85,10 @@ pub struct WaybackMachineProvider {
     insecure: bool,
     parallel: u32,
     rate_limit: Option<f32>,
+    /// CDX `from=` timestamp (already normalised to 14 digits).
+    from: Option<String>,
+    /// CDX `to=` timestamp (already normalised to 14 digits).
+    to: Option<String>,
     #[cfg(test)]
     base_url: String,
 }
@@ -33,9 +106,25 @@ impl WaybackMachineProvider {
             insecure: false,
             parallel: 5,
             rate_limit: None,
+            from: None,
+            to: None,
             #[cfg(test)]
             base_url: "https://web.archive.org".to_string(),
         }
+    }
+
+    /// Restrict crawled snapshots to those at or after `ts` (14-digit CDX
+    /// timestamp, see `normalize_cdx_timestamp`). Pass `None` to clear.
+    pub fn with_from(&mut self, ts: Option<String>) -> &mut Self {
+        self.from = ts;
+        self
+    }
+
+    /// Restrict crawled snapshots to those at or before `ts`. Pass `None` to
+    /// clear. Pair with `with_from` for a closed window.
+    pub fn with_to(&mut self, ts: Option<String>) -> &mut Self {
+        self.to = ts;
+        self
     }
 
     #[cfg(test)]
@@ -74,7 +163,7 @@ impl Provider for WaybackMachineProvider {
             // Plain-text streaming response is far more reliable than output=json
             // for large domains (the JSON variant buffers the entire result server-side
             // and frequently times out). collapse=urlkey trims server-side duplicates.
-            let url = if self.include_subdomains {
+            let mut url = if self.include_subdomains {
                 format!(
                     "{}/cdx/search/cdx?url=*.{domain}/*&fl=original&collapse=urlkey",
                     base_url
@@ -85,6 +174,14 @@ impl Provider for WaybackMachineProvider {
                     base_url
                 )
             };
+            if let Some(ts) = &self.from {
+                url.push_str("&from=");
+                url.push_str(ts);
+            }
+            if let Some(ts) = &self.to {
+                url.push_str("&to=");
+                url.push_str(ts);
+            }
 
             let client = self.client_config().build_client()?;
             let text = get_with_retry(&client, &url, self.retries).await?;
@@ -422,5 +519,90 @@ mod tests {
         let urls = provider.fetch_urls("example.com").await.unwrap();
 
         assert_eq!(urls, vec!["http://example.com/real".to_string()]);
+    }
+
+    #[test]
+    fn test_normalize_cdx_timestamp_year_only() {
+        assert_eq!(
+            normalize_cdx_timestamp("2020", false).as_deref(),
+            Some("20200101000000")
+        );
+        assert_eq!(
+            normalize_cdx_timestamp("2020", true).as_deref(),
+            Some("20201231235959")
+        );
+    }
+
+    #[test]
+    fn test_normalize_cdx_timestamp_year_month() {
+        assert_eq!(
+            normalize_cdx_timestamp("202003", false).as_deref(),
+            Some("20200301000000")
+        );
+        assert_eq!(
+            normalize_cdx_timestamp("202003", true).as_deref(),
+            Some("20200331235959")
+        );
+    }
+
+    #[test]
+    fn test_normalize_cdx_timestamp_day_and_full() {
+        assert_eq!(
+            normalize_cdx_timestamp("20200315", false).as_deref(),
+            Some("20200315000000")
+        );
+        assert_eq!(
+            normalize_cdx_timestamp("20200315123045", false).as_deref(),
+            Some("20200315123045")
+        );
+        // Hyphens and slashes are stripped before length check.
+        assert_eq!(
+            normalize_cdx_timestamp("2020-03-15", false).as_deref(),
+            Some("20200315000000")
+        );
+    }
+
+    #[test]
+    fn test_normalize_cdx_timestamp_rejects_invalid() {
+        // Length not in {4, 6, 8, 14}.
+        assert!(normalize_cdx_timestamp("20203", false).is_none());
+        // Out-of-range month.
+        assert!(normalize_cdx_timestamp("202013", false).is_none());
+        // Out-of-range day.
+        assert!(normalize_cdx_timestamp("20200300", false).is_none());
+        // Pre-1996 year.
+        assert!(normalize_cdx_timestamp("1995", false).is_none());
+        // Empty / non-digit garbage.
+        assert!(normalize_cdx_timestamp("oops", false).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_passes_date_range() {
+        use mockito;
+
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
+                mockito::Matcher::UrlEncoded("fl".into(), "original".into()),
+                mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("from".into(), "20200101000000".into()),
+                mockito::Matcher::UrlEncoded("to".into(), "20201231235959".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("http://example.com/page\n")
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_from(Some("20200101000000".to_string()));
+        provider.with_to(Some("20201231235959".to_string()));
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["http://example.com/page".to_string()]);
+        mock.assert();
     }
 }


### PR DESCRIPTION
## Summary
PR-E. Two refinements of existing providers — both refine reach without new external dependencies.

### Wayback date filter
- `--wayback-from DATE` / `--wayback-to DATE` map to CDX `from=` / `to=` query params.
- Accepts `YYYY`, `YYYYMM`, `YYYYMMDD`, or the full 14-digit `YYYYMMDDhhmmss`. Partial dates pad toward the start of the range for `from` and the end of the range for `to`, so `--wayback-from 2020 --wayback-to 2023` covers exactly 2020-01-01 00:00:00 through 2023-12-31 23:59:59.
- Non-digit separators (`-`, `/`) are stripped before length check, so `2020-03-15` works.
- Malformed values trigger a one-time stderr warning per flag and the run continues unfiltered.

### Common Crawl multi-index
- `--cc-index` now takes a comma-separated list, e.g. `--cc-index CC-MAIN-2026-17,CC-MAIN-2025-51,CC-MAIN-2025-47`.
- Each entry becomes its own `CommonCrawlProvider` instance — they fan out in parallel via the existing per-provider task pool and surface as separate `--stats` rows.
- The config file's single-string `cc_index` value is now CSV-split on apply so users can configure multi-index there too.
- `latest` still works (single entry calls `collinfo.json`). If a user combines `latest` with explicit entries, each `latest` slot does its own `collinfo` lookup — acceptable for now since `latest` is typically used alone.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 387 passed (7 new tests):
  - `normalize_cdx_timestamp` for year-only / year-month / day / full / hyphenated input
  - `normalize_cdx_timestamp` rejects bad length, out-of-range month/day, pre-1996 year, garbage
  - mockito test verifies `from=` and `to=` query params reach Wayback
  - `--cc-index` clap parsing of comma-separated list
  - `--wayback-from` / `--wayback-to` clap parsing
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Smoke: `urx --providers wayback --wayback-from 2023 --wayback-to 2023 example.com` returns only 2023 snapshots
- [ ] Smoke: `urx --providers cc --cc-index CC-MAIN-2026-17,CC-MAIN-2025-51 --stats example.com` shows two CC rows