### PR TITLE
fix: close silently-broken & unsafe behavior (round 2)

### DIFF
--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -28,12 +28,30 @@ impl CacheKey {
     }
 }
 
+/// Feed one field into the hasher length-prefixed, so that adjacent fields can
+/// never be confused for one another. Without this, concatenating raw bytes
+/// lets distinct configs collide (e.g. domain `"ab"`+provider `"c"` hashes the
+/// same as domain `"a"`+provider `"bc"`), which would cross-pollinate caches.
+fn feed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+/// Feed a list of strings unambiguously: element count, then each element
+/// length-prefixed.
+fn feed_list(hasher: &mut Sha256, items: &[String]) {
+    hasher.update((items.len() as u64).to_le_bytes());
+    for item in items {
+        feed(hasher, item.as_bytes());
+    }
+}
+
 impl std::fmt::Display for CacheKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut hasher = Sha256::new();
-        hasher.update(&self.domain);
-        hasher.update(self.providers.join(","));
-        hasher.update(&self.filters_hash);
+        feed(&mut hasher, self.domain.as_bytes());
+        feed_list(&mut hasher, &self.providers);
+        feed(&mut hasher, self.filters_hash.as_bytes());
         let result = hasher.finalize();
         for byte in result {
             write!(f, "{:02x}", byte)?;
@@ -59,21 +77,38 @@ pub struct CacheFilters {
 }
 
 impl CacheFilters {
-    /// Compute a hash of the filter configuration
+    /// Compute a hash of the filter configuration.
+    ///
+    /// Every field is fed length-prefixed (see [`feed`]/[`feed_list`]) so that
+    /// no two distinct filter sets can hash to the same value through field-
+    /// boundary ambiguity — e.g. `presets=["a"], min_length=Some(1)` must not
+    /// collide with `presets=["a1"], min_length=None`.
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
 
-        hasher.update(if self.subs { "1" } else { "0" });
-        hasher.update(self.extensions.join(","));
-        hasher.update(self.exclude_extensions.join(","));
-        hasher.update(self.patterns.join(","));
-        hasher.update(self.exclude_patterns.join(","));
-        hasher.update(self.presets.join(","));
-        hasher.update(self.min_length.map(|l| l.to_string()).unwrap_or_default());
-        hasher.update(self.max_length.map(|l| l.to_string()).unwrap_or_default());
-        hasher.update(if self.strict { "1" } else { "0" });
-        hasher.update(if self.normalize_url { "1" } else { "0" });
-        hasher.update(if self.merge_endpoint { "1" } else { "0" });
+        hasher.update([self.subs as u8]);
+        feed_list(&mut hasher, &self.extensions);
+        feed_list(&mut hasher, &self.exclude_extensions);
+        feed_list(&mut hasher, &self.patterns);
+        feed_list(&mut hasher, &self.exclude_patterns);
+        feed_list(&mut hasher, &self.presets);
+        feed(
+            &mut hasher,
+            self.min_length
+                .map(|l| l.to_string())
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            self.max_length
+                .map(|l| l.to_string())
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        hasher.update([self.strict as u8]);
+        hasher.update([self.normalize_url as u8]);
+        hasher.update([self.merge_endpoint as u8]);
 
         hasher
             .finalize()
@@ -491,6 +526,57 @@ mod tests {
 
         assert_eq!(key1.providers, key2.providers);
         assert_eq!(format!("{}", key1), format!("{}", key2));
+    }
+
+    #[test]
+    fn test_cache_filters_hash_no_field_boundary_collision() {
+        // presets=["a"] + min_length=Some(1) must NOT hash the same as
+        // presets=["a1"] + min_length=None (the old concatenation collided).
+        let base = CacheFilters {
+            subs: false,
+            extensions: vec![],
+            exclude_extensions: vec![],
+            patterns: vec![],
+            exclude_patterns: vec![],
+            presets: vec![],
+            min_length: None,
+            max_length: None,
+            strict: false,
+            normalize_url: false,
+            merge_endpoint: false,
+        };
+        let a = CacheFilters {
+            presets: vec!["a".to_string()],
+            min_length: Some(1),
+            ..base.clone()
+        };
+        let b = CacheFilters {
+            presets: vec!["a1".to_string()],
+            min_length: None,
+            ..base.clone()
+        };
+        assert_ne!(a.compute_hash(), b.compute_hash());
+    }
+
+    #[test]
+    fn test_cache_key_no_field_boundary_collision() {
+        let filters = CacheFilters {
+            subs: false,
+            extensions: vec![],
+            exclude_extensions: vec![],
+            patterns: vec![],
+            exclude_patterns: vec![],
+            presets: vec![],
+            min_length: None,
+            max_length: None,
+            strict: false,
+            normalize_url: false,
+            merge_endpoint: false,
+        };
+        // domain "ab" + provider "c" vs domain "a" + provider "bc".
+        let k1 = CacheKey::new("ab", &["c".to_string()], &filters);
+        let k2 = CacheKey::new("a", &["bc".to_string()], &filters);
+        assert_ne!(format!("{}", k1), format!("{}", k2));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -233,6 +233,12 @@ pub struct Args {
     #[clap(long, default_value = "true")]
     pub strict: bool,
 
+    /// Disable host validation entirely (keep every URL a provider returns,
+    /// regardless of host). Convenience inverse of `--strict`; wins over it.
+    #[clap(help_heading = "Filter Options")]
+    #[clap(long)]
+    pub no_strict: bool,
+
     /// Control which components network settings apply to (all, providers, testers, or providers,testers)
     #[clap(help_heading = "Network Options")]
     #[clap(long, default_value = "all", value_parser = validate_network_scope)]
@@ -392,6 +398,40 @@ fn parse_domain_line(line: &str) -> Option<String> {
     }
 }
 
+/// Reduce a user-supplied target to a bare host. People routinely paste a full
+/// URL (`https://example.com/path?q=1`) or `example.com/` as the target; left
+/// as-is those produce a malformed provider query (`url=https://example.com/...`)
+/// that silently returns nothing. We strip any scheme, path, query, and
+/// fragment and lowercase the host. Returns `None` when nothing host-like
+/// remains. `www.` is intentionally preserved (it can be a distinct host).
+pub fn normalize_domain(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // A pasted full URL: let the URL parser pull out the host. This branch is
+    // authoritative — a `://` means the input is meant as a URL, so if it has
+    // no parseable host we return None rather than mis-reading the scheme.
+    if trimmed.contains("://") {
+        return url::Url::parse(trimmed)
+            .ok()
+            .and_then(|u| u.host_str().map(|h| h.to_lowercase()));
+    }
+    // Otherwise drop a scheme-relative prefix and anything from the first
+    // path/query/fragment separator onward.
+    let host = trimmed
+        .trim_start_matches("//")
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_end_matches('.');
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.to_lowercase())
+}
+
 impl Args {
     /// Parse `--rate-limit-by` entries into a `provider_id -> requests/sec`
     /// map. Malformed entries are dropped and reported via `parse_errors`
@@ -413,6 +453,13 @@ impl Args {
             }
         }
         map
+    }
+
+    /// Effective host-validation setting. `--no-strict` wins over `--strict`,
+    /// so users can disable filtering with the natural flag instead of the
+    /// unusual `--strict false`.
+    pub fn strict_enabled(&self) -> bool {
+        self.strict && !self.no_strict
     }
 
     /// Check if robots.txt discovery should be used
@@ -626,6 +673,49 @@ mod tests {
         assert_eq!(args.files.len(), 2);
         assert_eq!(args.files[0].to_str().unwrap(), "file1.txt");
         assert_eq!(args.files[1].to_str().unwrap(), "file2.warc");
+    }
+
+    #[test]
+    fn test_normalize_domain() {
+        assert_eq!(
+            normalize_domain("example.com").as_deref(),
+            Some("example.com")
+        );
+        assert_eq!(
+            normalize_domain("https://example.com/path?q=1#frag").as_deref(),
+            Some("example.com")
+        );
+        assert_eq!(
+            normalize_domain("http://www.example.com/").as_deref(),
+            Some("www.example.com")
+        );
+        assert_eq!(
+            normalize_domain("example.com/foo").as_deref(),
+            Some("example.com")
+        );
+        assert_eq!(
+            normalize_domain("  EXAMPLE.com.  ").as_deref(),
+            Some("example.com")
+        );
+        assert_eq!(
+            normalize_domain("//cdn.example.com/x").as_deref(),
+            Some("cdn.example.com")
+        );
+        assert_eq!(normalize_domain(""), None);
+        assert_eq!(normalize_domain("   "), None);
+        assert_eq!(normalize_domain("https://"), None);
+    }
+
+    #[test]
+    fn test_strict_enabled() {
+        let args = Args::parse_from(["urx", "example.com"]);
+        assert!(args.strict_enabled()); // default on
+
+        let args = Args::parse_from(["urx", "example.com", "--no-strict"]);
+        assert!(!args.strict_enabled()); // --no-strict wins
+
+        let args = Args::parse_from(["urx", "example.com", "--strict", "true", "--no-strict"]);
+        assert!(!args.strict_enabled()); // --no-strict still wins over --strict true
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -723,6 +723,7 @@ mod tests {
             min_length: None,
             max_length: None,
             strict: true,
+            no_strict: false,
             network_scope: "all".to_string(),
             proxy: None,
             proxy_auth: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,9 +157,16 @@ fn collect_domains(args: &Args) -> Result<Vec<String>> {
         domains.extend(read_domains_from_stdin()?);
     }
 
+    // Reduce each target to a bare host so a pasted full URL or trailing path
+    // doesn't silently corrupt provider queries (a common copy/paste footgun).
+    let mut normalized: Vec<String> = domains
+        .iter()
+        .filter_map(|d| cli::normalize_domain(d))
+        .collect();
+
     let mut seen = std::collections::HashSet::new();
-    domains.retain(|d| seen.insert(d.clone()));
-    Ok(domains)
+    normalized.retain(|d| seen.insert(d.clone()));
+    Ok(normalized)
 }
 
 /// Parse API keys from environment variable (comma-separated) and combine with CLI keys
@@ -592,21 +599,40 @@ fn apply_url_filters(
     let mut sorted_urls = url_filter.apply_filters(urls);
 
     // Apply host validation if strict mode is enabled and we have domains (not from file)
-    if args.strict && args.files.is_empty() {
+    if args.strict_enabled() && args.files.is_empty() {
         if args.verbose && !args.silent {
             println!("Enforcing strict host validation...");
         }
-        // Re-resolve the original domain list. We can't read stdin a second
-        // time, so the host validator falls back to whatever positional args
-        // and --domain-list files supplied.
+        // Re-resolve the original domain list, normalized the same way as the
+        // fetch targets so the validator's hosts line up with what was queried.
+        // We can't read stdin a second time, so this falls back to whatever
+        // positional args and --domain-list files supplied.
         let mut domains: Vec<String> = args.domains.clone();
         for path in &args.domain_list {
             domains.extend(read_domains_from_file(path)?);
         }
+        let domains: Vec<String> = domains
+            .iter()
+            .filter_map(|d| cli::normalize_domain(d))
+            .collect();
 
         if !domains.is_empty() {
+            let before = sorted_urls.len();
             let host_validator = HostValidator::new(&domains, args.subs);
             sorted_urls.retain(|url| host_validator.is_valid_host(url));
+            let removed = before - sorted_urls.len();
+
+            // When validation discards most (or all) of what providers returned,
+            // a quiet, much-smaller result looks like a broken provider. Surface
+            // a single hint (even without -v; --silent still suppresses it). The
+            // most common cause is www.<domain> captures under a bare apex query.
+            let drops_most = before > 0 && (sorted_urls.is_empty() || removed * 2 > before);
+            if drops_most && !args.silent && !args.subs {
+                eprintln!(
+                    "[urx] strict host validation removed {removed}/{before} URLs; \
+                     pass --subs to keep subdomains (incl. www.) or --no-strict to keep all hosts"
+                );
+            }
 
             if args.verbose && !args.silent {
                 println!(
@@ -728,7 +754,7 @@ fn create_cache_key(domain: &str, args: &Args) -> CacheKey {
         presets: args.preset.clone(),
         min_length: args.min_length,
         max_length: args.max_length,
-        strict: args.strict,
+        strict: args.strict_enabled(),
         normalize_url: args.normalize_url,
         merge_endpoint: args.merge_endpoint,
     };
@@ -1656,6 +1682,7 @@ mod tests {
             min_length: None,
             max_length: None,
             strict: true, // Default strict mode enabled
+            no_strict: false,
             network_scope: "all".to_string(),
             proxy: None,
             proxy_auth: None,
@@ -1920,6 +1947,7 @@ mod tests {
             min_length: None,
             max_length: None,
             strict: false,
+            no_strict: false,
             network_scope: "all".to_string(),
             proxy: None,
             proxy_auth: None,
@@ -2041,6 +2069,7 @@ mod tests {
             min_length: None,
             max_length: None,
             strict: true,
+            no_strict: false,
             network_scope: "all".to_string(),
             proxy: None,
             proxy_auth: None,

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -12,7 +12,7 @@ use crate::providers::Provider;
 pub struct RobotsProvider {
     timeout: Duration,
     retries: u32,
-    user_agent: Option<String>,
+    random_agent: bool,
     proxy: Option<String>,
     proxy_auth: Option<String>,
     insecure: bool,
@@ -27,7 +27,7 @@ impl RobotsProvider {
         Self {
             timeout: Duration::from_secs(30),
             retries: 3,
-            user_agent: None,
+            random_agent: false,
             proxy: None,
             proxy_auth: None,
             insecure: false,
@@ -54,35 +54,16 @@ impl RobotsProvider {
         HttpClientConfig {
             timeout: self.timeout.as_secs(),
             insecure: self.insecure,
-            random_agent: false, // user_agent is handled separately
+            random_agent: self.random_agent,
             proxy: self.proxy.clone(),
             proxy_auth: self.proxy_auth.clone(),
         }
     }
 
+    /// Build the HTTP client via the shared config so it always sends a
+    /// User-Agent (a UA-less request is rejected with 400 by some servers).
     fn build_client(&self) -> Result<Client> {
-        let config = self.client_config();
-        let mut builder = Client::builder()
-            .timeout(Duration::from_secs(config.timeout))
-            .danger_accept_invalid_certs(config.insecure);
-
-        if let Some(ref proxy_url) = config.proxy {
-            let mut proxy = reqwest::Proxy::all(proxy_url)?;
-
-            if let Some(ref auth) = config.proxy_auth {
-                let username = auth.split(':').next().unwrap_or("");
-                let password = auth.split(':').nth(1).unwrap_or("");
-                proxy = proxy.basic_auth(username, password);
-            }
-
-            builder = builder.proxy(proxy);
-        }
-
-        if let Some(ref agent) = self.user_agent {
-            builder = builder.user_agent(agent);
-        }
-
-        Ok(builder.build()?)
+        self.client_config().build_client()
     }
 }
 
@@ -175,11 +156,7 @@ impl Provider for RobotsProvider {
         self.retries = count;
     }
     fn with_random_agent(&mut self, enabled: bool) {
-        if enabled {
-            self.user_agent = Some(crate::network::random_user_agent());
-        } else {
-            self.user_agent = None;
-        }
+        self.random_agent = enabled;
     }
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
@@ -197,7 +174,7 @@ mod tests {
         let provider = RobotsProvider::new();
         assert_eq!(provider.timeout, Duration::from_secs(30));
         assert_eq!(provider.retries, 3);
-        assert_eq!(provider.user_agent, None);
+        assert!(!provider.random_agent);
         assert_eq!(provider.proxy, None);
         assert_eq!(provider.proxy_auth, None);
         assert!(!provider.insecure);
@@ -240,16 +217,11 @@ mod tests {
     fn test_with_random_agent() {
         let mut provider = RobotsProvider::new();
         provider.with_random_agent(true);
-        assert!(provider.user_agent.is_some());
-        assert!(provider
-            .user_agent
-            .as_ref()
-            .unwrap()
-            .starts_with("Mozilla/5.0"));
+        assert!(provider.random_agent);
 
         // Test disabling the random agent
         provider.with_random_agent(false);
-        assert_eq!(provider.user_agent, None);
+        assert!(!provider.random_agent);
     }
 
     #[test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -3,6 +3,7 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 use reqwest::Client;
 use roxmltree::Document;
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
@@ -10,11 +11,19 @@ use std::time::Duration;
 use crate::network::client::HttpClientConfig;
 use crate::providers::Provider;
 
+/// Max nesting depth for sitemap-index → sitemap recursion. A hostile or
+/// misconfigured index can chain or cycle indefinitely; this bounds it.
+const MAX_SITEMAP_DEPTH: usize = 10;
+
+/// Overall cap on URLs collected from one domain's sitemaps, so a giant (or
+/// adversarial) sitemap tree can't grow memory without bound.
+const MAX_SITEMAP_URLS: usize = 1_000_000;
+
 #[derive(Clone)]
 pub struct SitemapProvider {
     timeout: Duration,
     retries: u32,
-    user_agent: Option<String>,
+    random_agent: bool,
     proxy: Option<String>,
     proxy_auth: Option<String>,
     insecure: bool,
@@ -25,7 +34,7 @@ impl SitemapProvider {
         Self {
             timeout: Duration::from_secs(30),
             retries: 3,
-            user_agent: None,
+            random_agent: false,
             proxy: None,
             proxy_auth: None,
             insecure: false,
@@ -36,39 +45,39 @@ impl SitemapProvider {
         HttpClientConfig {
             timeout: self.timeout.as_secs(),
             insecure: self.insecure,
-            random_agent: false, // user_agent is handled separately
+            random_agent: self.random_agent,
             proxy: self.proxy.clone(),
             proxy_auth: self.proxy_auth.clone(),
         }
     }
 
+    /// Build the HTTP client via the shared config so it always sends a
+    /// User-Agent (a UA-less request is rejected with 400 by some servers).
     fn build_client(&self) -> Result<Client> {
-        let config = self.client_config();
-        let mut builder = Client::builder()
-            .timeout(Duration::from_secs(config.timeout))
-            .danger_accept_invalid_certs(config.insecure);
-
-        if let Some(ref proxy_url) = config.proxy {
-            let mut proxy = reqwest::Proxy::all(proxy_url)?;
-
-            if let Some(ref auth) = config.proxy_auth {
-                let username = auth.split(':').next().unwrap_or("");
-                let password = auth.split(':').nth(1).unwrap_or("");
-                proxy = proxy.basic_auth(username, password);
-            }
-
-            builder = builder.proxy(proxy);
-        }
-
-        if let Some(ref agent) = self.user_agent {
-            builder = builder.user_agent(agent);
-        }
-
-        Ok(builder.build()?)
+        self.client_config().build_client()
     }
 
+    /// Recursively fetch and parse a sitemap (or sitemap index).
+    ///
+    /// `visited` records already-fetched sitemap URLs to break cycles
+    /// (`A → A`, `A → B → A`); `depth` bounds straight-line nesting; and the
+    /// caller stops feeding work once [`MAX_SITEMAP_URLS`] is reached. Together
+    /// these stop a malicious sitemap from hanging the run or exhausting memory.
     #[async_recursion]
-    async fn parse_sitemap(client: &Client, sitemap_url: &str) -> Result<Vec<String>> {
+    async fn parse_sitemap(
+        client: &Client,
+        sitemap_url: &str,
+        depth: usize,
+        visited: &mut HashSet<String>,
+    ) -> Result<Vec<String>> {
+        if depth > MAX_SITEMAP_DEPTH {
+            return Ok(Vec::new());
+        }
+        // A sitemap URL we've already fetched in this walk is a cycle — skip it.
+        if !visited.insert(sitemap_url.to_string()) {
+            return Ok(Vec::new());
+        }
+
         let resp = client.get(sitemap_url).send().await?;
         if !resp.status().is_success() {
             return Ok(Vec::new());
@@ -85,15 +94,22 @@ impl SitemapProvider {
                 if is_sitemap_index {
                     // This is a sitemap index file, so we need to process each sitemap
                     for sitemap_node in doc.descendants().filter(|n| n.has_tag_name("sitemap")) {
+                        if urls.len() >= MAX_SITEMAP_URLS {
+                            break;
+                        }
                         if let Some(loc_node) =
                             sitemap_node.descendants().find(|n| n.has_tag_name("loc"))
                         {
                             if let Some(nested_sitemap_url) = loc_node.text() {
-                                // Recursively fetch and parse nested sitemaps
-                                // Box::pin the future to avoid infinitely sized futures
-                                let nested_urls =
-                                    Box::pin(Self::parse_sitemap(client, nested_sitemap_url))
-                                        .await?;
+                                // Recursively fetch and parse nested sitemaps.
+                                // Box::pin the future to avoid infinitely sized futures.
+                                let nested_urls = Box::pin(Self::parse_sitemap(
+                                    client,
+                                    nested_sitemap_url,
+                                    depth + 1,
+                                    visited,
+                                ))
+                                .await?;
                                 urls.extend(nested_urls);
                             }
                         }
@@ -101,6 +117,9 @@ impl SitemapProvider {
                 } else {
                     // This is a regular sitemap file
                     for url_node in doc.descendants().filter(|n| n.has_tag_name("url")) {
+                        if urls.len() >= MAX_SITEMAP_URLS {
+                            break;
+                        }
                         if let Some(loc_node) =
                             url_node.descendants().find(|n| n.has_tag_name("loc"))
                         {
@@ -114,6 +133,9 @@ impl SitemapProvider {
             Err(_) => {
                 // If XML parsing fails, try to handle it as a text file (some sitemaps are just lists of URLs)
                 for line in content.lines() {
+                    if urls.len() >= MAX_SITEMAP_URLS {
+                        break;
+                    }
                     let line = line.trim();
                     if line.starts_with("http") {
                         urls.push(line.to_string());
@@ -139,6 +161,9 @@ impl Provider for SitemapProvider {
         Box::pin(async move {
             let client = self.build_client()?;
             let mut urls = Vec::new();
+            // Shared across all candidate locations so a sitemap reachable from
+            // more than one entry point is fetched at most once.
+            let mut visited = HashSet::new();
 
             // Try common sitemap locations
             let sitemap_urls = vec![
@@ -156,7 +181,8 @@ impl Provider for SitemapProvider {
                 if let Ok(resp) = resp {
                     if resp.status().is_success() {
                         // Found a valid sitemap, parse it
-                        let sitemap_urls = Self::parse_sitemap(&client, &sitemap_url).await?;
+                        let sitemap_urls =
+                            Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited).await?;
                         urls.extend(sitemap_urls);
                     }
                 }
@@ -180,11 +206,7 @@ impl Provider for SitemapProvider {
         self.retries = count;
     }
     fn with_random_agent(&mut self, enabled: bool) {
-        if enabled {
-            self.user_agent = Some(crate::network::random_user_agent());
-        } else {
-            self.user_agent = None;
-        }
+        self.random_agent = enabled;
     }
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
@@ -203,7 +225,7 @@ mod tests {
         let provider = SitemapProvider::new();
         assert_eq!(provider.timeout, Duration::from_secs(30));
         assert_eq!(provider.retries, 3);
-        assert_eq!(provider.user_agent, None);
+        assert!(!provider.random_agent);
         assert_eq!(provider.proxy, None);
         assert_eq!(provider.proxy_auth, None);
         assert!(!provider.insecure);
@@ -244,15 +266,9 @@ mod tests {
     fn test_with_random_agent() {
         let mut provider = SitemapProvider::new();
         provider.with_random_agent(true);
-        assert!(provider.user_agent.is_some());
-        assert!(provider
-            .user_agent
-            .as_ref()
-            .unwrap()
-            .starts_with("Mozilla/5.0"));
-        // Disabling should reset UA to None
+        assert!(provider.random_agent);
         provider.with_random_agent(false);
-        assert_eq!(provider.user_agent, None);
+        assert!(!provider.random_agent);
     }
 
     #[test]
@@ -429,6 +445,36 @@ mod tests {
         let urls = result.unwrap();
         assert_eq!(urls.len(), 1);
         assert!(urls.contains(&"https://example.com/nested-page".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_sitemap_index_self_cycle_terminates() {
+        // A sitemap index that references itself must not loop forever.
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+
+        let self_ref_index = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://{host}/sitemap_index.xml</loc></sitemap>
+</sitemapindex>"#
+        );
+
+        // Allow many hits; the cycle guard should make far fewer (ideally 1-2).
+        let _m = server
+            .mock("GET", "/sitemap_index.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(self_ref_index)
+            .expect_at_most(5)
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        // Completing at all (not hanging) is the assertion.
+        let result = provider.fetch_urls(&host).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

A codebase-wide analysis (after the Wayback work) surfaced several **silently-broken or unsafe** behaviors. This PR fixes the verified, low-risk ones. Each was confirmed against the source before changing.

### Correctness
- **Cache key collisions.** `CacheKey`/`CacheFilters` hashed fields by raw concatenation, so distinct configs could collide and **share cache entries** — e.g. `presets=["a"] + min_length=Some(1)` hashed the same as `presets=["a1"] + min_length=None`, and domain `"ab"`+provider `"c"` == domain `"a"`+provider `"bc"`. Now every field is fed **length-prefixed**.

### Reliability / safety
- **Sitemap & Robots now always send a User-Agent.** Both built their own client and sent no UA by default — the exact gap the recent hardening closed elsewhere (a UA-less request is rejected with `400` by some servers). They now use the shared `HttpClientConfig::build_client` (also removes two duplicated builder blocks).
- **Sitemap recursion guard.** Recursive sitemap-index parsing had no bound. A self-referencing (`A→A`) or cyclic (`A→B→A`) index could recurse/fetch forever. Added a depth limit, a visited-set cycle break, and an overall URL cap.

### UX
- **`--no-strict`.** Disabling host validation required the unusual `--strict false`; `--no-strict` is the natural inverse and wins over `--strict`.
- **Warn on heavy validation drop.** When strict host validation removes most/all collected URLs (commonly `www.<apex>` for a bare apex query), urx now prints a one-line stderr hint suggesting `--subs`/`--no-strict`, so a filtered-to-empty result isn't mistaken for a broken provider.
- **Domain normalization.** Positional/file targets are reduced to a bare host (scheme/path/query stripped), so pasting `https://example.com/path` no longer silently yields zero results. Validator host lists are normalized the same way to stay consistent with what was queried.

## Testing
- 437 tests pass (incl. new tests: cache collision regression, sitemap self-cycle termination, `normalize_domain`, `strict_enabled`); clippy + rustfmt clean.

## Notes
- The cache-hash change invalidates pre-existing cache entries (they simply miss and re-fetch once) — intended.
- Deferred to a focused follow-up (higher-risk / product decisions): enforcing `--rate-limit`/`--rate-limit-by` (currently a no-op; touches all providers + timing tests), pagination for CommonCrawl/urlscan/ZoomEye/GitHub, reusing the HTTP client in testers, and VT v2→v3.