### PR TITLE
feat(providers): GitHub Code Search source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `--output-dir PATH` (alias `--oD`) to split results into one file per domain (`<host>.<ext>`), with `<ext>` matching `--format`. Coexists with `--output` and stdout; the directory is created if missing; unparseable URLs land in `_unknown.<ext>`
 - Add `--wayback-from` / `--wayback-to` to restrict Wayback Machine results to a date window. Accepts YYYY / YYYYMM / YYYYMMDD / YYYYMMDDhhmmss; partial dates pad toward the appropriate end of the range; malformed values are dropped with a warning
 - `--cc-index` now accepts a comma-separated list (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`); each entry becomes its own provider instance running in parallel, with separate stats lines
+- Add `github` provider for GitHub Code Search. Enabled via `--github-api-key` (or `URX_GITHUB_API_KEY`, comma-separated for rotation). Pulls URLs out of `text_matches` fragments and requires an exact host or subdomain match before keeping a URL
 
 ## 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Provider Options:
           API key for VirusTotal (can be used multiple times for rotation, can also use URX_VT_API_KEY environment variable with comma-separated keys)
       --urlscan-api-key <URLSCAN_API_KEY>
           API key for Urlscan (can be used multiple times for rotation, can also use URX_URLSCAN_API_KEY environment variable with comma-separated keys)
+      --github-api-key <GITHUB_API_KEY>
+          Personal access token for the GitHub Code Search provider (also reads URX_GITHUB_API_KEY, comma-separated for rotation)
 
 Discovery Options:
       --exclude-robots   Exclude robots.txt discovery

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -42,6 +42,7 @@ Provider Options:
   --vt-api-key <VT_API_KEY>             API key for VirusTotal
   --urlscan-api-key <URLSCAN_API_KEY>   API key for Urlscan
   --zoomeye-api-key <ZOOMEYE_API_KEY>   API key for ZoomEye
+  --github-api-key <GITHUB_API_KEY>     Personal access token for GitHub Code Search (URX_GITHUB_API_KEY)
 
 Discovery Options:
   --exclude-robots   Exclude robots.txt discovery

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -128,6 +128,12 @@ pub struct Args {
     #[clap(long, action = clap::ArgAction::Append)]
     pub zoomeye_api_key: Vec<String>,
 
+    #[clap(help_heading = "Provider Options")]
+    /// Personal access token for GitHub Code Search (also reads URX_GITHUB_API_KEY,
+    /// comma-separated for rotation). Required for the `github` provider.
+    #[clap(long, action = clap::ArgAction::Append)]
+    pub github_api_key: Vec<String>,
+
     /// Include robots.txt discovery (default: true)
     #[clap(long, default_value = "true", hide = true)]
     pub include_robots: bool,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -722,6 +722,7 @@ mod tests {
             output_dir: None,
             wayback_from: None,
             wayback_to: None,
+            github_api_key: vec![],
         };
         assert_eq!(args.output, None);
         assert_eq!(args.format, "plain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use network::NetworkSettings;
 use output::create_outputter;
 use progress::ProgressManager;
 use providers::{
-    CommonCrawlProvider, OTXProvider, Provider, RobotsProvider, SitemapProvider, UrlscanProvider,
-    VirusTotalProvider, WaybackMachineProvider, ZoomEyeProvider,
+    CommonCrawlProvider, GitHubProvider, OTXProvider, Provider, RobotsProvider, SitemapProvider,
+    UrlscanProvider, VirusTotalProvider, WaybackMachineProvider, ZoomEyeProvider,
 };
 use readers::read_urls_from_file;
 use runner::{add_provider, process_domains, ProviderRunResult};
@@ -88,6 +88,12 @@ fn provider_catalog() -> &'static [ProviderInfo] {
             display_name: "ZoomEye",
             requires_key: true,
             summary: "ZoomEye search (URX_ZOOMEYE_API_KEY)",
+        },
+        ProviderInfo {
+            id: "github",
+            display_name: "GitHub",
+            requires_key: true,
+            summary: "GitHub Code Search (URX_GITHUB_API_KEY)",
         },
         ProviderInfo {
             id: "robots",
@@ -202,10 +208,11 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
     let mut providers: Vec<Box<dyn Provider>> = Vec::new();
     let mut provider_names: Vec<String> = Vec::new();
 
-    // Get VirusTotal and Urlscan API keys (from CLI and env vars)
+    // Get API keys (from CLI and env vars)
     let vt_api_keys = parse_api_keys(args.vt_api_key.clone(), "URX_VT_API_KEY");
     let urlscan_api_keys = parse_api_keys(args.urlscan_api_key.clone(), "URX_URLSCAN_API_KEY");
     let zoomeye_api_keys = parse_api_keys(args.zoomeye_api_key.clone(), "URX_ZOOMEYE_API_KEY");
+    let github_api_keys = parse_api_keys(args.github_api_key.clone(), "URX_GITHUB_API_KEY");
 
     // Build the effective providers list. `--all-providers` expands to every
     // catalog entry whose required key (if any) is available; otherwise we
@@ -222,6 +229,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
                     "vt" => !vt_api_keys.is_empty(),
                     "urlscan" => !urlscan_api_keys.is_empty(),
                     "zoomeye" => !zoomeye_api_keys.is_empty(),
+                    "github" => !github_api_keys.is_empty(),
                     _ => false,
                 }
             })
@@ -256,6 +264,13 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             &mut providers_list,
             &zoomeye_api_keys,
             "zoomeye",
+            args.verbose,
+            args.silent,
+        );
+        auto_enable_provider(
+            &mut providers_list,
+            &github_api_keys,
+            "github",
             args.verbose,
             args.silent,
         );
@@ -408,6 +423,22 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
             );
         } else if !args.silent && !suppress_key_errors {
             eprintln!("Error: The ZoomEye provider (zoomeye) requires an API key. Please use --zoomeye-api-key or set the URX_ZOOMEYE_API_KEY environment variable.");
+        }
+    }
+
+    if providers_list.iter().any(|p| p == "github") {
+        if !github_api_keys.is_empty() {
+            add_provider(
+                args,
+                network_settings,
+                &mut providers,
+                &mut provider_names,
+                "github",
+                "GitHub".to_string(),
+                || GitHubProvider::new_with_keys(github_api_keys.clone()),
+            );
+        } else if !args.silent && !suppress_key_errors {
+            eprintln!("Error: The GitHub provider (github) requires an API key. Please use --github-api-key or set the URX_GITHUB_API_KEY environment variable.");
         }
     }
 
@@ -1463,6 +1494,7 @@ mod tests {
             output_dir: None,
             wayback_from: None,
             wayback_to: None,
+            github_api_key: vec![],
         };
 
         let progress_manager = ProgressManager::new(true);
@@ -1667,6 +1699,7 @@ mod tests {
             output_dir: None,
             wayback_from: None,
             wayback_to: None,
+            github_api_key: vec![],
         }
     }
 
@@ -1750,6 +1783,7 @@ mod tests {
             output_dir: None,
             wayback_from: None,
             wayback_to: None,
+            github_api_key: vec![],
         };
 
         let progress_manager = ProgressManager::new(true);

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -1,0 +1,413 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::ApiKeyRotator;
+use super::Provider;
+use crate::network::client::HttpClientConfig;
+
+/// Maximum search-result pages we fetch per domain. GitHub Code Search caps
+/// at 1000 results total (10 × 100), and each page costs against a tight
+/// rate limit, so we stop early by default.
+const MAX_PAGES: u32 = 3;
+const PER_PAGE: u32 = 100;
+
+#[derive(Clone)]
+pub struct GitHubProvider {
+    api_key_rotator: ApiKeyRotator,
+    include_subdomains: bool,
+    proxy: Option<String>,
+    proxy_auth: Option<String>,
+    timeout: u64,
+    retries: u32,
+    random_agent: bool,
+    insecure: bool,
+    parallel: u32,
+    rate_limit: Option<f32>,
+    #[cfg(test)]
+    base_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchItem {
+    #[serde(default)]
+    text_matches: Vec<TextMatch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TextMatch {
+    #[serde(default)]
+    fragment: String,
+}
+
+impl GitHubProvider {
+    #[allow(dead_code)]
+    pub fn new(api_key: String) -> Self {
+        if api_key.is_empty() {
+            Self::new_with_keys(vec![])
+        } else {
+            Self::new_with_keys(vec![api_key])
+        }
+    }
+
+    pub fn new_with_keys(api_keys: Vec<String>) -> Self {
+        let filtered: Vec<String> = api_keys.into_iter().filter(|k| !k.is_empty()).collect();
+        GitHubProvider {
+            api_key_rotator: ApiKeyRotator::new(filtered),
+            include_subdomains: false,
+            proxy: None,
+            proxy_auth: None,
+            timeout: 30,
+            retries: 3,
+            random_agent: false,
+            insecure: false,
+            parallel: 1,
+            rate_limit: None,
+            #[cfg(test)]
+            base_url: "https://api.github.com".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_url(&mut self, url: String) -> &mut Self {
+        self.base_url = url;
+        self
+    }
+
+    fn client_config(&self) -> HttpClientConfig {
+        HttpClientConfig {
+            timeout: self.timeout,
+            insecure: self.insecure,
+            random_agent: self.random_agent,
+            proxy: self.proxy.clone(),
+            proxy_auth: self.proxy_auth.clone(),
+        }
+    }
+}
+
+/// Extract URLs from a free-form text fragment that contain `domain`
+/// (or, when `include_subdomains` is true, any subdomain of it).
+/// The matched URL must end its host exactly at `domain` so we don't
+/// surface unrelated hosts like `notexample.com` for a search of `example.com`.
+pub(crate) fn extract_matching_urls(
+    fragment: &str,
+    domain: &str,
+    include_subdomains: bool,
+    sink: &mut HashSet<String>,
+) {
+    let domain = domain.to_ascii_lowercase();
+    for token in fragment.split(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == ',') {
+        let token = token.trim_end_matches(|c: char| {
+            matches!(c, '.' | ')' | ']' | '}' | '>' | ';' | ':' | '!' | '?' | '`')
+        });
+        let lower = token.to_ascii_lowercase();
+        if !lower.starts_with("http://") && !lower.starts_with("https://") {
+            continue;
+        }
+        let Ok(parsed) = url::Url::parse(token) else {
+            continue;
+        };
+        let Some(host) = parsed.host_str().map(|s| s.to_ascii_lowercase()) else {
+            continue;
+        };
+        let host_matches = if include_subdomains {
+            host == domain || host.ends_with(&format!(".{domain}"))
+        } else {
+            host == domain
+        };
+        if host_matches {
+            sink.insert(token.to_string());
+        }
+    }
+}
+
+impl Provider for GitHubProvider {
+    fn clone_box(&self) -> Box<dyn Provider> {
+        Box::new(self.clone())
+    }
+
+    fn fetch_urls<'a>(
+        &'a self,
+        domain: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        Box::pin(async move {
+            if !self.api_key_rotator.has_keys() {
+                return Ok(Vec::new());
+            }
+            let api_key = self
+                .api_key_rotator
+                .next_key()
+                .expect("Key rotator should have keys since has_keys() returned true");
+
+            let client = self.client_config().build_client()?;
+
+            #[cfg(not(test))]
+            let base = "https://api.github.com";
+            #[cfg(test)]
+            let base = self.base_url.as_str();
+
+            // Quoted phrase search keeps the result set tight to literal
+            // mentions of the domain rather than partial-token matches.
+            let q = format!("\"{domain}\"");
+            let encoded_q = url::form_urlencoded::byte_serialize(q.as_bytes()).collect::<String>();
+
+            let mut urls: HashSet<String> = HashSet::new();
+            let mut last_error: Option<anyhow::Error> = None;
+
+            'pages: for page in 1..=MAX_PAGES {
+                let url =
+                    format!("{base}/search/code?q={encoded_q}&per_page={PER_PAGE}&page={page}");
+
+                let mut attempt: u32 = 0;
+                loop {
+                    if attempt > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64))
+                            .await;
+                    }
+
+                    let resp = client
+                        .get(&url)
+                        .header("Authorization", format!("Bearer {api_key}"))
+                        .header("Accept", "application/vnd.github.v3.text-match+json")
+                        .header("X-GitHub-Api-Version", "2022-11-28")
+                        .send()
+                        .await;
+
+                    match resp {
+                        Ok(response) => {
+                            let status = response.status();
+                            if !status.is_success() {
+                                // 422 from search/code typically means we ran
+                                // past the result set — treat as natural end
+                                // rather than retrying.
+                                if status.as_u16() == 422 {
+                                    break 'pages;
+                                }
+                                last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
+                                attempt += 1;
+                                if attempt > self.retries {
+                                    break 'pages;
+                                }
+                                continue;
+                            }
+
+                            match response.json::<SearchResponse>().await {
+                                Ok(parsed) => {
+                                    let was_empty = parsed.items.is_empty();
+                                    for item in parsed.items {
+                                        for m in item.text_matches {
+                                            extract_matching_urls(
+                                                &m.fragment,
+                                                domain,
+                                                self.include_subdomains,
+                                                &mut urls,
+                                            );
+                                        }
+                                    }
+                                    if was_empty {
+                                        // No more results — stop paginating.
+                                        break 'pages;
+                                    }
+                                    break;
+                                }
+                                Err(e) => {
+                                    last_error = Some(anyhow::anyhow!(
+                                        "Failed to parse GitHub response: {e}"
+                                    ));
+                                    attempt += 1;
+                                    if attempt > self.retries {
+                                        break 'pages;
+                                    }
+                                    continue;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            last_error = Some(e.into());
+                            attempt += 1;
+                            if attempt > self.retries {
+                                break 'pages;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if urls.is_empty() {
+                if let Some(e) = last_error {
+                    return Err(e);
+                }
+            }
+
+            let mut out: Vec<String> = urls.into_iter().collect();
+            out.sort();
+            Ok(out)
+        })
+    }
+
+    fn with_subdomains(&mut self, include: bool) {
+        self.include_subdomains = include;
+    }
+    fn with_proxy(&mut self, proxy: Option<String>) {
+        self.proxy = proxy;
+    }
+    fn with_proxy_auth(&mut self, auth: Option<String>) {
+        self.proxy_auth = auth;
+    }
+    fn with_timeout(&mut self, seconds: u64) {
+        self.timeout = seconds;
+    }
+    fn with_retries(&mut self, count: u32) {
+        self.retries = count;
+    }
+    fn with_random_agent(&mut self, enabled: bool) {
+        self.random_agent = enabled;
+    }
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
+    }
+    fn with_parallel(&mut self, parallel: u32) {
+        self.parallel = parallel;
+    }
+    fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
+        self.rate_limit = rate_limit;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_urls_exact_host() {
+        let mut sink = HashSet::new();
+        extract_matching_urls(
+            "see https://example.com/login and https://other.test/x",
+            "example.com",
+            false,
+            &mut sink,
+        );
+        assert_eq!(sink.len(), 1);
+        assert!(sink.contains("https://example.com/login"));
+    }
+
+    #[test]
+    fn test_extract_urls_rejects_non_matching_suffix() {
+        // A naive substring check would catch this; the host-match logic
+        // must require exact equality (or a `.<domain>` suffix).
+        let mut sink = HashSet::new();
+        extract_matching_urls(
+            "https://notexample.com/path",
+            "example.com",
+            false,
+            &mut sink,
+        );
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn test_extract_urls_subdomains() {
+        let mut sink = HashSet::new();
+        extract_matching_urls(
+            "https://api.example.com/v1 https://example.com/root https://x.notexample.com",
+            "example.com",
+            true,
+            &mut sink,
+        );
+        assert!(sink.contains("https://api.example.com/v1"));
+        assert!(sink.contains("https://example.com/root"));
+        assert!(!sink.iter().any(|u| u.contains("notexample.com")));
+    }
+
+    #[test]
+    fn test_extract_urls_strips_trailing_punctuation() {
+        let mut sink = HashSet::new();
+        extract_matching_urls(
+            "visit https://example.com/path. Then check https://example.com/other),",
+            "example.com",
+            false,
+            &mut sink,
+        );
+        assert!(sink.contains("https://example.com/path"));
+        assert!(sink.contains("https://example.com/other"));
+    }
+
+    #[test]
+    fn test_new_provider_filters_empty_keys() {
+        let p = GitHubProvider::new_with_keys(vec!["".to_string(), "k1".to_string()]);
+        assert!(p.api_key_rotator.has_keys());
+        assert_eq!(p.api_key_rotator.key_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_returns_empty_without_keys() {
+        let p = GitHubProvider::new_with_keys(vec![]);
+        let urls = p.fetch_urls("example.com").await.unwrap();
+        assert!(urls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_with_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let body = serde_json::json!({
+            "items": [
+                {
+                    "text_matches": [
+                        { "fragment": "see https://example.com/login and https://api.example.com/v2" },
+                        { "fragment": "noise" }
+                    ]
+                }
+            ]
+        })
+        .to_string();
+        // Page 1 returns one item; page 2 returns no items → loop stops.
+        let _p1 = server
+            .mock("GET", "/search/code")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .expect(1)
+            .create_async()
+            .await;
+        let _p2 = server
+            .mock("GET", "/search/code")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "2".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"items": []}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = GitHubProvider::new_with_keys(vec!["test-token".into()]);
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["https://example.com/login".to_string()]);
+
+        // With subdomains enabled the api.example.com URL also surfaces.
+        provider.with_subdomains(true);
+        // Reset rotator key state isn't necessary; rotation tolerates re-fetch.
+        // Reuse page mocks — they each expect exactly 1 hit per provider run
+        // so we need fresh mocks for the second call: just confirm extraction
+        // logic from a fragment instead.
+        let mut sink = HashSet::new();
+        extract_matching_urls(
+            "see https://example.com/login and https://api.example.com/v2",
+            "example.com",
+            true,
+            &mut sink,
+        );
+        assert!(sink.contains("https://api.example.com/v2"));
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -4,6 +4,7 @@ use std::pin::Pin;
 
 mod api_key_rotation;
 mod commoncrawl;
+mod github;
 mod otx;
 mod robots;
 mod sitemap;
@@ -13,6 +14,7 @@ pub mod wayback;
 mod zoomeye;
 pub use api_key_rotation::ApiKeyRotator;
 pub use commoncrawl::CommonCrawlProvider;
+pub use github::GitHubProvider;
 pub use otx::OTXProvider;
 pub use robots::RobotsProvider;
 pub use sitemap::SitemapProvider;


### PR DESCRIPTION
## Summary
Adds a `github` provider that pulls URL candidates out of GitHub Code Search results — the same approach subfinder uses for subdomain discovery, adapted for URL harvesting.

### How it works
- Query: literal `\"<domain>\"` phrase search against `GET /search/code`.
- Auth: `--github-api-key` (or `URX_GITHUB_API_KEY`, comma-separated for rotation through the existing `ApiKeyRotator`).
- Pagination: 3 pages × 100 results max — GitHub Code Search has a tight rate limit, and a `422` from the API (past the result set) ends pagination cleanly.
- Extraction: each `text_matches.fragment` is tokenised, candidates are stripped of trailing punctuation (`.`, `)`, `,`, `;`, etc.), parsed via `url::Url`, and kept only when the parsed host equals the target domain — or, with `--subs`, ends with `.<domain>`. So `https://notexample.com/...` does not surface for a search of `example.com`.

### Integration
- Provider id `github` is in the catalog, so it shows up in `--list-providers`, gets auto-enabled when `--github-api-key` is set, expands under `--all-providers` only if a key is available, and can be turned off via `--exclude-providers github`. Per-provider rate limits via `--rate-limit-by github=2` also work.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 394 passed (7 new tests):
  - `extract_matching_urls` exact-host match (rejects `notexample.com` for `example.com`)
  - subdomain matching with `--subs`
  - trailing-punctuation stripping (`example.com/path.`, `example.com/path),`)
  - empty-keys filtering on construction
  - fetch returns empty without keys
  - mockito two-page fetch — page 1 returns results, page 2 is empty so the loop exits; only the exact-host URL is returned
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Smoke: `URX_GITHUB_API_KEY=ghp_… urx --providers github --show-sources example.com`
- [ ] Smoke: `urx --all-providers --stats example.com` shows a `GitHub` row when the env var is set