### PR TITLE
feat: reliable Wayback fetching + modern progress UI

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -46,10 +46,17 @@ impl HttpClientConfig {
             builder = builder.danger_accept_invalid_certs(true);
         }
 
-        if self.random_agent {
-            let ua = crate::network::random_user_agent();
-            builder = builder.user_agent(ua);
-        }
+        // Always send a User-Agent. reqwest sends none by default, and several
+        // upstreams — notably the Wayback CDX API — answer a UA-less request
+        // with `400 Bad Request`, so an unset header was a silent, blanket
+        // source of provider failures. `--random-agent` rotates realistic
+        // browser strings; otherwise we send a polite, tool-identifying default.
+        let ua = if self.random_agent {
+            crate::network::random_user_agent()
+        } else {
+            crate::network::default_user_agent()
+        };
+        builder = builder.user_agent(ua);
 
         if let Some(proxy_url) = &self.proxy {
             let mut proxy = reqwest::Proxy::all(proxy_url)?;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -8,4 +8,4 @@ mod settings;
 pub mod user_agent;
 
 pub use settings::{NetworkScope, NetworkSettings};
-pub use user_agent::random_user_agent;
+pub use user_agent::{default_user_agent, random_user_agent};

--- a/src/network/user_agent.rs
+++ b/src/network/user_agent.rs
@@ -202,6 +202,22 @@ impl UserAgent {
 
 // Convenience free functions
 
+/// Polite, tool-identifying User-Agent used when UA randomisation is off.
+///
+/// Sending *some* User-Agent is mandatory, not cosmetic: the Wayback CDX
+/// endpoint (and some others) reject a request with no `User-Agent` header
+/// outright with `400 Bad Request`. The `Mozilla/5.0 (compatible; …)` form is
+/// the conventional "polite bot" shape that upstreams accept while still
+/// honestly identifying urx.
+pub fn default_user_agent() -> String {
+    concat!(
+        "Mozilla/5.0 (compatible; urx/",
+        env!("CARGO_PKG_VERSION"),
+        "; +https://github.com/hahwul/urx)"
+    )
+    .to_string()
+}
+
 /// Returns a random realistic User-Agent with desktop/mobile weighting.
 /// Roughly 65% desktop, 35% mobile.
 pub fn random_user_agent() -> String {
@@ -232,6 +248,15 @@ mod tests {
             "UA must start with Mozilla/5.0, got: {ua}"
         );
         assert!(ua.len() > 40, "UA too short: {ua}");
+    }
+
+    #[test]
+    fn default_user_agent_is_nonempty_and_identifies_urx() {
+        let ua = default_user_agent();
+        // Must be non-empty: an absent UA makes the Wayback CDX API 400.
+        assert!(!ua.is_empty());
+        assert!(ua.contains("urx/"), "default UA should identify urx: {ua}");
+        assert!(ua.contains(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -1,4 +1,103 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Dense braille spinner frames. Cycling these at ~80ms reads as the smooth,
+/// continuous motion modern CLIs/agents use — a clear upgrade over a 10-frame
+/// dot spinner that visibly stutters.
+pub const SPINNER_FRAMES: &[&str] = &["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"];
+
+/// Eighth-block gradient for determinate bars. The first char is "full", the
+/// last is "empty", and the ones in between render sub-cell fractions, so the
+/// leading edge of the bar slides smoothly instead of jumping a whole cell.
+const BAR_FILL: &str = "█▉▊▋▌▍▎▏ ";
+
+/// Steady-tick interval for spinners (ms). Fast enough to feel alive, slow
+/// enough not to flicker or burn CPU.
+const SPINNER_TICK_MS: u64 = 80;
+
+/// Steady-tick interval for determinate bars (ms).
+const BAR_TICK_MS: u64 = 80;
+
+/// Style for a provider line while a fetch is in flight: animated spinner,
+/// bold provider name, free-form status message, and a dimmed elapsed timer.
+pub fn provider_running_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {spinner:.cyan.bold} {prefix:.bold} {wide_msg} {elapsed:>5.dim}")
+        .expect("static provider running template is valid")
+        .tick_strings(SPINNER_FRAMES)
+}
+
+/// Terminal style for a provider line after a successful fetch. The message is
+/// expected to lead with a ✓ glyph; the whole line is tinted green.
+pub fn provider_success_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {prefix:.green.bold} {wide_msg:.green}")
+        .expect("static provider success template is valid")
+}
+
+/// Terminal style for a provider line after a failed fetch. The message is
+/// expected to lead with a ✗ glyph; the whole line is tinted red.
+pub fn provider_error_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {prefix:.red.bold} {wide_msg:.red}")
+        .expect("static provider error template is valid")
+}
+
+/// Terminal style for a provider line that succeeded but returned *incomplete*
+/// results (e.g. a paginating fetch lost a page mid-cursor). Tinted yellow so a
+/// partial result is visually distinct from a clean ✓ and from a hard ✗.
+pub fn provider_partial_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {prefix:.yellow.bold} {wide_msg:.yellow}")
+        .expect("static provider partial template is valid")
+}
+
+/// A small, cloneable handle that providers use to surface fine-grained
+/// progress (e.g. "page 3/12") on their own line without knowing anything
+/// about `indicatif`. Cloning is cheap and updates are no-ops on a hidden bar,
+/// so passing one in costs nothing when progress is disabled.
+#[derive(Clone)]
+pub struct ProgressReporter {
+    bar: ProgressBar,
+    /// Stable leading context (e.g. "(1/3) example.com · ") prepended to every
+    /// detail so the line keeps identifying which domain is being worked.
+    prefix: String,
+    /// Set by a provider when the results it is about to return are known to be
+    /// incomplete (e.g. a paginating fetch lost a page after already collecting
+    /// some). Shared across clones via `Arc`, so the runner that handed the
+    /// reporter in can read it back after the fetch resolves and avoid
+    /// presenting a truncated result as a clean success.
+    partial: Arc<AtomicBool>,
+}
+
+impl ProgressReporter {
+    /// Build a reporter that writes to `bar`, prefixing each detail with
+    /// `prefix` (which should already include any trailing separator).
+    pub fn new(bar: ProgressBar, prefix: impl Into<String>) -> Self {
+        ProgressReporter {
+            bar,
+            prefix: prefix.into(),
+            partial: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Replace the trailing status detail, keeping the stable prefix.
+    pub fn detail(&self, detail: impl AsRef<str>) {
+        self.bar
+            .set_message(format!("{}{}", self.prefix, detail.as_ref()));
+    }
+
+    /// Flag the result as incomplete. The runner reads this via [`is_partial`]
+    /// after the fetch to mark the line partial and warn instead of reporting a
+    /// clean success.
+    ///
+    /// [`is_partial`]: ProgressReporter::is_partial
+    pub fn mark_partial(&self) {
+        self.partial.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether the provider flagged the result as incomplete.
+    pub fn is_partial(&self) -> bool {
+        self.partial.load(Ordering::Relaxed)
+    }
+}
 
 pub struct ProgressManager {
     multi_progress: MultiProgress,
@@ -22,74 +121,51 @@ impl ProgressManager {
         }
 
         let style = ProgressStyle::with_template(
-            "{prefix:.bold.dim} [{bar:38.cyan/blue}] {pos}/{len} {wide_msg}",
+            "  {prefix:.bold.cyan} {bar:28.cyan/blue} {pos:>3}/{len:<3} {wide_msg:.dim}",
         )
         .unwrap()
-        .progress_chars("=> ");
+        .progress_chars(BAR_FILL);
 
         let bar = self.multi_progress.add(ProgressBar::new(total as u64));
         bar.set_style(style);
         bar.set_prefix("Domains");
-        // Faster tick rate for more responsive UI updates
-        bar.enable_steady_tick(std::time::Duration::from_millis(50));
+        bar.enable_steady_tick(std::time::Duration::from_millis(BAR_TICK_MS));
 
         bar
     }
 
     pub fn create_provider_bars(&self, provider_names: &[String]) -> Vec<ProgressBar> {
         if self.no_progress {
-            // Return hidden progress bars when progress is disabled
+            // Hidden spinners still accept set_message/set_style calls, so the
+            // runner can drive them unconditionally without branching.
             return provider_names
                 .iter()
-                .map(|_| {
-                    let bar = ProgressBar::hidden();
-                    bar.set_length(100);
-                    bar
-                })
+                .map(|_| ProgressBar::hidden())
                 .collect();
         }
 
-        let style = ProgressStyle::with_template(
-            "{prefix:.bold.dim} [{bar:40.green/white}] {spinner} {wide_msg}",
-        )
-        .unwrap()
-        .progress_chars("=> ")
-        .with_key(
-            "spinner",
-            |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
-                // Using a spinner with 10 frames for smooth animation
-                write!(
-                    w,
-                    "{}",
-                    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][state.pos() as usize % 10]
-                )
-                .unwrap();
-            },
-        );
+        let style = provider_running_style();
 
-        // First, create all progress bars and add them to the multi_progress
+        // Indeterminate spinner per provider: a fetch has no honest percentage
+        // (the archive doesn't tell us up front how much it will return), so we
+        // animate motion + elapsed time rather than faking a filling bar.
         let bars: Vec<ProgressBar> = provider_names
             .iter()
             .map(|name| {
-                let bar = self.multi_progress.add(ProgressBar::new(100));
-                // Format provider name to have consistent width
+                let bar = self.multi_progress.add(ProgressBar::new_spinner());
                 bar.set_prefix(format!("{name:<15}"));
-                // Set style with consistent template
                 bar.set_style(style.clone());
-                // Use a slower tick rate to reduce flicker
-                bar.enable_steady_tick(std::time::Duration::from_millis(100));
-                // Initialize with an empty message to establish the line
-                bar.set_message("Initializing...");
+                bar.enable_steady_tick(std::time::Duration::from_millis(SPINNER_TICK_MS));
+                bar.set_message("queued…");
                 bar
             })
             .collect();
 
-        // Force draw all bars to establish their positions in the terminal
+        // Force an initial draw so every line claims its row in the terminal.
         for bar in &bars {
             bar.tick();
         }
 
-        // Return all created bars
         bars
     }
 
@@ -101,16 +177,16 @@ impl ProgressManager {
             return bar;
         }
 
-        let style =
-            ProgressStyle::with_template("{prefix:.bold.dim} [{bar:40.yellow/white}] {wide_msg}")
-                .unwrap()
-                .progress_chars("=> ");
+        let style = ProgressStyle::with_template(
+            "  {prefix:.bold.yellow} {bar:28.yellow/blue} {wide_msg:.dim}",
+        )
+        .unwrap()
+        .progress_chars(BAR_FILL);
 
         let bar = self.multi_progress.add(ProgressBar::new(100));
         bar.set_style(style);
         bar.set_prefix("Filtering");
-        // Faster tick rate for more responsive UI updates
-        bar.enable_steady_tick(std::time::Duration::from_millis(50));
+        bar.enable_steady_tick(std::time::Duration::from_millis(BAR_TICK_MS));
 
         bar
     }
@@ -123,16 +199,16 @@ impl ProgressManager {
             return bar;
         }
 
-        let style =
-            ProgressStyle::with_template("{prefix:.bold.dim} [{bar:40.magenta/white}] {wide_msg}")
-                .unwrap()
-                .progress_chars("=> ");
+        let style = ProgressStyle::with_template(
+            "  {prefix:.bold.magenta} {bar:28.magenta/blue} {wide_msg:.dim}",
+        )
+        .unwrap()
+        .progress_chars(BAR_FILL);
 
         let bar = self.multi_progress.add(ProgressBar::new(100));
         bar.set_style(style);
         bar.set_prefix("Transforming");
-        // Faster tick rate for more responsive UI updates
-        bar.enable_steady_tick(std::time::Duration::from_millis(50));
+        bar.enable_steady_tick(std::time::Duration::from_millis(BAR_TICK_MS));
 
         bar
     }
