### PR TITLE
feat(aur): AUR packaging + lockstep version scripts (vc/vu)

### DIFF
--- a/.github/workflows/publish_aur.yml
+++ b/.github/workflows/publish_aur.yml
@@ -1,0 +1,55 @@
+---
+name: AUR Publish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.9.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+jobs:
+  publish-aur:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          # Manual dispatch reads the PKGBUILD from the default branch (latest
+          # recipe); the package source itself is fetched from the v$pkgver tag
+          # tarball at build time, so the recipe need not come from the tag.
+          # Auto runs (after Release) use the released ref.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.repository.default_branch }}
+
+      - name: Get Version
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="${{ github.event.inputs.version }}"
+          else
+            RAW_VERSION="${{ github.event.workflow_run.head_branch }}"
+          fi
+          VERSION="${RAW_VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Resolved version: $VERSION"
+
+      - name: Update PKGBUILD version
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${{ env.VERSION }}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          cat aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: urx
+          pkgbuild: aur/PKGBUILD
+          commit_username: hahwul
+          commit_email: hahwul@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: HAHWUL <hahwul@gmail.com>
+pkgname=urx
+pkgver=0.9.0
+pkgrel=1
+pkgdesc="Extracts URLs from OSINT Archives for Security Insights"
+arch=('x86_64' 'aarch64')
+url="https://github.com/hahwul/urx"
+license=('MIT')
+depends=('gcc-libs')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/hahwul/urx/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release
+}
+
+check() {
+    cd "$pkgname-$pkgver"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo test --frozen --release
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$pkgname"
+    install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE
+    install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+}

--- a/justfile
+++ b/justfile
@@ -1,20 +1,55 @@
+alias b := build
+alias d := dev
+alias ds := docs-serve
+alias t := test
+alias vc := version-check
+alias vu := version-update
+
+# List available tasks.
 default:
-    @echo "Listing available tasks..."
     @just --list
 
+# Build release binary.
+[group('build')]
+build:
+    cargo build --release
+
+# Build debug binary.
+[group('build')]
+dev:
+    cargo build
+
+# Serve docs site locally.
+[group('documents')]
+docs-serve:
+    hwaro serve -i docs --base-url="http://localhost:3000"
+
+# Install docs dependencies (macOS).
+[group('documents')]
+docs-dependencies:
+    brew install hahwul/hwaro/hwaro
+
+# Format and auto-fix lints.
+[group('development')]
+fix:
+    cargo fmt
+    cargo clippy --fix --allow-dirty
+
+# Report urx version across Cargo.toml, Cargo.lock, aur.
+[group('release')]
+version-check:
+    crystal run scripts/version_check.cr
+
+# Bump urx version in lockstep across all version-bearing files.
+[group('release')]
+version-update:
+    crystal run scripts/version_update.cr
+
+# Run tests, lints, format and doc checks.
+[group('test')]
 test:
     cargo test
     cargo clippy -- --deny warnings
     cargo clippy --tests -- --deny warnings
     cargo fmt --check
     cargo doc --workspace --all-features --no-deps --document-private-items