@@ -146,16 +222,15 @@ impl ProgressManager {
         }
 
         let style = ProgressStyle::with_template(
-            "{prefix:.bold.dim} [{bar:40.blue/white}] {pos}/{len} {wide_msg}",
+            "  {prefix:.bold.blue} {bar:28.blue/blue} {pos:>5}/{len:<5} {wide_msg:.dim}",
         )
         .unwrap()
-        .progress_chars("=> ");
+        .progress_chars(BAR_FILL);
 
         let bar = self.multi_progress.add(ProgressBar::new(total as u64));
         bar.set_style(style);
-        bar.set_prefix("Testing URLs");
-        // Faster tick rate for more responsive UI updates
-        bar.enable_steady_tick(std::time::Duration::from_millis(50));
+        bar.set_prefix("Testing");
+        bar.enable_steady_tick(std::time::Duration::from_millis(BAR_TICK_MS));
 
         bar
     }
@@ -205,7 +280,8 @@ mod tests {
 
         assert_eq!(bars.len(), provider_names.len());
         for bar in bars.iter() {
-            assert_eq!(bar.length(), Some(100));
+            // Provider lines are indeterminate spinners, so they carry no length.
+            assert_eq!(bar.length(), None);
             assert_eq!(bar.position(), 0);
         }
     }
@@ -219,9 +295,31 @@ mod tests {
 
         assert_eq!(bars.len(), provider_names.len());
         for bar in bars.iter() {
-            assert_eq!(bar.length(), Some(100));
-            assert_eq!(bar.position(), 0);
+            assert!(bar.is_hidden());
         }
+    }
+
+    #[test]
+    fn test_progress_reporter_updates_message() {
+        let manager = ProgressManager::new(false);
+        let bars = manager.create_provider_bars(&["wayback".to_string()]);
+        let reporter = ProgressReporter::new(bars[0].clone(), "(1/2) example.com · ");
+        reporter.detail("page 3/12");
+        assert_eq!(
+            bars[0].message(),
+            "(1/2) example.com · page 3/12".to_string()
+        );
+    }
+
+    #[test]
+    fn test_progress_reporter_partial_flag_shares_across_clones() {
+        let reporter = ProgressReporter::new(ProgressBar::hidden(), "x");
+        assert!(!reporter.is_partial());
+        let clone = reporter.clone();
+        // A provider holds a clone; marking it must be visible to the original
+        // handle the runner kept (shared Arc).
+        clone.mark_partial();
+        assert!(reporter.is_partial());
     }
 
     #[test]

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -22,9 +22,11 @@ const BAR_TICK_MS: u64 = 80;
 /// Style for a provider line while a fetch is in flight: animated spinner,
 /// bold provider name, free-form status message, and a dimmed elapsed timer.
 pub fn provider_running_style() -> ProgressStyle {
-    ProgressStyle::with_template("  {spinner:.cyan.bold} {prefix:.bold} {wide_msg} {elapsed:>5.dim}")
-        .expect("static provider running template is valid")
-        .tick_strings(SPINNER_FRAMES)
+    ProgressStyle::with_template(
+        "  {spinner:.cyan.bold} {prefix:.bold} {wide_msg} {elapsed:>5.dim}",
+    )
+    .expect("static provider running template is valid")
+    .tick_strings(SPINNER_FRAMES)
 }
 
 /// Terminal style for a provider line after a successful fetch. The message is

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,20 @@ pub trait Provider: Send + Sync {
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>>;
 
+    /// Fetch URLs while optionally reporting fine-grained progress (e.g. a
+    /// paginating provider can surface "page 3/12") through `reporter`.
+    ///
+    /// The default implementation ignores the reporter and delegates to
+    /// [`Provider::fetch_urls`], so providers that have nothing interesting to
+    /// report need not implement it.
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        _reporter: Option<crate::progress::ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls(domain)
+    }
+
     // Configuration options
     /// Include or exclude subdomains in the search
     fn with_subdomains(&mut self, include: bool);

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -4,6 +4,67 @@ use std::pin::Pin;
 
 use super::Provider;
 use crate::network::client::{get_with_retry, HttpClientConfig};