-
-fix:
-    cargo fmt
-    cargo clippy --fix --allow-dirty
-
-build:
-    cargo build --release
-
-dev:
-    cargo build

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -1,0 +1,63 @@
+# Reports the version string declared in each file urx keeps in lockstep
+# (Cargo.toml, Cargo.lock, aur/PKGBUILD).
+# Exits non-zero when they disagree so it can gate a release.
+
+CARGO_TOML   = "Cargo.toml"
+CARGO_LOCK   = "Cargo.lock"
+AUR_PKGBUILD = "aur/PKGBUILD"
+
+# Cargo.toml: top-level `version = "X"` inside [package].
+def cargo_toml_version : String?
+  content = File.read(CARGO_TOML)
+  pkg = content.match(/^\[package\][\s\S]*?(?=^\[|\z)/m)
+  return nil unless pkg
+  match = pkg[0].match(/^version\s*=\s*"([^"]+)"/m)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+# Cargo.lock: the `name = "urx"` entry's version line.
+def cargo_lock_version : String?
+  content = File.read(CARGO_LOCK)
+  match = content.match(/name\s*=\s*"urx"\s*\nversion\s*=\s*"([^"]+)"/)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+# aur/PKGBUILD: `pkgver=X`. AUR forbids hyphens in pkgver, so pre-release
+# versions are stored with `_` (e.g. 0.10.0_dev.1); normalize back to `-`
+# so it compares equal to the other files.
+def aur_version : String?
+  content = File.read(AUR_PKGBUILD)
+  match = content.match(/^pkgver=([^\s]+)/m)
+  match ? match[1].gsub('_', '-') : nil
+rescue
+  nil
+end
+
+cargo_v = cargo_toml_version
+lock_v  = cargo_lock_version
+aur_v   = aur_version
+
+puts "#{CARGO_TOML.ljust(22)} #{cargo_v || "Not found"}"
+puts "#{CARGO_LOCK.ljust(22)} #{lock_v || "Not found"}"
+puts "#{AUR_PKGBUILD.ljust(22)} #{aur_v || "Not found"}"
+puts
+
+versions = [cargo_v, lock_v, aur_v].compact
+
+if versions.empty?
+  puts "No versions found!"
+  exit 1
+end
+
+unique = versions.uniq
+
+if unique.size == 1
+  puts "All versions match: #{unique.first}"
+else
+  puts "Versions disagree: #{unique.join(", ")}"
+  exit 1
+end

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -1,0 +1,165 @@
+# Bumps the urx version across every file that hardcodes it
+# (Cargo.toml, Cargo.lock, aur/PKGBUILD).
+# Prompts for the new version interactively and prints a per-file checkmark.
+#
+# Pre-release suffixes are allowed (e.g. 0.10.0-dev.1, 0.10.0-rc.1).
+
+CARGO_TOML   = "Cargo.toml"
+CARGO_LOCK   = "Cargo.lock"
+AUR_PKGBUILD = "aur/PKGBUILD"
+
+# Read helpers (mirror version_check.cr).
+
+def cargo_toml_version : String?
+  content = File.read(CARGO_TOML)
+  pkg = content.match(/^\[package\][\s\S]*?(?=^\[|\z)/m)
+  return nil unless pkg
+  match = pkg[0].match(/^version\s*=\s*"([^"]+)"/m)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+def cargo_lock_version : String?
+  content = File.read(CARGO_LOCK)
+  match = content.match(/name\s*=\s*"urx"\s*\nversion\s*=\s*"([^"]+)"/)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+def aur_version : String?
+  content = File.read(AUR_PKGBUILD)
+  match = content.match(/^pkgver=([^\s]+)/m)
+  match ? match[1].gsub('_', '-') : nil
+rescue
+  nil
+end
+
+# Write helpers — surgical regex replace, only the package's own version
+# line (Cargo.toml's [package] block, the urx entry in Cargo.lock).
+# Other dependencies and lockfile entries are left alone.
+
+def update_cargo_toml(new_version : String) : Bool
+  content = File.read(CARGO_TOML)
+  pkg_match = content.match(/^\[package\][\s\S]*?(?=^\[|\z)/m)
+  return false unless pkg_match
+  pkg_block = pkg_match[0]
+  updated_pkg = pkg_block.sub(/^(version\s*=\s*")[^"]+(")/m, "\\1#{new_version}\\2")
+  return false if updated_pkg == pkg_block
+  File.write(CARGO_TOML, content.sub(pkg_block, updated_pkg))
+  true
+rescue ex
+  puts "  error: #{ex.message}"
+  false
+end
+
+def update_cargo_lock(new_version : String) : Bool
+  content = File.read(CARGO_LOCK)
+  updated = content.sub(
+    /(name\s*=\s*"urx"\s*\nversion\s*=\s*")[^"]+(")/,
+    "\\1#{new_version}\\2",
+  )
+  return false if updated == content
+  File.write(CARGO_LOCK, updated)
+  true
+rescue ex
+  puts "  error: #{ex.message}"
+  false
+end
+
+# AUR pkgver disallows hyphens; rewrite `-` as `_` so dev/rc tags remain
+# valid for `makepkg --printsrcinfo`. Also resets pkgrel=1 on bump.
+# NOTE: Crystal's `/m` flag is MULTILINE *and* DOTALL, so `.` matches
+# newlines. Match the value with `[^\n]*` to stay on a single line —
+# `.*` would swallow the rest of the file.
+def update_aur(new_version : String) : Bool
+  content = File.read(AUR_PKGBUILD)
+  aur_ver = new_version.gsub('-', '_')
+  updated = content.sub(/^pkgver=[^\n]*/m, "pkgver=#{aur_ver}")
+                   .sub(/^pkgrel=[^\n]*/m, "pkgrel=1")
+  return false if updated == content
+  File.write(AUR_PKGBUILD, updated)
+  true
+rescue ex
+  puts "  error: #{ex.message}"
+  false
+end
+
+# Loose semver — allow numeric pre-release suffix (`-dev.1`, `-rc.2`,
+# `-alpha`).
+def valid_version?(version : String) : Bool
+  !!(version =~ /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$/)
+end
+
+# Status report.
+
+cargo_v = cargo_toml_version
+lock_v  = cargo_lock_version
+aur_v   = aur_version
+
+puts "Current versions:"
+puts "  #{CARGO_TOML.ljust(22)} #{cargo_v || "Not found"}"
+puts "  #{CARGO_LOCK.ljust(22)} #{lock_v || "Not found"}"
+puts "  #{AUR_PKGBUILD.ljust(22)} #{aur_v || "Not found"}"
+puts
+
+versions = [cargo_v, lock_v, aur_v].compact
+unique = versions.uniq
+
+if unique.size > 1
+  puts "Warning: versions disagree (#{unique.join(", ")})"
+  puts
+end
+
+current = cargo_v || lock_v || aur_v || "unknown"
+puts "Current: #{current}"
+print "New version (Enter to cancel): "
+input = gets
+new_version = input.try(&.strip) || ""
+
+if new_version.empty?
+  puts "Cancelled."
+  exit 0
+end
+
+unless valid_version?(new_version)
+  puts "Invalid version: #{new_version} (expected X.Y.Z or X.Y.Z-suffix)"
+  exit 1
+end
+
+if new_version == current && unique.size == 1
+  puts "No change."
+  exit 0
+end
+
+puts
+puts "Updating to #{new_version}..."
+
+ok = 0
+total = 0
+
+[
+  {CARGO_TOML, ->{ update_cargo_toml(new_version) }, !cargo_v.nil?},
+  {CARGO_LOCK, ->{ update_cargo_lock(new_version) }, !lock_v.nil?},
+  {AUR_PKGBUILD, ->{ update_aur(new_version) }, !aur_v.nil?},
+].each do |tuple|
+  path, fn, present = tuple
+  next unless present
+  total += 1
+  print "  #{path.ljust(22)} "
+  if fn.call
+    puts "ok"
+    ok += 1
+  else
+    puts "FAIL"
+  end
+end
+
+puts
+if ok == total
+  puts "Updated #{ok} files to #{new_version}."
+else
+  puts "Updated #{ok}/#{total} files."
+  exit 1
+end


### PR DESCRIPTION
## What

Adds AUR packaging and lockstep version-management tooling, matching the dalfox standard.

- **`aur/PKGBUILD`** — AUR recipe (pkgname `urx`, source from the `v$pkgver` tag tarball, default-feature build)
- **`.github/workflows/publish_aur.yml`** — publishes to AUR after a successful Release (KSX `deploy-aur`), plus a manual `workflow_dispatch` path. Dispatch reads the recipe from the default branch (source still comes from the tag tarball), so a release can be re-published without rewriting the tag.
- **`scripts/version_check.cr`** (`just vc`) — reports the version in `Cargo.toml`, `Cargo.lock`, `aur/PKGBUILD`; exits non-zero if they disagree
- **`scripts/version_update.cr`** (`just vu`) — bumps all of them in lockstep (AUR `pkgver` normalizes `-`→`_`)
- **`justfile`** — `vc`/`vu` aliases, dalfox-style task groups, docs + release tasks; existing `test`/`fix` recipes preserved; adds `docs-serve`

The version scripts deliberately use `[^\n]*` (not `.*`) for line-scoped subs — Crystal's `/m` flag is MULTILINE **and** DOTALL, so `.*` would swallow the rest of the file (see hahwul/dalfox#1029).

## Verification

- `just vc` → all three files report `0.9.0` and match
- `crystal build --no-codegen` passes for both scripts
- `bash -n aur/PKGBUILD` passes; `pkgrel`/`arch` present; `publish_aur.yml` is valid YAML
- in-memory `vu` bump preserves the full PKGBUILD (38→38 lines)

## Note for the first AUR install test

`reqwest`'s default `default-tls` feature pulls in OpenSSL, so building from AUR (`makepkg`) may need `openssl`/`pkgconf` in `makedepends` and `openssl` in `depends`. Publishing is unaffected (the action only generates `.SRCINFO`); worth verifying when first building the package.

Requires the `AUR_SSH_PRIVATE_KEY` repo secret.