+use crate::progress::ProgressReporter;
+
+/// How many rows to ask the CDX server for per request. A bounded `limit` is
+/// what keeps large domains from failing: an unbounded query makes the server
+/// compute and buffer the *entire* result set (it then routinely times out),
+/// whereas a capped request streams a slice and returns promptly. Most domains
+/// fit in a single page; only the large ones the user cares about paginate.
+const PAGE_LIMIT: usize = 50_000;
+
+/// Hard ceiling on the number of pages we will follow, so a misbehaving cursor
+/// can never spin forever. At `PAGE_LIMIT` rows each, this covers domains with
+/// up to ~500M captured URLs — far beyond anything real.
+const MAX_PAGES: usize = 10_000;
+
+/// Split a CDX `showResumeKey=true` response into its URL rows and the resume
+/// key for the next page (if any).
+///
+/// The server streams the result rows, then — *only while more results remain*
+/// — a blank line followed by an opaque resume key:
+///
+/// ```text
+/// https://example.com/a
+/// https://example.com/b
+///                          <- blank separator
+/// eJxLzs_V...              <- resume key
+/// ```
+///
+/// We treat a trailing, non-URL token *that is preceded by a blank line* as the
+/// cursor. Requiring the blank separator is what stops stray non-URL junk in a
+/// malformed/error body from being mistaken for a key (which would trigger a
+/// spurious follow-up request). No such trailing token ⇒ this was the last page.
+fn split_page(text: &str) -> (Vec<String>, Option<String>) {
+    let lines: Vec<&str> = text.lines().collect();
+
+    let mut resume_key = None;
+    let mut url_scan_end = lines.len();
+    if let Some(idx) = lines.iter().rposition(|l| !l.trim().is_empty()) {
+        let candidate = lines[idx].trim();
+        let is_url = candidate.starts_with("http://") || candidate.starts_with("https://");
+        let preceded_by_blank = idx > 0 && lines[idx - 1].trim().is_empty();
+        if !is_url && preceded_by_blank {
+            resume_key = Some(candidate.to_string());
+            url_scan_end = idx; // keep the key line out of the URL scan
+        }
+    }
+
+    let urls = lines[..url_scan_end]
+        .iter()
+        .map(|l| l.trim())
+        .filter(|l| l.starts_with("http://") || l.starts_with("https://"))
+        .map(String::from)
+        .collect();
+
+    (urls, resume_key)
+}
+
+/// Percent-encode a resume key so opaque cursor bytes (`+`, `/`, `=` in some
+/// base64 variants) survive being spliced back into the query string.
+fn encode_resume_key(key: &str) -> String {
+    url::form_urlencoded::byte_serialize(key.as_bytes()).collect()
+}
 
 /// Normalise a user-supplied date into a 14-digit Wayback CDX timestamp
 /// (`YYYYMMDDhhmmss`). Accepts `YYYY`, `YYYYMM`, `YYYYMMDD` and the full
@@ -143,6 +204,45 @@ impl WaybackMachineProvider {
             proxy_auth: self.proxy_auth.clone(),
         }
     }
+
+    /// Archive origin. Overridable in tests so the mock server can stand in.
+    fn base_url(&self) -> &str {
+        #[cfg(test)]
+        {
+            &self.base_url
+        }
+        #[cfg(not(test))]
+        {
+            "https://web.archive.org"
+        }
+    }
+
+    /// Build the CDX query *without* pagination params. Plain-text streaming
+    /// (`fl=original`) is far more reliable than `output=json` for large
+    /// domains, and `collapse=urlkey` trims server-side duplicates.
+    fn query_base(&self, domain: &str) -> String {
+        let mut url = if self.include_subdomains {
+            format!(
+                "{}/cdx/search/cdx?url=*.{domain}/*&fl=original&collapse=urlkey",
+                self.base_url()
+            )
+        } else {
+            format!(
+                "{}/cdx/search/cdx?url={domain}/*&fl=original&collapse=urlkey",
+                self.base_url()
+            )
+        };
+        if let Some(ts) = &self.from {
+            url.push_str("&from=");
+            url.push_str(ts);
+        }
+        if let Some(ts) = &self.to {
+            url.push_str("&to=");
+            url.push_str(ts);
+        }
+        url
+    }
+
 }
 
 impl Provider for WaybackMachineProvider {
@@ -154,50 +254,79 @@ impl Provider for WaybackMachineProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
-            #[cfg(not(test))]
-            let base_url = "https://web.archive.org";
-            #[cfg(test)]
-            let base_url = &self.base_url;
-
-            // Plain-text streaming response is far more reliable than output=json
-            // for large domains (the JSON variant buffers the entire result server-side
-            // and frequently times out). collapse=urlkey trims server-side duplicates.
-            let mut url = if self.include_subdomains {
-                format!(
-                    "{}/cdx/search/cdx?url=*.{domain}/*&fl=original&collapse=urlkey",
-                    base_url
-                )
-            } else {
-                format!(
-                    "{}/cdx/search/cdx?url={domain}/*&fl=original&collapse=urlkey",
-                    base_url
-                )
-            };
-            if let Some(ts) = &self.from {
-                url.push_str("&from=");
-                url.push_str(ts);
-            }
-            if let Some(ts) = &self.to {
-                url.push_str("&to=");
-                url.push_str(ts);
-            }
-
             let client = self.client_config().build_client()?;
-            let text = get_with_retry(&client, &url, self.retries).await?;
+            let query_base = self.query_base(domain);
 
-            if text.trim().is_empty() {
-                return Ok(Vec::new());
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
             }
 
-            // Defensive: a 200 OK from Wayback can occasionally carry a maintenance
-            // page or non-URL body. Restrict to lines that actually look like URLs.
-            let mut urls: Vec<String> = text
-                .lines()
-                .map(str::trim)
-                .filter(|l| l.starts_with("http://") || l.starts_with("https://"))
-                .map(String::from)
-                .collect();
+            // Walk the CDX cursor: each request returns at most PAGE_LIMIT rows
+            // plus a resume key pointing at the next slice. Following the key
+            // lets arbitrarily large domains complete as a series of bounded,
+            // fast requests instead of one unbounded request that times out.
+            let mut urls: Vec<String> = Vec::new();
+            let mut resume_key: Option<String> = None;
+            let mut pages = 0usize;
+
+            loop {
+                pages += 1;
+                if pages > MAX_PAGES {
+                    break;
+                }
+
+                let mut url = format!("{query_base}&limit={PAGE_LIMIT}&showResumeKey=true");
+                if let Some(key) = &resume_key {
+                    url.push_str("&resumeKey=");
+                    url.push_str(&encode_resume_key(key));
+                }
+
+                let text = match get_with_retry(&client, &url, self.retries).await {
+                    Ok(text) => text,
+                    Err(e) => {
+                        // Best effort: a mid-cursor failure shouldn't discard
+                        // the pages we already pulled. Only a failure on the
+                        // very first request (nothing collected) is fatal.
+                        if urls.is_empty() {
+                            return Err(e);
+                        }
+                        // We're returning a truncated result. Flag it so the
+                        // caller can mark the line partial and warn rather than
+                        // present an incomplete crawl as a clean success.
+                        if let Some(r) = &reporter {
+                            r.mark_partial();
+                        }
+                        break;
+                    }
+                };
+
+                let (page_urls, next_key) = split_page(&text);
+                let got = page_urls.len();
+                urls.extend(page_urls);
+
+                if let Some(r) = &reporter {
+                    r.detail(format!("{} URLs…", urls.len()));
+                }
+
+                // Continue only when the cursor actually advanced: a new resume
+                // key AND a non-empty page. Otherwise we've reached the end (or
+                // a stuck cursor) and must stop to avoid looping forever.
+                match next_key {
+                    Some(key) if got > 0 && resume_key.as_deref() != Some(key.as_str()) => {
+                        resume_key = Some(key);
+                    }
+                    _ => break,
+                }
+            }
 
             urls.sort();
             urls.dedup();
@@ -414,18 +543,22 @@ mod tests {
         use mockito;
 
         let mut server = mockito::Server::new_async().await;
+        // A small domain fits in one page: results, no trailing resume key, so
+        // exactly one request is made.
         let mock = server
             .mock("GET", "/cdx/search/cdx")
             .match_query(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
                 mockito::Matcher::UrlEncoded("fl".into(), "original".into()),
                 mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
             ]))
             .with_status(200)
             .with_header("content-type", "text/plain")
             .with_body(
                 "http://example.com/page1\nhttp://example.com/page2\nhttp://example.com/page1\n",
             )
+            .expect(1)
             .create_async()
             .await;
 
@@ -434,12 +567,172 @@ mod tests {
 
         let urls = provider.fetch_urls("example.com").await.unwrap();
 
-        // Should return unique URLs sorted
+        // Should return unique URLs sorted.
         assert_eq!(urls.len(), 2);
         assert_eq!(urls[0], "http://example.com/page1");
         assert_eq!(urls[1], "http://example.com/page2");
 
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_paginates_via_resume_key() {
+        use mockito;
+
+        let mut server = mockito::Server::new_async().await;
+        // First page: rows + a blank line + the resume key (more results remain).
+        // It fires before the continuation, so once it has served its single
+        // hit, mockito routes the keyed request to the page-two mock.
+        let page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
+            ]))
+            .with_status(200)
+            .with_body("http://example.com/a\nhttp://example.com/b\n\nKEY2\n")
+            .expect(1)
+            .create_async()
+            .await;
+        // Second page: keyed by the cursor; overlaps /b to prove cross-page
+        // dedup, and carries no trailing key so the walk terminates.
+        let page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("resumeKey".into(), "KEY2".into()))
+            .with_status(200)
+            .with_body("http://example.com/b\nhttp://example.com/c\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+                "http://example.com/c".to_string(),
+            ]
+        );
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_keeps_partial_results_on_midcursor_failure() {
+        use mockito;
+
+        let mut server = mockito::Server::new_async().await;
+        // First page succeeds and hands us a cursor...
+        let _page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
+            ]))
+            .with_status(200)
+            .with_body("http://example.com/a\nhttp://example.com/b\n\nKEY2\n")
+            .expect(1)
+            .create_async()
+            .await;
+        // ...but the follow-up fails. We should keep page one rather than error.
+        let _page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("resumeKey".into(), "KEY2".into()))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        // Drive it through a reporter so we can assert the partial flag is set.
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        // The lost second page must be surfaced as a partial result, not a
+        // clean success.
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_errors_when_first_request_fails() {
+        use mockito;
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        // Nothing collected yet → a hard failure must propagate.
+        assert!(provider.fetch_urls("example.com").await.is_err());
+    }
+
+    #[test]
+    fn test_split_page_extracts_resume_key_after_blank_line() {
+        let body = "http://example.com/a\nhttps://example.com/b\n\neJxKEY\n";
+        let (urls, key) = split_page(body);
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "https://example.com/b".to_string(),
+            ]
+        );
+        assert_eq!(key.as_deref(), Some("eJxKEY"));
+    }
+
+    #[test]
+    fn test_split_page_no_resume_key_on_last_page() {
+        let body = "http://example.com/a\nhttp://example.com/b\n";
+        let (urls, key) = split_page(body);
+        assert_eq!(urls.len(), 2);
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn test_split_page_ignores_trailing_junk_without_blank_separator() {
+        // A non-URL line *not* preceded by a blank line is junk (e.g. an error
+        // page line), never a resume key — so no spurious follow-up request.
+        let body = "<html>Service unavailable</html>\nhttp://example.com/real\nnot-a-url\n";
+        let (urls, key) = split_page(body);
+        assert_eq!(urls, vec!["http://example.com/real".to_string()]);
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn test_split_page_empty_body() {
+        let (urls, key) = split_page("");
+        assert!(urls.is_empty());
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn test_encode_resume_key() {
+        // URL-safe base64 chars pass through; +, /, = get percent-encoded.
+        assert_eq!(encode_resume_key("eJx-_09Az"), "eJx-_09Az");
+        assert_eq!(encode_resume_key("a+b/c="), "a%2Bb%2Fc%3D");
     }
 
     #[tokio::test]
@@ -453,10 +746,12 @@ mod tests {
                 mockito::Matcher::UrlEncoded("url".into(), "*.example.com/*".into()),
                 mockito::Matcher::UrlEncoded("fl".into(), "original".into()),
                 mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
             ]))
             .with_status(200)
             .with_header("content-type", "text/plain")
             .with_body("http://sub.example.com/page1\n")
+            .expect(1)
             .create_async()
             .await;
 
@@ -482,6 +777,7 @@ mod tests {
             .match_query(mockito::Matcher::Any)
             .with_status(200)
             .with_body("")
+            .expect(1)
             .create_async()
             .await;
 
@@ -589,10 +885,12 @@ mod tests {
                 mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
                 mockito::Matcher::UrlEncoded("from".into(), "20200101000000".into()),
                 mockito::Matcher::UrlEncoded("to".into(), "20201231235959".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
             ]))
             .with_status(200)
             .with_header("content-type", "text/plain")
             .with_body("http://example.com/page\n")
+            .expect(1)
             .create_async()
             .await;
 

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -242,7 +242,6 @@ impl WaybackMachineProvider {
         }
         url
     }
-
 }
 
 impl Provider for WaybackMachineProvider {
@@ -598,7 +597,10 @@ mod tests {
         // dedup, and carries no trailing key so the walk terminates.
         let page2 = server
             .mock("GET", "/cdx/search/cdx")
-            .match_query(mockito::Matcher::UrlEncoded("resumeKey".into(), "KEY2".into()))
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
             .with_status(200)
             .with_body("http://example.com/b\nhttp://example.com/c\n")
             .expect(1)
@@ -642,7 +644,10 @@ mod tests {
         // ...but the follow-up fails. We should keep page one rather than error.
         let _page2 = server
             .mock("GET", "/cdx/search/cdx")
-            .match_query(mockito::Matcher::UrlEncoded("resumeKey".into(), "KEY2".into()))
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
             .with_status(503)
             .create_async()
             .await;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -363,10 +363,8 @@ pub async fn process_domains(
                             }
                         } else {
                             provider_bar.set_style(provider_success_style());
-                            provider_bar.set_message(format!(
-                                "✓ {domain} · {} URLs",
-                                fmt_count(url_count)
-                            ));
+                            provider_bar
+                                .set_message(format!("✓ {domain} · {} URLs", fmt_count(url_count)));
                         }
                         provider_bar.tick();
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,14 +1,45 @@
 use futures::future::join_all;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::ProgressBar;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use tokio::task;
 
 use crate::cli::Args;
 use crate::network::{NetworkScope, NetworkSettings};
-use crate::progress::ProgressManager;
+use crate::progress::{
+    provider_error_style, provider_partial_style, provider_running_style, provider_success_style,
+    ProgressManager, ProgressReporter,
+};
 use crate::providers::Provider;
 use crate::utils::verbose_print;
+
+/// Format an integer with thousands separators (e.g. `12345` → `12,345`) so
+/// large URL counts stay legible in the progress summary.
+fn fmt_count(n: usize) -> String {
+    let digits = n.to_string();
+    let bytes = digits.as_bytes();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+/// Render an error as a single short line for a progress label, truncating on
+/// a char boundary so a verbose chain doesn't blow out the terminal width.
+fn short_error(e: &anyhow::Error) -> String {
+    let msg = e.to_string();
+    let one_line = msg.split('\n').next().unwrap_or(&msg);
+    let truncated: String = one_line.chars().take(80).collect();
+    if truncated.chars().count() < one_line.chars().count() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
 
 /// Lock a mutex, recovering the inner data if another task panicked while
 /// holding it. One failed provider task must not poison the shared state and
@@ -236,7 +267,6 @@ pub async fn process_domains(
     let mut provider_futures = Vec::new();
 
     // Extract the values we need from Args to avoid lifetime issues
-    let timeout = args.timeout.max(1);
     let verbose = args.verbose;
     let silent = args.silent;
     let no_progress = args.no_progress;
@@ -261,8 +291,12 @@ pub async fn process_domains(
 
         // Spawn a task for this provider
         let provider_future = task::spawn(async move {
-            // Track the current domain index for this provider
+            // Track the current domain index for this provider, plus running
+            // totals used to freeze the line on an honest end-of-run summary.
             let mut current_domain_idx = 0;
+            let mut provider_url_total = 0usize;
+            let mut provider_err_total = 0usize;
+            let mut provider_partial_total = 0usize;
 
             // Process all domains assigned to this provider
             loop {
@@ -278,80 +312,63 @@ pub async fn process_domains(
                     }
                 };
 
-                // Update the progress bar message to show which domain is being processed
-                provider_bar.set_message(format!(
-                    "({current_domain_idx}/{total_domains}) Fetching data for {domain}"
-                ));
-
-                // Use ticker for progress visualization
-                let bar_clone = provider_bar.clone();
-
-                // Clear line after setting initial message to ensure proper positioning
+                // Re-arm the spinner and reset the per-domain elapsed timer so
+                // the line reads as "this fetch", not "since the run started".
+                let prefix = format!("({current_domain_idx}/{total_domains}) {domain} · ");
+                provider_bar.set_style(provider_running_style());
+                provider_bar.reset_elapsed();
+                provider_bar.set_message(format!("{prefix}fetching…"));
                 if !no_progress && !silent {
                     provider_bar.tick();
                 }
 
-                let ticker_handle = tokio::spawn(async move {
-                    let start_time = std::time::Instant::now();
-                    let total_duration_ms = timeout * 1000;
+                // A paginating provider (Wayback) uses this handle to surface
+                // real page-by-page progress and to flag incomplete results.
+                // Built whenever output is allowed — including under
+                // --no-progress, so the partial-result signal still reaches the
+                // warning path; only --silent suppresses it.
+                let reporter = if !silent {
+                    Some(ProgressReporter::new(provider_bar.clone(), prefix))
+                } else {
+                    None
+                };
 
-                    let spinner_phase_duration =
-                        std::time::Duration::from_millis(total_duration_ms / 10);
-                    tokio::time::sleep(spinner_phase_duration).await;
-
-                    let progress_style = ProgressStyle::with_template(
-                        "{prefix:.bold.dim} [{bar:40.green/white}] {spinner} {wide_msg}",
-                    )
-                    .unwrap()
-                    .progress_chars("=> ")
-                    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]);
-
-                    bar_clone.set_style(progress_style);
-
-                    let update_interval_ms = 100;
-                    let end_time = start_time + std::time::Duration::from_millis(total_duration_ms);
-
-                    while std::time::Instant::now() < end_time {
-                        let now = std::time::Instant::now();
-                        let elapsed = now.duration_since(start_time).as_millis() as u64;
-                        let progress = (elapsed * 100) / total_duration_ms;
-
-                        bar_clone.set_position(progress.min(99));
-
-                        tokio::time::sleep(std::time::Duration::from_millis(update_interval_ms))
-                            .await;
-                    }
-
-                    bar_clone.set_position(100);
-                });
-
-                // Fetch URLs for this domain using this provider
+                // Fetch URLs for this domain using this provider.
                 let fetch_start = std::time::Instant::now();
-                let fetch_result = provider_clone.fetch_urls(&domain).await;
+                let fetch_result = provider_clone
+                    .fetch_urls_with_progress(&domain, reporter.clone())
+                    .await;
                 let fetch_elapsed = fetch_start.elapsed();
                 match fetch_result {
                     Ok(urls) => {
-                        provider_bar.set_position(100);
-                        provider_bar.set_message(format!(
-                            "({}/{}) Found {} URLs for {}",
-                            current_domain_idx,
-                            total_domains,
-                            urls.len(),
-                            domain
-                        ));
-                        ticker_handle.abort();
-                        provider_bar.set_style(
-                            ProgressStyle::with_template(
-                                "{prefix:.bold.dim} [{bar:40.green/white}] ✓ {wide_msg}",
-                            )
-                            .unwrap()
-                            .progress_chars("=>"),
-                        );
-
-                        // Force refresh to maintain line position
-                        provider_bar.tick();
-
                         let url_count = urls.len();
+                        provider_url_total += url_count;
+
+                        // The provider may have returned a *partial* result
+                        // (e.g. a page failed mid-pagination). Surface that as a
+                        // distinct, warned state rather than a clean success, so
+                        // a truncated crawl is never mistaken for a complete one.
+                        let partial = reporter.as_ref().is_some_and(|r| r.is_partial());
+                        if partial {
+                            provider_partial_total += 1;
+                            provider_bar.set_style(provider_partial_style());
+                            provider_bar.set_message(format!(
+                                "✓ {domain} · {} URLs (partial)",
+                                fmt_count(url_count)
+                            ));
+                            if verbose && !silent {
+                                eprintln!(
+                                    "Warning: partial results for {domain} from {provider_name}: a request failed mid-fetch; returning {url_count} URL(s) collected so far"
+                                );
+                            }
+                        } else {
+                            provider_bar.set_style(provider_success_style());
+                            provider_bar.set_message(format!(
+                                "✓ {domain} · {} URLs",
+                                fmt_count(url_count)
+                            ));
+                        }
+                        provider_bar.tick();
 
                         // Add URLs to the shared map (URL -> set of providers).
                         {
@@ -381,20 +398,10 @@ pub async fn process_domains(
                         }
                     }
                     Err(e) => {
-                        provider_bar.set_position(100);
-                        provider_bar.set_message(format!(
-                            "({current_domain_idx}/{total_domains}) Error: for {domain}"
-                        ));
-                        ticker_handle.abort();
-                        provider_bar.set_style(
-                            ProgressStyle::with_template(
-                                "{prefix:.bold.dim} [{bar:40.red/white}] ✗ {wide_msg}",
-                            )
-                            .unwrap()
-                            .progress_chars("=>"),
-                        );
+                        provider_err_total += 1;
 
-                        // Force refresh to maintain line position
+                        provider_bar.set_style(provider_error_style());
+                        provider_bar.set_message(format!("✗ {domain} · {}", short_error(&e)));
                         provider_bar.tick();
 
                         {
@@ -410,18 +417,30 @@ pub async fn process_domains(
                         }
                     }
                 }
-
-                // Get ready for the next domain if any
-                if current_domain_idx < total_domains {
-                    provider_bar.set_position(0); // Reset progress for next domain
-                }
             }
 
-            // This provider has finished all its domains
-            if current_domain_idx >= total_domains {
-                provider_bar.finish_with_message(format!(
-                    "({total_domains}/{total_domains}) Completed all domains"
-                ));
+            // Freeze this provider's line on a one-line summary that reflects
+            // what actually happened across all of its domains.
+            if provider_url_total == 0 && provider_err_total > 0 {
+                provider_bar.set_style(provider_error_style());
+                provider_bar
+                    .finish_with_message(format!("✗ all {provider_err_total} fetch(es) failed"));
+            } else {
+                // A partial anywhere keeps the line yellow so the run doesn't
+                // read as a clean, complete success at a glance.
+                provider_bar.set_style(if provider_partial_total > 0 {
+                    provider_partial_style()
+                } else {
+                    provider_success_style()
+                });
+                let mut summary = format!("✓ {} URLs", fmt_count(provider_url_total));
+                if provider_partial_total > 0 {
+                    summary.push_str(&format!(" · {provider_partial_total} partial"));
+                }
+                if provider_err_total > 0 {
+                    summary.push_str(&format!(" · {provider_err_total} error(s)"));
+                }
+                provider_bar.finish_with_message(summary);
             }
 
             if verbose && !silent {


### PR DESCRIPTION
## Summary

Wayback Machine fetches were failing on larger sites. Investigation (with live probing of the `web.archive.org` CDX API) found **two root causes**, plus an opportunity to modernize the progress UI.

### 1. Reliable Wayback fetching

- **Missing `User-Agent` → HTTP 400.** `reqwest` sends no UA by default and urx only set one with `--random-agent`, so archive.org rejected Wayback requests outright. `HttpClientConfig::build_client` now **always** sends a UA — a polite `Mozilla/5.0 (compatible; urx/<ver>; …)` default; `--random-agent` still rotates realistic browser strings. Fixes every provider, not just Wayback.
- **No pagination → timeout on large domains.** A single unbounded CDX request makes the server buffer the whole result set and time out. The `page`/`showNumPages` API **does not work** on web.archive.org (returns `-`, or `403` on large queries), so this uses **`resumeKey` cursor pagination** (`&limit=50000&showResumeKey=true`, following the trailing key). Each request is bounded and streams promptly, so arbitrarily large domains complete. Includes cross-page dedup, an infinite-loop guard, and best-effort partial results on a mid-cursor failure.

### 2. Modern progress UI

- Replaced the **fake timeout-based ticker** (it filled a bar from `--timeout`, not real work) with honest indeterminate braille spinners + per-domain elapsed time.
- Smooth eighth-block determinate bars; clean green `✓` / red `✗` / yellow partial states; thousand-separated counts; per-provider end summaries.
- New `ProgressReporter` lets Wayback surface real `"N URLs…"` progress while paging, and **signals incomplete results** so a truncated crawl shows `(partial)` + a `--verbose` warning instead of a silent success.

## Implementation notes
- Adds a default `Provider::fetch_urls_with_progress` trait method; only Wayback overrides it (others keep working via `fetch_urls`).

## Testing
- **434 tests pass; clippy clean.** New tests: resumeKey cursor loop, resume-key parsing edge cases (blank-line rule, trailing junk), partial-failure signaling, default UA.
- **Live E2E:** `urx hahwul.com --providers wayback --subs` → **5,637 URLs, 0 errors** (previously failed).
- Diff reviewed by an adversarial multi-agent pass; the one confirmed finding (silent partial results) is addressed in this PR.