### PR TITLE
Round 3 hardening: pagination, rate limiting, key safety, output & host-scope fixes

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,7 +28,7 @@ pub struct Args {
     /// merged with positional DOMAINS and stdin. Blank lines and `#` comments
     /// are ignored.
     #[clap(help_heading = "Input Options")]
-    #[clap(long = "domain-list", alias = "dL", visible_alias = "--dL", action = clap::ArgAction::Append, value_parser)]
+    #[clap(long = "domain-list", visible_alias = "dL", action = clap::ArgAction::Append, value_parser)]
     pub domain_list: Vec<PathBuf>,
 
     #[clap(help_heading = "Output Options")]
@@ -41,12 +41,7 @@ pub struct Args {
     /// stdout. The directory is created if missing. The extension matches
     /// --format (`json`, `csv`, or `txt` for plain).
     #[clap(help_heading = "Output Options")]
-    #[clap(
-        long = "output-dir",
-        alias = "oD",
-        visible_alias = "--oD",
-        value_parser
-    )]
+    #[clap(long = "output-dir", visible_alias = "oD", value_parser)]
     pub output_dir: Option<PathBuf>,
 
     /// Output format (e.g., "plain", "json", "csv")
@@ -301,17 +296,17 @@ pub struct Args {
 
     /// Check HTTP status code of collected URLs
     #[clap(help_heading = "Testing Options")]
-    #[clap(long, alias = "cs", visible_alias = "--cs")]
+    #[clap(long, visible_alias = "cs")]
     pub check_status: bool,
 
     /// Include URLs with specific HTTP status codes or patterns (e.g., --is=200,30x)
     #[clap(help_heading = "Testing Options")]
-    #[clap(long, alias = "is", visible_alias = "--is")]
+    #[clap(long, visible_alias = "is")]
     pub include_status: Vec<String>,
 
     /// Exclude URLs with specific HTTP status codes or patterns (e.g., --es=404,50x,5xx)
     #[clap(help_heading = "Testing Options")]
-    #[clap(long, alias = "es", visible_alias = "--es")]
+    #[clap(long, visible_alias = "es")]
     pub exclude_status: Vec<String>,
 
     /// Extract additional links from collected URLs (requires HTTP requests)

--- a/src/filters/host_validation.rs
+++ b/src/filters/host_validation.rs
@@ -40,10 +40,20 @@ impl HostValidator {
                     return true;
                 }
 
-                // If subdomains are allowed, check if the host is a subdomain of any of our domains
                 if self.include_subdomains {
+                    // If subdomains are allowed, accept any subdomain of a target.
                     for domain in &self.domains {
                         if host_stripped.ends_with(&format!(".{domain}")) {
+                            return true;
+                        }
+                    }
+                } else {
+                    // Even in strict (apex-only) mode, treat the conventional
+                    // `www.` host as the apex itself: a site served entirely on
+                    // www.<domain> must not return zero results for a bare
+                    // `<domain>` query. Other subdomains still require --subs.
+                    for domain in &self.domains {
+                        if host_stripped == format!("www.{domain}") {
                             return true;
                         }
                     }
@@ -89,6 +99,21 @@ mod tests {
 
         // Subdomains should not be valid with default settings
         assert!(!validator.is_valid_host("https://sub.example.com/path"));
+    }
+
+    #[test]
+    fn test_www_treated_as_apex_in_strict_mode() {
+        let domains = vec!["example.com".to_string()];
+        let validator = HostValidator::new(&domains, false); // strict, no --subs
+
+        // www counts as the apex...
+        assert!(validator.is_valid_host("https://www.example.com/path"));
+        assert!(validator.is_valid_host("https://example.com/path"));
+        // ...but other subdomains still require --subs.
+        assert!(!validator.is_valid_host("https://blog.example.com/path"));
+        assert!(!validator.is_valid_host("https://api.example.com/path"));
+        // a www-of-www is a sub-subdomain, not the apex.
+        assert!(!validator.is_valid_host("https://www.www.example.com/path"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,13 +624,14 @@ fn apply_url_filters(
 
             // When validation discards most (or all) of what providers returned,
             // a quiet, much-smaller result looks like a broken provider. Surface
-            // a single hint (even without -v; --silent still suppresses it). The
-            // most common cause is www.<domain> captures under a bare apex query.
+            // a single hint (even without -v; --silent still suppresses it). With
+            // www. already kept as the apex, the usual remaining cause is other
+            // subdomains under a bare apex query.
             let drops_most = before > 0 && (sorted_urls.is_empty() || removed * 2 > before);
             if drops_most && !args.silent && !args.subs {
                 eprintln!(
                     "[urx] strict host validation removed {removed}/{before} URLs; \
-                     pass --subs to keep subdomains (incl. www.) or --no-strict to keep all hosts"
+                     pass --subs to keep subdomains or --no-strict to keep all hosts"
                 );
             }
 

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -74,6 +74,18 @@ impl HttpClientConfig {
     }
 }
 
+/// Parse a `Retry-After` response header into a sleep duration so a throttled
+/// request waits as long as the server asked before retrying. Only the
+/// delta-seconds form (the common API case, e.g. `Retry-After: 30`) is honored;
+/// the HTTP-date form returns `None` and the caller falls back to its normal
+/// back-off. The value is capped so a hostile or absurd header can't stall a run.
+pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    const MAX_RETRY_AFTER_SECS: u64 = 60;
+    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    let secs: u64 = raw.trim().parse().ok()?;
+    Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
+}
+
 /// Execute an HTTP GET request with retry and exponential back-off.
 ///
 /// `max_retries` is the number of **additional** attempts after the first
@@ -133,6 +145,36 @@ pub async fn get_with_retry(client: &Client, url: &str, max_retries: u32) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_retry_after_delay_parses_seconds() {
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("30"));
+        assert_eq!(retry_after_delay(&headers), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_retry_after_delay_caps_large_values() {
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("100000"));
+        assert_eq!(retry_after_delay(&headers), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn test_retry_after_delay_ignores_http_date_and_missing() {
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+        let empty = HeaderMap::new();
+        assert_eq!(retry_after_delay(&empty), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
+        );
+        assert_eq!(retry_after_delay(&headers), None);
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,8 +4,10 @@
 // across different parts of the application, such as providers and testers.
 
 pub mod client;
+mod rate_limiter;
 mod settings;
 pub mod user_agent;
 
+pub use rate_limiter::RateLimiter;
 pub use settings::{NetworkScope, NetworkSettings};
 pub use user_agent::{default_user_agent, random_user_agent};

--- a/src/network/rate_limiter.rs
+++ b/src/network/rate_limiter.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+/// Minimum-interval rate limiter that paces a provider's HTTP requests.
+///
+/// Built from a requests-per-second rate; each [`RateLimiter::acquire`] blocks
+/// until at least `1/rate` seconds have elapsed since the previous acquire, so
+/// requests go out no faster than the configured rate. Cloning shares the same
+/// timestamp, so every request paced by a given limiter is throttled together.
+///
+/// Providers build one per `fetch_urls` call and `acquire()` before each
+/// request, which paces a domain's (often paginated) requests. This is what
+/// makes `--rate-limit` / `--rate-limit-by` actually take effect — previously
+/// the configured rate was stored but never enforced.
+#[derive(Clone, Debug)]
+pub struct RateLimiter {
+    last: Arc<Mutex<Option<Instant>>>,
+    min_interval: Duration,
+}
+
+impl RateLimiter {
+    /// Build a limiter for `requests_per_sec`. Returns `None` for a
+    /// non-positive or non-finite rate, i.e. "no limiting".
+    pub fn new(requests_per_sec: f32) -> Option<Self> {
+        if requests_per_sec <= 0.0 || !requests_per_sec.is_finite() {
+            return None;
+        }
+        Some(Self {
+            last: Arc::new(Mutex::new(None)),
+            min_interval: Duration::from_secs_f32(1.0 / requests_per_sec),
+        })
+    }
+
+    /// Convenience constructor from an `Option<f32>` rate, so callers can write
+    /// `RateLimiter::from_rate(self.rate_limit)`.
+    pub fn from_rate(requests_per_sec: Option<f32>) -> Option<Self> {
+        requests_per_sec.and_then(Self::new)
+    }
+
+    /// Block until issuing the next request respects the configured rate. The
+    /// lock is held across the sleep so concurrent callers queue rather than
+    /// all firing at once.
+    pub async fn acquire(&self) {
+        let mut guard = self.last.lock().await;
+        if let Some(prev) = *guard {
+            let elapsed = prev.elapsed();
+            if elapsed < self.min_interval {
+                tokio::time::sleep(self.min_interval - elapsed).await;
+            }
+        }
+        *guard = Some(Instant::now());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_non_positive_rate_disables_limiting() {
+        assert!(RateLimiter::new(0.0).is_none());
+        assert!(RateLimiter::new(-1.0).is_none());
+        assert!(RateLimiter::new(f32::NAN).is_none());
+        assert!(RateLimiter::new(f32::INFINITY).is_none());
+        assert!(RateLimiter::from_rate(None).is_none());
+        assert!(RateLimiter::from_rate(Some(5.0)).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_acquire_spaces_requests() {
+        // 20 req/s => 50ms minimum interval.
+        let limiter = RateLimiter::new(20.0).unwrap();
+        let start = Instant::now();
+        limiter.acquire().await; // first: no wait
+        limiter.acquire().await; // second: ~50ms
+        limiter.acquire().await; // third: ~50ms
+                                 // Two enforced gaps (~100ms); allow scheduler slack.
+        assert!(
+            start.elapsed() >= Duration::from_millis(90),
+            "elapsed too short: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_first_acquire_does_not_block() {
+        let limiter = RateLimiter::new(1.0).unwrap(); // 1s interval
+        let start = Instant::now();
+        limiter.acquire().await; // first acquire must be immediate
+        assert!(start.elapsed() < Duration::from_millis(200));
+    }
+}

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -121,18 +121,13 @@ impl CsvFormatter {
 
 impl Formatter for CsvFormatter {
     fn format(&self, url_data: &UrlData, _is_last: bool) -> String {
-        let escaped_url = csv_escape(&url_data.url);
-        let status_field = url_data
-            .status
-            .as_deref()
-            .map(csv_escape)
-            .unwrap_or_default();
-        if url_data.sources.is_empty() {
-            format!("{escaped_url},{status_field}\n")
-        } else {
-            let sources_field = csv_escape(&url_data.sources.join("|"));
-            format!("{escaped_url},{status_field},{sources_field}\n")
-        }
+        // Standalone row: include only the columns this entry actually has,
+        // so a single formatted row is self-consistent (no dangling commas).
+        csv_row(
+            url_data,
+            url_data.status.is_some(),
+            !url_data.sources.is_empty(),
+        )
     }
 
     fn clone_box(&self) -> Box<dyn Formatter> {
@@ -140,10 +135,52 @@ impl Formatter for CsvFormatter {
     }
 }
 
+/// Build the CSV header line for the given column layout. The `url` column is
+/// always present; `status` / `sources` are included only when the run carries
+/// that data, and the row formatter mirrors exactly the same layout so every
+/// line has an identical column count.
+pub(crate) fn csv_header(has_status: bool, has_sources: bool) -> String {
+    let mut cols = vec!["url"];
+    if has_status {
+        cols.push("status");
+    }
+    if has_sources {
+        cols.push("sources");
+    }
+    let mut line = cols.join(",");
+    line.push('\n');
+    line
+}
+
+/// Format one CSV data row for the given column layout. Must agree with
+/// [`csv_header`] on which columns are emitted so header and body stay aligned.
+pub(crate) fn csv_row(url_data: &UrlData, has_status: bool, has_sources: bool) -> String {
+    let mut fields = vec![csv_escape(&url_data.url)];
+    if has_status {
+        fields.push(
+            url_data
+                .status
+                .as_deref()
+                .map(csv_escape)
+                .unwrap_or_default(),
+        );
+    }
+    if has_sources {
+        fields.push(if url_data.sources.is_empty() {
+            String::new()
+        } else {
+            csv_escape(&url_data.sources.join("|"))
+        });
+    }
+    let mut line = fields.join(",");
+    line.push('\n');
+    line
+}
+
 /// Escape a field value for CSV output per RFC 4180.
 /// If the value contains a comma, double-quote, or newline, wrap it in
 /// double-quotes and escape any internal double-quotes by doubling them.
-fn csv_escape(value: &str) -> String {
+pub(crate) fn csv_escape(value: &str) -> String {
     if value.contains(',') || value.contains('"') || value.contains('\n') {
         let escaped = value.replace('"', "\"\"");
         format!("\"{escaped}\"")
@@ -315,9 +352,9 @@ mod tests {
     fn test_csv_formatter() {
         let formatter = CsvFormatter::new();
 
-        // Test URL without status
+        // Test URL without status: a lone url is a single column, no dangling comma
         let url_data = UrlData::new("https://example.com".to_string());
-        assert_eq!(formatter.format(&url_data, false), "https://example.com,\n");
+        assert_eq!(formatter.format(&url_data, false), "https://example.com\n");
 
         // Test URL with status
         let url_data_status =
@@ -352,7 +389,7 @@ mod tests {
         let url_data = UrlData::new("https://example.com/path?a=1,2&b=3".to_string());
         assert_eq!(
             formatter.format(&url_data, false),
-            "\"https://example.com/path?a=1,2&b=3\",\n"
+            "\"https://example.com/path?a=1,2&b=3\"\n"
         );
     }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -110,7 +110,7 @@ mod tests {
     fn test_create_outputter_csv() {
         let outputter = create_outputter("csv");
         let url_data = UrlData::new("https://example.com".to_string());
-        assert_eq!(outputter.format(&url_data, false), "https://example.com,\n");
+        assert_eq!(outputter.format(&url_data, false), "https://example.com\n");
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod tests {
         let csv_outputter = create_outputter("CSV");
         assert_eq!(
             csv_outputter.format(&url_data, false),
-            "https://example.com,\n"
+            "https://example.com\n"
         );
     }
 

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -28,14 +28,24 @@ impl Outputter for PlainOutputter {
     fn output(&self, urls: &[UrlData], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
         match output_path {
             Some(path) => {
+                // Writing to a file: suppress ANSI colour. The `colored` crate
+                // decides on color globally from stdout's TTY status, so without
+                // this a run in an interactive terminal would bake escape codes
+                // into the file. Restore auto-detection afterward so a later
+                // stdout write (e.g. --output-dir alongside stdout) stays colored.
+                colored::control::set_override(false);
                 let mut file = File::create(&path).context("Failed to create output file")?;
 
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
-                    file.write_all(formatted.as_bytes())
-                        .context("Failed to write to output file")?;
-                }
-                Ok(())
+                let result = (|| {
+                    for (i, url_data) in urls.iter().enumerate() {
+                        let formatted = self.format(url_data, i == urls.len() - 1);
+                        file.write_all(formatted.as_bytes())
+                            .context("Failed to write to output file")?;
+                    }
+                    Ok(())
+                })();
+                colored::control::unset_override();
+                result
             }
             None => {
                 if silent {
@@ -126,22 +136,20 @@ impl Outputter for CsvOutputter {
     }
 
     fn output(&self, urls: &[UrlData], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
+        // Decide the column layout once for the whole run so the header and
+        // every row emit exactly the same columns (otherwise rows could carry a
+        // trailing/extra comma the header doesn't, breaking strict CSV parsers).
         let has_status = urls.iter().any(|url| url.status.is_some());
         let has_sources = urls.iter().any(|url| !url.sources.is_empty());
-        let header: &[u8] = match (has_status, has_sources) {
-            (false, false) => b"url\n",
-            (true, false) => b"url,status\n",
-            (false, true) => b"url,status,sources\n",
-            (true, true) => b"url,status,sources\n",
-        };
+        let header = super::formatter::csv_header(has_status, has_sources);
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
-                file.write_all(header)
+                file.write_all(header.as_bytes())
                     .context("Failed to write CSV header")?;
 
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
+                for url_data in urls {
+                    let formatted = super::formatter::csv_row(url_data, has_status, has_sources);
                     file.write_all(formatted.as_bytes())
                         .context("Failed to write to output file")?;
                 }
@@ -153,10 +161,10 @@ impl Outputter for CsvOutputter {
                     return Ok(());
                 };
 
-                print!("{}", std::str::from_utf8(header).unwrap_or(""));
+                print!("{header}");
 
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
+                for url_data in urls {
+                    let formatted = super::formatter::csv_row(url_data, has_status, has_sources);
                     print!("{formatted}");
                 }
 
@@ -208,7 +216,7 @@ mod tests {
     fn test_csv_outputter_format() {
         let outputter = CsvOutputter::new();
         let url_data = UrlData::new("https://example.com".to_string());
-        assert_eq!(outputter.format(&url_data, false), "https://example.com,\n");
+        assert_eq!(outputter.format(&url_data, false), "https://example.com\n");
 
         let url_data_status =
             UrlData::with_status("https://example.com".to_string(), "200 OK".to_string());
@@ -216,6 +224,28 @@ mod tests {
             outputter.format(&url_data_status, true),
             "https://example.com,200 OK\n"
         );
+    }
+
+    #[test]
+    fn test_csv_outputter_no_status_no_sources_single_column() -> Result<()> {
+        // Regression: a url-only run must produce a single `url` column for both
+        // header and every row (no dangling trailing comma).
+        let outputter = CsvOutputter::new();
+        let urls = vec![
+            UrlData::new("https://example.com/a".to_string()),
+            UrlData::new("https://example.com/b".to_string()),
+        ];
+        let temp_file = NamedTempFile::new()?;
+        let temp_path = temp_file.path().to_path_buf();
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
+
+        let mut content = String::new();
+        File::open(&temp_path)?.read_to_string(&mut content)?;
+        assert_eq!(
+            content,
+            "url\nhttps://example.com/a\nhttps://example.com/b\n"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -7,6 +7,7 @@ use tokio::sync::OnceCell;
 
 use super::Provider;
 use crate::network::client::{get_with_retry, HttpClientConfig};
+use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
 /// Sentinel value that asks the provider to resolve the most recent Common
@@ -203,6 +204,7 @@ impl Provider for CommonCrawlProvider {
             let index = self.effective_index().await?;
             let query_base = self.query_base(&index, domain);
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             if let Some(r) = &reporter {
                 r.detail("fetching…");
@@ -213,6 +215,9 @@ impl Provider for CommonCrawlProvider {
             // ask how many pages the query spans via `&showNumPages=true` and
             // then walk every page, or large domains are silently truncated to
             // their first block.
+            if let Some(rl) = &limiter {
+                rl.acquire().await;
+            }
             let count_url = format!("{query_base}&showNumPages=true");
             let pages = match get_with_retry(&client, &count_url, self.retries).await {
                 Ok(body) => serde_json::from_str::<CCPageInfo>(body.trim())
@@ -234,6 +239,9 @@ impl Provider for CommonCrawlProvider {
 
             let mut urls = Vec::new();
             for page in 0..pages {
+                if let Some(rl) = &limiter {
+                    rl.acquire().await;
+                }
                 let page_url = format!("{query_base}&page={page}");
                 match get_with_retry(&client, &page_url, self.retries).await {
                     Ok(text) => {

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -7,10 +7,16 @@ use tokio::sync::OnceCell;
 
 use super::Provider;
 use crate::network::client::{get_with_retry, HttpClientConfig};
+use crate::progress::ProgressReporter;
 
 /// Sentinel value that asks the provider to resolve the most recent Common
 /// Crawl index at runtime via `collinfo.json`.
 pub(crate) const LATEST_INDEX_ALIAS: &str = "latest";
+
+/// Hard ceiling on the number of CDX index pages we will fetch for one domain,
+/// mirroring the Wayback guard. At the index server's default block size this
+/// covers far more captures than any real domain has.
+const CC_MAX_PAGES: usize = 10_000;
 
 /// Validate that a Common Crawl index identifier matches the expected
 /// `CC-MAIN-YYYY-WW` shape before we splice it into a URL path. This guards
@@ -52,6 +58,14 @@ pub struct CommonCrawlProvider {
 #[derive(Deserialize)]
 struct CCRecord {
     url: String,
+}
+
+/// Response shape of a `&showNumPages=true` probe — the index server reports
+/// how many block-paginated pages a query spans. Extra fields (pageSize,
+/// blocks) are ignored.
+#[derive(Deserialize)]
+struct CCPageInfo {
+    pages: usize,
 }
 
 #[derive(Deserialize)]
@@ -154,6 +168,18 @@ impl CommonCrawlProvider {
 
         Ok(cached.clone())
     }
+
+    /// Build the index query without pagination params. `output=json` streams
+    /// one JSON record per line; `&page=N` / `&showNumPages=true` are appended
+    /// per request.
+    fn query_base(&self, index: &str, domain: &str) -> String {
+        let base_url = self.index_base_url();
+        if self.include_subdomains {
+            format!("{base_url}/{index}-index?url=*.{domain}/*&output=json")
+        } else {
+            format!("{base_url}/{index}-index?url={domain}/*&output=json")
+        }
+    }
 }
 
 impl Provider for CommonCrawlProvider {
@@ -165,32 +191,75 @@ impl Provider for CommonCrawlProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             let index = self.effective_index().await?;
-            let base_url = self.index_base_url();
-
-            let url_pattern = if self.include_subdomains {
-                format!(
-                    "{}/{}-index?url=*.{}/*&output=json",
-                    base_url, index, domain
-                )
-            } else {
-                format!("{}/{}-index?url={}/*&output=json", base_url, index, domain)
-            };
-
+            let query_base = self.query_base(&index, domain);
             let client = self.client_config().build_client()?;
-            let text = get_with_retry(&client, &url_pattern, self.retries).await?;
 
-            if text.trim().is_empty() {
-                return Ok(Vec::new());
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
             }
 
-            let mut urls = Vec::new();
+            // The Common Crawl index server block-paginates: a single request
+            // returns only the first block (historically ~15k records). We must
+            // ask how many pages the query spans via `&showNumPages=true` and
+            // then walk every page, or large domains are silently truncated to
+            // their first block.
+            let count_url = format!("{query_base}&showNumPages=true");
+            let pages = match get_with_retry(&client, &count_url, self.retries).await {
+                Ok(body) => serde_json::from_str::<CCPageInfo>(body.trim())
+                    .map(|info| info.pages)
+                    // A 200 that isn't a page-count document: fall back to a
+                    // single page rather than giving up.
+                    .unwrap_or(1),
+                // The index returns 404 for a domain with no captures. Don't
+                // hard-fail the probe; fall through to a single page=0 fetch so
+                // genuine "no data" stays an empty/`Err` result exactly as the
+                // single-request implementation produced.
+                Err(_) => 1,
+            };
 
-            // Common Crawl returns one JSON object per line
-            for line in text.lines() {
-                if let Ok(record) = serde_json::from_str::<CCRecord>(line) {
-                    urls.push(record.url);
+            if pages == 0 {
+                return Ok(Vec::new());
+            }
+            let pages = pages.min(CC_MAX_PAGES);
+
+            let mut urls = Vec::new();
+            for page in 0..pages {
+                let page_url = format!("{query_base}&page={page}");
+                match get_with_retry(&client, &page_url, self.retries).await {
+                    Ok(text) => {
+                        // Common Crawl returns one JSON object per line.
+                        for line in text.lines() {
+                            if let Ok(record) = serde_json::from_str::<CCRecord>(line) {
+                                urls.push(record.url);
+                            }
+                        }
+                        if let Some(r) = &reporter {
+                            r.detail(format!("{} URLs…", urls.len()));
+                        }
+                    }
+                    Err(e) => {
+                        // Nothing collected yet (e.g. a not-found domain whose
+                        // first page 404s) is a hard failure, matching the old
+                        // single-request behaviour. A mid-pagination failure
+                        // keeps what we have and flags the result as partial.
+                        if urls.is_empty() {
+                            return Err(e);
+                        }
+                        if let Some(r) = &reporter {
+                            r.mark_partial();
+                        }
+                        break;
+                    }
                 }
             }
 
@@ -523,6 +592,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fetch_urls_paginates_all_pages() {
+        let mut server = mockito::Server::new_async().await;
+
+        // The server reports the query spans two pages.
+        let probe = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showNumPages".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"pages": 2, "pageSize": 5, "blocks": 9}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let page0 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/a\"}")
+            .expect(1)
+            .create_async()
+            .await;
+        let page1 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/b\"}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = CommonCrawlProvider::new();
+        provider.base_url = server.url();
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/a".to_string(),
+                "https://example.com/b".to_string(),
+            ]
+        );
+        probe.assert();
+        page0.assert();
+        page1.assert();
+    }
+
+    #[tokio::test]
     async fn test_latest_alias_resolves_via_collinfo() {
         let mut server = mockito::Server::new_async().await;
 
@@ -540,6 +658,9 @@ mod tests {
             .create_async()
             .await;
 
+        // Each fetch now issues a showNumPages probe plus the page fetch, so two
+        // fetch_urls calls hit the index endpoint four times. The probe body
+        // isn't a page-count document, so the provider falls back to one page.
         let index_mock = server
             .mock("GET", "/CC-MAIN-2099-01-index")
             .match_query(mockito::Matcher::AllOf(vec![
@@ -548,7 +669,7 @@ mod tests {
             ]))
             .with_status(200)
             .with_body("{\"url\": \"https://example.com/a\"}")
-            .expect(2)
+            .expect(4)
             .create_async()
             .await;
 

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -143,10 +143,6 @@ impl Provider for GitHubProvider {
             if !self.api_key_rotator.has_keys() {
                 return Ok(Vec::new());
             }
-            let api_key = self
-                .api_key_rotator
-                .next_key()
-                .expect("Key rotator should have keys since has_keys() returned true");
 
             let client = self.client_config().build_client()?;
             let limiter = RateLimiter::from_rate(self.rate_limit);
@@ -175,6 +171,10 @@ impl Provider for GitHubProvider {
                             .await;
                     }
 
+                    // Rotate the token per attempt so a rate-limited/secondary-
+                    // limited token is retried with a different one when several
+                    // are configured.
+                    let api_key = self.api_key_rotator.next_key().unwrap_or_default();
                     if let Some(rl) = &limiter {
                         rl.acquire().await;
                     }

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -8,6 +8,7 @@ use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
 
 /// Maximum search-result pages we fetch per domain. GitHub Code Search caps
 /// at 1000 results total (10 × 100), and each page costs against a tight
@@ -139,6 +140,14 @@ impl Provider for GitHubProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             if !self.api_key_rotator.has_keys() {
                 return Ok(Vec::new());
@@ -159,6 +168,9 @@ impl Provider for GitHubProvider {
 
             let mut urls: HashSet<String> = HashSet::new();
             let mut last_error: Option<anyhow::Error> = None;
+            // Set when a page exhausts its retries, so results collected so far
+            // are reported as a truncated/partial crawl rather than a clean run.
+            let mut truncated = false;
 
             'pages: for page in 1..=MAX_PAGES {
                 let url =
@@ -208,6 +220,7 @@ impl Provider for GitHubProvider {
                                 last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                                 attempt += 1;
                                 if attempt > self.retries {
+                                    truncated = true;
                                     break 'pages;
                                 }
                                 continue;
@@ -238,6 +251,7 @@ impl Provider for GitHubProvider {
                                     ));
                                     attempt += 1;
                                     if attempt > self.retries {
+                                        truncated = true;
                                         break 'pages;
                                     }
                                     continue;
@@ -248,6 +262,7 @@ impl Provider for GitHubProvider {
                             last_error = Some(e.into());
                             attempt += 1;
                             if attempt > self.retries {
+                                truncated = true;
                                 break 'pages;
                             }
                         }
@@ -258,6 +273,13 @@ impl Provider for GitHubProvider {
             if urls.is_empty() {
                 if let Some(e) = last_error {
                     return Err(e);
+                }
+            } else if truncated {
+                // We collected some URLs but a later page exhausted its retries,
+                // so this is a partial result — flag it instead of presenting a
+                // truncated crawl as a clean success.
+                if let Some(r) = &reporter {
+                    r.mark_partial();
                 }
             }
 
@@ -366,6 +388,49 @@ mod tests {
         let p = GitHubProvider::new_with_keys(vec![]);
         let urls = p.fetch_urls("example.com").await.unwrap();
         assert!(urls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_partial_result_is_flagged_when_a_page_fails() {
+        let mut server = mockito::Server::new_async().await;
+        let body = serde_json::json!({
+            "items": [ { "text_matches": [ { "fragment": "https://example.com/login" } ] } ]
+        })
+        .to_string();
+        // Page 1 yields a URL...
+        let _p1 = server
+            .mock("GET", "/search/code")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .expect(1)
+            .create_async()
+            .await;
+        // ...but page 2 fails and exhausts retries, so the result is partial.
+        let _p2 = server
+            .mock("GET", "/search/code")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "2".into()))
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = GitHubProvider::new_with_keys(vec!["t".into()]);
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        let reporter =
+            ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ".to_string());
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        // The page-1 URL is kept...
+        assert_eq!(urls, vec!["https://example.com/login".to_string()]);
+        // ...and the lost page is surfaced as partial, not a clean success.
+        assert!(reporter.is_partial());
     }
 
     #[tokio::test]

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -196,6 +196,15 @@ impl Provider for GitHubProvider {
                                 if status.as_u16() == 422 {
                                     break 'pages;
                                 }
+                                // Honor Retry-After on primary (429) and
+                                // secondary (403) rate limits before retrying.
+                                if matches!(status.as_u16(), 429 | 403) {
+                                    if let Some(d) = crate::network::client::retry_after_delay(
+                                        response.headers(),
+                                    ) {
+                                        tokio::time::sleep(d).await;
+                                    }
+                                }
                                 last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                                 attempt += 1;
                                 if attempt > self.retries {

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 
 /// Maximum search-result pages we fetch per domain. GitHub Code Search caps
 /// at 1000 results total (10 × 100), and each page costs against a tight
@@ -148,6 +149,7 @@ impl Provider for GitHubProvider {
                 .expect("Key rotator should have keys since has_keys() returned true");
 
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             #[cfg(not(test))]
             let base = "https://api.github.com";
@@ -173,6 +175,9 @@ impl Provider for GitHubProvider {
                             .await;
                     }
 
+                    if let Some(rl) = &limiter {
+                        rl.acquire().await;
+                    }
                     let resp = client
                         .get(&url)
                         .header("Authorization", format!("Bearer {api_key}"))

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 use super::Provider;
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 
 // Helper function to deserialize null as default value for i32
 fn deserialize_null_i32<'de, D>(deserializer: D) -> Result<i32, D::Error>
@@ -167,6 +168,7 @@ impl Provider for OTXProvider {
             let mut all_urls = Vec::new();
             let mut page = 0;
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             loop {
                 let url = self.format_url(domain, page);
@@ -176,6 +178,9 @@ impl Provider for OTXProvider {
                 let mut result = None;
 
                 for attempt in 0..=self.retries {
+                    if let Some(rl) = &limiter {
+                        rl.acquire().await;
+                    }
                     match client.get(&url).send().await {
                         Ok(response) => {
                             if response.status().is_success() {

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -61,6 +61,12 @@ struct OTXUrlEntry {
 
 const OTX_RESULTS_LIMIT: u32 = 200;
 
+/// Hard ceiling on OTX pages walked for one domain. OTX paginates `has_next`,
+/// but a stuck cursor or a server that keeps reporting `has_next: true` would
+/// otherwise loop forever issuing requests. At `OTX_RESULTS_LIMIT` rows/page
+/// this still covers far more URLs than any domain has in OTX.
+const OTX_MAX_PAGES: u32 = 1_000;
+
 impl OTXProvider {
     /// Creates a new OTXProvider with default settings
     pub fn new() -> Self {
@@ -266,10 +272,28 @@ impl Provider for OTXProvider {
                 }
 
                 if let Some(otx_result) = result {
-                    all_urls.extend(otx_result.url_list.into_iter().map(|entry| entry.url));
+                    let has_next = otx_result.has_next;
+                    let page_len = otx_result.url_list.len();
 
-                    // Check for next page
-                    if !otx_result.has_next {
+                    // Keep only entries with a usable URL — OTX occasionally
+                    // returns rows with an empty `url`, which would otherwise be
+                    // emitted as blank lines.
+                    all_urls.extend(
+                        otx_result
+                            .url_list
+                            .into_iter()
+                            .map(|entry| entry.url)
+                            .filter(|url| !url.is_empty()),
+                    );
+
+                    // Stop when this page returned nothing (there is no more
+                    // data, even if the server still claims `has_next`), or when
+                    // the API reports no further pages. A full page with
+                    // `has_next` absent (some responses omit it) is treated as
+                    // "maybe more", so a single trailing empty fetch confirms the
+                    // end rather than truncating at page one.
+                    let page_full = page_len as u32 >= OTX_RESULTS_LIMIT;
+                    if page_len == 0 || (!has_next && !page_full) {
                         break;
                     }
                 } else {
@@ -280,6 +304,9 @@ impl Provider for OTXProvider {
                 }
 
                 page += 1;
+                if page >= OTX_MAX_PAGES {
+                    break;
+                }
             }
 
             Ok(all_urls)
@@ -624,6 +651,55 @@ mod tests {
         let urls = result.unwrap();
 
         assert!(urls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_terminates_on_empty_page_despite_has_next() {
+        // A misbehaving API that keeps claiming has_next:true but returns no
+        // rows must not loop forever — an empty page ends the walk.
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        let _m1 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=1",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{ "has_next": true, "url_list": [] }"#)
+            .create();
+
+        let mut provider = OTXProvider::new();
+        provider.with_base_url(url);
+
+        let result = provider.fetch_urls("example.com").await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_skips_empty_url_entries() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        let _m1 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=1",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{ "has_next": false, "url_list": [ { "url": "" }, { "url": "http://example.com/real" } ] }"#,
+            )
+            .create();
+
+        let mut provider = OTXProvider::new();
+        provider.with_base_url(url);
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["http://example.com/real".to_string()]);
     }
 
     #[tokio::test]

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -111,7 +111,13 @@ impl Provider for RobotsProvider {
                         format!("http://{domain}/robots.txt")
                     };
 
-                    let http_resp = client.get(&http_url).send().await?;
+                    // robots.txt discovery is best-effort: a transport failure
+                    // on the HTTP fallback means "no robots.txt", not a fatal
+                    // error that should sink the whole provider.
+                    let http_resp = match client.get(&http_url).send().await {
+                        Ok(resp) => resp,
+                        Err(_) => return Ok(urls),
+                    };
                     if !http_resp.status().is_success() {
                         return Ok(urls);
                     }
@@ -124,17 +130,24 @@ impl Provider for RobotsProvider {
 
             for line in text.lines() {
                 let line = line.trim();
-                if line.starts_with("Disallow:") {
-                    if let Some(path) = line.strip_prefix("Disallow:").map(|s| s.trim()) {
-                        if !path.is_empty() && path != "/" {
-                            let url = format!("{protocol}://{domain}{path}");
-                            urls.push(url);
-                        }
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                // RFC 9309: field names are case-insensitive and may carry
+                // surrounding whitespace (e.g. `Disallow :`). Split on the first
+                // colon so `Sitemap: https://…` keeps its `https://` value.
+                let Some((field, value)) = line.split_once(':') else {
+                    continue;
+                };
+                let value = value.trim();
+                match field.trim().to_ascii_lowercase().as_str() {
+                    "disallow" if !value.is_empty() && value != "/" => {
+                        urls.push(format!("{protocol}://{domain}{value}"));
                     }
-                } else if line.starts_with("Sitemap:") {
-                    if let Some(link) = line.strip_prefix("Sitemap:").map(|s| s.trim()) {
-                        urls.push(link.to_string());
+                    "sitemap" if !value.is_empty() => {
+                        urls.push(value.to_string());
                     }
+                    _ => {}
                 }
             }
 
@@ -298,6 +311,31 @@ Sitemap: https://example.com/sitemap.xml
         assert!(urls.contains(&"https://example.com/private/".to_string()));
         assert!(urls.contains(&"https://example.com/admin".to_string()));
         assert!(urls.contains(&"https://example.com/sitemap.xml".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_robots_directives_case_insensitive() {
+        let mut server = mockito::Server::new_async().await;
+        // Mixed/lower-case fields and a space before the colon — all RFC 9309
+        // legal and all previously ignored by the case-sensitive parser.
+        let robots = "user-agent: *\n\
+                      disallow: /lower/\n\
+                      DISALLOW: /upper\n\
+                      Sitemap : https://example.com/sm.xml\n";
+        let _m = server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(robots)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(server.url());
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert!(urls.contains(&"https://example.com/lower/".to_string()));
+        assert!(urls.contains(&"https://example.com/upper".to_string()));
+        assert!(urls.contains(&"https://example.com/sm.xml".to_string()));
     }
 
     #[tokio::test]

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -139,10 +139,22 @@ impl Provider for RobotsProvider {
                 let Some((field, value)) = line.split_once(':') else {
                     continue;
                 };
-                let value = value.trim();
+                // Take the first whitespace-delimited token of the value: paths
+                // and URLs never contain spaces, so this drops any trailing
+                // inline `# comment` and stray whitespace in one step.
+                let value = value.split_whitespace().next().unwrap_or("");
                 match field.trim().to_ascii_lowercase().as_str() {
                     "disallow" if !value.is_empty() && value != "/" => {
-                        urls.push(format!("{protocol}://{domain}{value}"));
+                        // Disallow entries can be match patterns, not literal
+                        // paths: skip glob (`*`) patterns and strip a trailing
+                        // `$` end-anchor so we don't emit unfetchable junk URLs.
+                        if value.contains('*') {
+                            continue;
+                        }
+                        let path = value.strip_suffix('$').unwrap_or(value);
+                        if !path.is_empty() && path != "/" {
+                            urls.push(format!("{protocol}://{domain}{path}"));
+                        }
                     }
                     "sitemap" if !value.is_empty() => {
                         urls.push(value.to_string());
@@ -336,6 +348,35 @@ Sitemap: https://example.com/sitemap.xml
         assert!(urls.contains(&"https://example.com/lower/".to_string()));
         assert!(urls.contains(&"https://example.com/upper".to_string()));
         assert!(urls.contains(&"https://example.com/sm.xml".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_robots_skips_patterns_and_strips_comments() {
+        let mut server = mockito::Server::new_async().await;
+        let robots = "User-agent: *\n\
+                      Disallow: /admin/*.php\n\
+                      Disallow: /secret$\n\
+                      Disallow: /good/\n\
+                      Sitemap: https://example.com/sm.xml # main sitemap\n";
+        let _m = server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(robots)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(server.url());
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        // Glob pattern is skipped entirely.
+        assert!(!urls.iter().any(|u| u.contains('*')), "{urls:?}");
+        // Trailing `$` anchor is stripped.
+        assert!(urls.contains(&"https://example.com/secret".to_string()));
+        assert!(urls.contains(&"https://example.com/good/".to_string()));
+        // Inline comment is removed from the Sitemap value.
+        assert!(urls.contains(&"https://example.com/sm.xml".to_string()));
+        assert!(!urls.iter().any(|u| u.contains('#')), "{urls:?}");
     }
 
     #[tokio::test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -19,6 +19,30 @@ const MAX_SITEMAP_DEPTH: usize = 10;
 /// adversarial) sitemap tree can't grow memory without bound.
 const MAX_SITEMAP_URLS: usize = 1_000_000;
 
+/// Cap on the raw bytes read from a single sitemap document. Without it, a
+/// hostile or misconfigured endpoint could stream gigabytes into memory before
+/// any URL parsing happens (the per-URL cap only bounds the *parsed* output).
+const MAX_SITEMAP_BYTES: usize = 50 * 1024 * 1024;
+
+/// Read a response body but stop after `max` bytes, so an unbounded (or
+/// deliberately huge) document can't exhaust memory. Reads incrementally via
+/// `chunk()` rather than buffering the whole body up front.
+async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        let remaining = max.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        if chunk.len() > remaining {
+            buf.extend_from_slice(&chunk[..remaining]);
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
 #[derive(Clone)]
 pub struct SitemapProvider {
     timeout: Duration,
@@ -83,7 +107,19 @@ impl SitemapProvider {
             return Ok(Vec::new());
         }
 
-        let content = resp.text().await?;
+        // Only a genuine text sitemap should fall back to line-based parsing.
+        // Decide that from the URL suffix / Content-Type *before* consuming the
+        // body, so an XML endpoint that returns an HTML error page isn't mined
+        // for stray `http` lines.
+        let is_text_sitemap = sitemap_url.to_ascii_lowercase().ends_with(".txt")
+            || resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|ct| ct.to_ascii_lowercase().contains("text/plain"))
+                .unwrap_or(false);
+
+        let content = read_body_capped(resp, MAX_SITEMAP_BYTES).await?;
         let mut urls = Vec::new();
 
         match Document::parse(&content) {
@@ -131,14 +167,18 @@ impl SitemapProvider {
                 }
             }
             Err(_) => {
-                // If XML parsing fails, try to handle it as a text file (some sitemaps are just lists of URLs)
-                for line in content.lines() {
-                    if urls.len() >= MAX_SITEMAP_URLS {
-                        break;
-                    }
-                    let line = line.trim();
-                    if line.starts_with("http") {
-                        urls.push(line.to_string());
+                // XML parse failed. Only treat it as a plain-text URL list when
+                // the source actually is text (a .txt sitemap or text/plain);
+                // otherwise this was an HTML/error page and yields no URLs.
+                if is_text_sitemap {
+                    for line in content.lines() {
+                        if urls.len() >= MAX_SITEMAP_URLS {
+                            break;
+                        }
+                        let line = line.trim();
+                        if line.starts_with("http") {
+                            urls.push(line.to_string());
+                        }
                     }
                 }
             }
@@ -498,6 +538,31 @@ mod tests {
         assert_eq!(urls.len(), 2);
         assert!(urls.contains(&"https://example.com/page1".to_string()));
         assert!(urls.contains(&"https://example.com/page2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_xml_html_error_page_not_mined() {
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+
+        // A non-XML HTML error page served where a .xml sitemap was expected.
+        // The unescaped '&' makes XML parsing fail; the http line must NOT be
+        // harvested, because the source is not a text sitemap.
+        let html = "<html>\n<p>error & oops</p>\nhttp://attacker.example/inject\n</html>";
+        let _m = server
+            .mock("GET", "/sitemap.xml")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body(html)
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        let urls = provider.fetch_urls(&host).await.unwrap();
+        assert!(
+            !urls.iter().any(|u| u.contains("attacker.example")),
+            "HTML error page was mined for URLs: {urls:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -124,7 +124,6 @@ impl UrlscanProvider {
         &self,
         client: &reqwest::Client,
         url: &str,
-        api_key: &str,
         limiter: Option<&RateLimiter>,
     ) -> Result<UrlscanResponse> {
         let mut last_error = None;
@@ -135,9 +134,12 @@ impl UrlscanProvider {
                 tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
             }
 
+            // Rotate the key per attempt so a rate-limited key is retried with a
+            // different one when several are configured.
+            let api_key = self.api_key_rotator.next_key().unwrap_or_default();
             let mut req = client.get(url);
             if !api_key.is_empty() {
-                req = req.header("API-Key", api_key);
+                req = req.header("API-Key", &api_key);
             }
 
             if let Some(rl) = limiter {
@@ -191,12 +193,6 @@ impl Provider for UrlscanProvider {
                 return Ok(Vec::new());
             }
 
-            // Get the next API key in rotation
-            let api_key = self
-                .api_key_rotator
-                .next_key()
-                .expect("Key rotator should have keys since has_keys() returned true");
-
             // Use the url crate for encoding the domain
             let encoded_domain =
                 url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
@@ -234,10 +230,7 @@ impl Provider for UrlscanProvider {
                     None => base_query.clone(),
                 };
 
-                let response = match self
-                    .fetch_page(&client, &url, &api_key, limiter.as_ref())
-                    .await
-                {
+                let response = match self.fetch_page(&client, &url, limiter.as_ref()).await {
                     Ok(resp) => resp,
                     Err(e) => {
                         // A failure on the very first page is fatal; a later
@@ -524,6 +517,41 @@ mod tests {
         assert!(result.is_ok(), "Expected success with empty API key");
         let urls = result.unwrap();
         assert_eq!(urls.len(), 0, "Expected empty URLs list with empty API key");
+    }
+
+    #[tokio::test]
+    async fn test_retry_rotates_to_next_key() {
+        let mut server = mockito::Server::new_async().await;
+        // The first key is rate-limited...
+        let k1 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Any)
+            .match_header("API-Key", "key1")
+            .with_status(429)
+            .expect(1)
+            .create_async()
+            .await;
+        // ...so the retry must use the second key, which succeeds.
+        let k2 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Any)
+            .match_header("API-Key", "key2")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"status":200,"has_more":false,"results":[{"page":{"domain":"example.com","url":"https://example.com/ok","status":"200"}}]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = UrlscanProvider::new_with_keys(vec!["key1".into(), "key2".into()]);
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["https://example.com/ok".to_string()]);
+        k1.assert();
+        k2.assert();
     }
 
     #[tokio::test]

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 
 #[derive(Clone)]
 pub struct UrlscanProvider {
@@ -124,6 +125,7 @@ impl UrlscanProvider {
         client: &reqwest::Client,
         url: &str,
         api_key: &str,
+        limiter: Option<&RateLimiter>,
     ) -> Result<UrlscanResponse> {
         let mut last_error = None;
         let mut attempt = 0;
@@ -138,6 +140,9 @@ impl UrlscanProvider {
                 req = req.header("API-Key", api_key);
             }
 
+            if let Some(rl) = limiter {
+                rl.acquire().await;
+            }
             match req.send().await {
                 Ok(response) => {
                     if !response.status().is_success() {
@@ -208,6 +213,7 @@ impl Provider for UrlscanProvider {
                 format!("https://urlscan.io/api/v1/search/?q=domain:{encoded_domain}&size=100");
 
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             // urlscan returns at most 100 results per request and signals more
             // via `has_more`; the next page is requested by passing the last
@@ -228,7 +234,10 @@ impl Provider for UrlscanProvider {
                     None => base_query.clone(),
                 };
 
-                let response = match self.fetch_page(&client, &url, &api_key).await {
+                let response = match self
+                    .fetch_page(&client, &url, &api_key, limiter.as_ref())
+                    .await
+                {
                     Ok(resp) => resp,
                     Err(e) => {
                         // A failure on the very first page is fatal; a later

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -147,9 +147,17 @@ impl UrlscanProvider {
             }
             match req.send().await {
                 Ok(response) => {
-                    if !response.status().is_success() {
+                    let status = response.status();
+                    if !status.is_success() {
+                        if status.as_u16() == 429 {
+                            if let Some(d) =
+                                crate::network::client::retry_after_delay(response.headers())
+                            {
+                                tokio::time::sleep(d).await;
+                            }
+                        }
                         attempt += 1;
-                        last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
+                        last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                         continue;
                     }
                     match response.json::<UrlscanResponse>().await {

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -50,6 +50,27 @@ struct ArchivedPage {
     status: String,
 }
 
+/// Hard ceiling on urlscan result pages walked for one domain (100 results
+/// each), so a huge or misbehaving result set can't spin indefinitely.
+const URLSCAN_MAX_PAGES: usize = 100;
+
+/// Turn a result's `sort` array into the `search_after` cursor urlscan expects:
+/// the array values rendered as a comma-separated string. Returns `None` when
+/// the result carries no sort key (so we can't page further).
+fn sort_to_search_after(sort: &[serde_json::Value]) -> Option<String> {
+    if sort.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = sort
+        .iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        })
+        .collect();
+    Some(parts.join(","))
+}
+
 impl UrlscanProvider {
     #[allow(dead_code)]
     pub fn new(api_key: String) -> Self {
@@ -95,6 +116,59 @@ impl UrlscanProvider {
             proxy_auth: self.proxy_auth.clone(),
         }
     }
+
+    /// Fetch and parse a single search page with retry/back-off. Returns the
+    /// parsed response or the last error after exhausting retries.
+    async fn fetch_page(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        api_key: &str,
+    ) -> Result<UrlscanResponse> {
+        let mut last_error = None;
+        let mut attempt = 0;
+
+        while attempt <= self.retries {
+            if attempt > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
+            }
+
+            let mut req = client.get(url);
+            if !api_key.is_empty() {
+                req = req.header("API-Key", api_key);
+            }
+
+            match req.send().await {
+                Ok(response) => {
+                    if !response.status().is_success() {
+                        attempt += 1;
+                        last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
+                        continue;
+                    }
+                    match response.json::<UrlscanResponse>().await {
+                        Ok(parsed) => return Ok(parsed),
+                        Err(e) => {
+                            attempt += 1;
+                            last_error =
+                                Some(anyhow::anyhow!("Failed to parse Urlscan response: {}", e));
+                            continue;
+                        }
+                    }
+                }
+                Err(e) => {
+                    attempt += 1;
+                    last_error = Some(e.into());
+                    continue;
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "Failed after {} attempts: {}",
+            self.retries + 1,
+            last_error.unwrap_or_else(|| anyhow::anyhow!("unknown error"))
+        ))
+    }
 }
 
 impl Provider for UrlscanProvider {
@@ -122,85 +196,78 @@ impl Provider for UrlscanProvider {
             let encoded_domain =
                 url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
 
-            // Construct the URL - use base_url in test mode
+            // Construct the base query - use base_url in test mode
             #[cfg(test)]
-            let url = format!(
+            let base_query = format!(
                 "{}/api/v1/search/?q=domain:{}&size=100",
                 self.base_url, encoded_domain
             );
 
             #[cfg(not(test))]
-            let url =
+            let base_query =
                 format!("https://urlscan.io/api/v1/search/?q=domain:{encoded_domain}&size=100");
 
             let client = self.client_config().build_client()?;
 
-            // Implement retry logic
-            let mut last_error = None;
-            let mut attempt = 0;
+            // urlscan returns at most 100 results per request and signals more
+            // via `has_more`; the next page is requested by passing the last
+            // result's `sort` values as `search_after`. The previous code never
+            // paginated, silently capping every domain at 100 URLs.
+            let mut all_urls = Vec::new();
+            let mut search_after: Option<String> = None;
+            let mut pages = 0;
 
-            while attempt <= self.retries {
-                if attempt > 0 {
-                    // Wait before retrying, with increasing backoff
-                    tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64))
-                        .await;
+            loop {
+                pages += 1;
+                if pages > URLSCAN_MAX_PAGES {
+                    break;
                 }
 
-                // Create a new request with API key header
-                let mut req = client.get(&url);
-                if !api_key.is_empty() {
-                    req = req.header("API-Key", &api_key);
-                }
+                let url = match &search_after {
+                    Some(cursor) => format!("{base_query}&search_after={cursor}"),
+                    None => base_query.clone(),
+                };
 
-                match req.send().await {
-                    Ok(response) => {
-                        // Check if response is successful
-                        if !response.status().is_success() {
-                            attempt += 1;
-                            last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
-                            continue;
-                        }
-
-                        // Parse response
-                        match response.json::<UrlscanResponse>().await {
-                            Ok(urlscan_response) => {
-                                let mut urls = Vec::new();
-                                for result in urlscan_response.results {
-                                    urls.push(result.page.url);
-                                }
-                                return Ok(urls);
-                            }
-                            Err(e) => {
-                                attempt += 1;
-                                last_error = Some(anyhow::anyhow!(
-                                    "Failed to parse Urlscan response: {}",
-                                    e
-                                ));
-                                continue;
-                            }
-                        }
-                    }
+                let response = match self.fetch_page(&client, &url, &api_key).await {
+                    Ok(resp) => resp,
                     Err(e) => {
-                        attempt += 1;
-                        last_error = Some(e.into());
-                        continue;
+                        // A failure on the very first page is fatal; a later
+                        // failure keeps the pages already collected.
+                        if all_urls.is_empty() {
+                            return Err(e);
+                        }
+                        break;
                     }
+                };
+
+                if response.results.is_empty() {
+                    break;
+                }
+
+                // Capture the cursor before consuming the results.
+                let next_cursor = response
+                    .results
+                    .last()
+                    .and_then(|r| sort_to_search_after(&r.sort));
+
+                let more = response.has_more;
+                for result in response.results {
+                    all_urls.push(result.page.url);
+                }
+
+                if !more {
+                    break;
+                }
+
+                match next_cursor {
+                    Some(cursor) => search_after = Some(cursor),
+                    // No usable cursor — can't page further without risking an
+                    // infinite loop re-requesting page one.
+                    None => break,
                 }
             }
 
-            // If we got here, all attempts failed
-            if let Some(e) = last_error {
-                Err(anyhow::anyhow!(
-                    "Failed after {} attempts: {}",
-                    self.retries + 1,
-                    e
-                ))
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed after {} attempts",
-                    self.retries + 1
-                ))
-            }
+            Ok(all_urls)
         })
     }
 
@@ -448,6 +515,50 @@ mod tests {
         assert!(result.is_ok(), "Expected success with empty API key");
         let urls = result.unwrap();
         assert_eq!(urls.len(), 0, "Expected empty URLs list with empty API key");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_paginates_with_search_after() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Page one signals more results and carries a sort cursor.
+        let page1 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Regex("size=100$".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"status":200,"has_more":true,"results":[{"page":{"domain":"example.com","url":"https://example.com/p1","status":"200"},"sort":[1700000000000,"abc"]}]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        // Page two is requested via search_after=<cursor> and ends the walk.
+        let page2 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Regex("search_after=1700000000000".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"status":200,"has_more":false,"results":[{"page":{"domain":"example.com","url":"https://example.com/p2","status":"200"},"sort":[1700000000001,"def"]}]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = UrlscanProvider::new("k".to_string());
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/p1".to_string(),
+                "https://example.com/p2".to_string(),
+            ]
+        );
+        page1.assert();
+        page2.assert();
     }
 
     #[tokio::test]

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -164,7 +164,11 @@ impl Provider for VirusTotalProvider {
                     }
                     Err(e) => {
                         attempt += 1;
-                        last_error = Some(e.into());
+                        // The VirusTotal key rides in the query string, and a
+                        // reqwest transport error renders the full request URL
+                        // in its Display output. Strip the URL so the key never
+                        // reaches stderr / logs via the surfaced error.
+                        last_error = Some(e.without_url().into());
                         continue;
                     }
                 }
@@ -300,6 +304,28 @@ mod tests {
         assert!(!provider.api_key_rotator.has_keys());
         assert_eq!(provider.api_key_rotator.key_count(), 0);
         assert_eq!(provider.api_key_rotator.current_key(), None);
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_does_not_leak_api_key() {
+        // The VirusTotal key is passed in the request URL's query string, so a
+        // transport-layer failure (which reqwest renders with the full URL)
+        // must not surface it through the returned error.
+        let mut provider = VirusTotalProvider::new_with_keys(vec!["SUPERSECRETKEY".to_string()]);
+        // Port 1 reliably refuses the connection; keep the run fast.
+        provider.with_base_url("http://127.0.0.1:1".to_string());
+        provider.with_retries(0);
+        provider.with_timeout(5);
+
+        let err = provider
+            .fetch_urls("example.com")
+            .await
+            .expect_err("connection to port 1 should fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("SUPERSECRETKEY"),
+            "API key leaked in error message: {msg}"
+        );
     }
 
     #[test]

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -142,9 +142,18 @@ impl Provider for VirusTotalProvider {
                 match client.get(&url).send().await {
                     Ok(response) => {
                         // Check if response is successful
-                        if !response.status().is_success() {
+                        let status = response.status();
+                        if !status.is_success() {
+                            // On a throttle, wait as long as the server asked.
+                            if status.as_u16() == 429 {
+                                if let Some(d) =
+                                    crate::network::client::retry_after_delay(response.headers())
+                                {
+                                    tokio::time::sleep(d).await;
+                                }
+                            }
                             attempt += 1;
-                            last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
+                            last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                             continue;
                         }
 

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -99,28 +99,9 @@ impl Provider for VirusTotalProvider {
                 return Ok(Vec::new());
             }
 
-            // Get the next API key in rotation
-            let api_key = self
-                .api_key_rotator
-                .next_key()
-                .expect("Key rotator should have keys since has_keys() returned true");
-
             // Use the url crate for encoding the domain
             let encoded_domain =
                 url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
-
-            // Construct the URL - use base_url in test mode
-            #[cfg(test)]
-            let url = format!(
-                "{}/vtapi/v2/domain/report?apikey={}&domain={}",
-                self.base_url, api_key, encoded_domain
-            );
-
-            #[cfg(not(test))]
-            let url = format!(
-                "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
-                api_key, encoded_domain
-            );
 
             let client = self.client_config().build_client()?;
             let limiter = RateLimiter::from_rate(self.rate_limit);
@@ -135,6 +116,25 @@ impl Provider for VirusTotalProvider {
                     tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64))
                         .await;
                 }
+
+                // Rotate to the next key each attempt: if a key is rate-limited
+                // or invalid, the retry uses a different one when several are
+                // configured (with a single key this is a no-op).
+                let api_key = self
+                    .api_key_rotator
+                    .next_key()
+                    .expect("Key rotator should have keys since has_keys() returned true");
+
+                #[cfg(test)]
+                let url = format!(
+                    "{}/vtapi/v2/domain/report?apikey={}&domain={}",
+                    self.base_url, api_key, encoded_domain
+                );
+                #[cfg(not(test))]
+                let url = format!(
+                    "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
+                    api_key, encoded_domain
+                );
 
                 if let Some(rl) = &limiter {
                     rl.acquire().await;

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 
 #[derive(Clone)]
 pub struct VirusTotalProvider {
@@ -122,6 +123,7 @@ impl Provider for VirusTotalProvider {
             );
 
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             // Implement retry logic
             let mut last_error = None;
@@ -134,6 +136,9 @@ impl Provider for VirusTotalProvider {
                         .await;
                 }
 
+                if let Some(rl) = &limiter {
+                    rl.acquire().await;
+                }
                 match client.get(&url).send().await {
                     Ok(response) => {
                         // Check if response is successful

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -4,6 +4,7 @@ use std::pin::Pin;
 
 use super::Provider;
 use crate::network::client::{get_with_retry, HttpClientConfig};
+use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
 /// How many rows to ask the CDX server for per request. A bounded `limit` is
@@ -264,6 +265,7 @@ impl Provider for WaybackMachineProvider {
         Box::pin(async move {
             let client = self.client_config().build_client()?;
             let query_base = self.query_base(domain);
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             if let Some(r) = &reporter {
                 r.detail("fetching…");
@@ -289,6 +291,9 @@ impl Provider for WaybackMachineProvider {
                     url.push_str(&encode_resume_key(key));
                 }
 
+                if let Some(rl) = &limiter {
+                    rl.acquire().await;
+                }
                 let text = match get_with_retry(&client, &url, self.retries).await {
                     Ok(text) => text,
                     Err(e) => {
@@ -622,6 +627,49 @@ mod tests {
         );
         page1.assert();
         page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_paces_page_requests() {
+        use std::time::{Duration, Instant};
+        let mut server = mockito::Server::new_async().await;
+        // Page one hands back a resume key so a second request is made.
+        let _page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showResumeKey".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/a\n\nKEY2\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let _page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/b\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+        // 5 req/s => a 200ms minimum gap before the second page request.
+        provider.with_rate_limit(Some(5.0));
+
+        let start = Instant::now();
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls.len(), 2);
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "rate limit was not applied; elapsed {:?}",
+            start.elapsed()
+        );
     }
 
     #[tokio::test]

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -134,11 +134,6 @@ impl Provider for ZoomEyeProvider {
                 return Ok(Vec::new());
             }
 
-            let api_key = self
-                .api_key_rotator
-                .next_key()
-                .expect("Key rotator should have keys since has_keys() returned true");
-
             let dork = self.build_dork(domain);
             let qbase64 = STANDARD.encode(dork.as_bytes());
 
@@ -174,6 +169,9 @@ impl Provider for ZoomEyeProvider {
                             .await;
                     }
 
+                    // Rotate the key per attempt so a rate-limited/quota-hit key
+                    // is retried with a different one when several are configured.
+                    let api_key = self.api_key_rotator.next_key().unwrap_or_default();
                     let req = client
                         .post(&api_url)
                         .header("API-KEY", &api_key)

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -182,10 +182,17 @@ impl Provider for ZoomEyeProvider {
                     }
                     match req.send().await {
                         Ok(response) => {
-                            if !response.status().is_success() {
+                            let status = response.status();
+                            if !status.is_success() {
+                                if status.as_u16() == 429 {
+                                    if let Some(d) = crate::network::client::retry_after_delay(
+                                        response.headers(),
+                                    ) {
+                                        tokio::time::sleep(d).await;
+                                    }
+                                }
                                 attempt += 1;
-                                last_error =
-                                    Some(anyhow::anyhow!("HTTP error: {}", response.status()));
+                                last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                                 continue;
                             }
 

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -24,6 +24,15 @@ pub struct ZoomEyeProvider {
     base_url: String,
 }
 
+/// ZoomEye v2 returns HTTP 200 for business-logic errors too; only this `code`
+/// means the query succeeded. Anything else (bad/expired key, quota, malformed
+/// query) must be surfaced rather than read as "zero results".
+const ZOOMEYE_SUCCESS_CODE: i32 = 60000;
+
+/// Hard ceiling on pages walked for one domain, so a stale or inflated `total`
+/// from the server can't drive an unbounded request loop.
+const ZOOMEYE_MAX_PAGES: u32 = 1_000;
+
 #[derive(Debug, Serialize, Deserialize)]
 struct ZoomEyeResponse {
     #[serde(default)]
@@ -179,6 +188,16 @@ impl Provider for ZoomEyeProvider {
 
                             match response.json::<ZoomEyeResponse>().await {
                                 Ok(zoomeye_response) => {
+                                    // A 200 with a non-success code is an API
+                                    // error (rejected key, quota, bad query) —
+                                    // don't mistake it for an empty result set.
+                                    if zoomeye_response.code != ZOOMEYE_SUCCESS_CODE {
+                                        last_error = Some(anyhow::anyhow!(
+                                            "ZoomEye API error: code {}",
+                                            zoomeye_response.code
+                                        ));
+                                        break;
+                                    }
                                     total = zoomeye_response.total;
                                     for entry in zoomeye_response.data {
                                         if !entry.url.is_empty() {
@@ -214,11 +233,15 @@ impl Provider for ZoomEyeProvider {
                     ));
                 }
 
+                // A page that returned no rows means the data is exhausted even
+                // if `total` claims otherwise — stop rather than loop on a stale
+                // count.
+                let page_was_empty = page_urls.is_empty();
                 all_urls.extend(page_urls);
 
                 // Check if there are more pages
                 let fetched_so_far = (page as u64) * (pagesize as u64);
-                if fetched_so_far >= total {
+                if page_was_empty || fetched_so_far >= total || page >= ZOOMEYE_MAX_PAGES {
                     break;
                 }
 
@@ -487,6 +510,30 @@ mod tests {
         assert!(result.is_ok(), "Expected success with empty API key");
         let urls = result.unwrap();
         assert_eq!(urls.len(), 0, "Expected empty URLs list with empty API key");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_surfaces_business_error_code() {
+        // HTTP 200 but a non-success `code` (e.g. expired key / quota) must be
+        // an error, not a silent empty result.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/v2/search")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"code": 60500, "message": "auth failed", "data": []}"#)
+            .create_async()
+            .await;
+
+        let mut provider = ZoomEyeProvider::new("expired-key".to_string());
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        let err = provider
+            .fetch_urls("example.com")
+            .await
+            .expect_err("non-success code should be an error");
+        assert!(err.to_string().contains("60500"), "got: {err}");
     }
 
     #[tokio::test]

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 
 #[derive(Clone)]
 pub struct ZoomEyeProvider {
@@ -148,6 +149,7 @@ impl Provider for ZoomEyeProvider {
             let api_url = "https://api.zoomeye.ai/v2/search".to_string();
 
             let client = self.client_config().build_client()?;
+            let limiter = RateLimiter::from_rate(self.rate_limit);
 
             let mut all_urls: Vec<String> = Vec::new();
             let mut page: u32 = 1;
@@ -177,6 +179,9 @@ impl Provider for ZoomEyeProvider {
                         .header("API-KEY", &api_key)
                         .json(&request_body);
 
+                    if let Some(rl) = &limiter {
+                        rl.acquire().await;
+                    }
                     match req.send().await {
                         Ok(response) => {
                             if !response.status().is_success() {

--- a/src/tester_manager/mod.rs
+++ b/src/tester_manager/mod.rs
@@ -1,5 +1,6 @@
-use futures::future::join_all;
-use tokio::task;
+use futures::stream::{self, StreamExt};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::cli::Args;
 use crate::network::{NetworkScope, NetworkSettings};
@@ -43,107 +44,103 @@ pub async fn process_urls_with_testers(
     let test_bar = progress_manager.create_test_bar(transformed_urls.len());
     test_bar.set_message("Preparing URL testing...");
 
-    // Process URLs with testers
-    let mut new_urls = Vec::new();
+    // Process URLs with testers.
+    //
+    // Concurrency is bounded by --parallel. The previous implementation spawned
+    // one task per 10-URL chunk and launched them all at once, so a run over
+    // tens of thousands of URLs could open thousands of simultaneous
+    // connections — exhausting file descriptors and hammering the target. We
+    // instead stream URL chunks through `buffer_unordered`, keeping at most
+    // `parallel` chunks in flight at a time, and advance the progress bar as
+    // each URL actually completes (not when its task is merely scheduled).
+    let parallel = args.parallel.unwrap_or(5).max(1) as usize;
+    let total = transformed_urls.len() as u64;
+    let completed = Arc::new(AtomicU64::new(0));
 
-    // Create tasks for parallel processing
-    let mut tasks = Vec::new();
-    let url_chunks: Vec<_> = transformed_urls.chunks(10).collect();
-    let chunk_count = url_chunks.len();
+    let verbose = args.verbose;
+    let check_status = should_check_status;
+    let extract_links = args.extract_links;
+    let silent = args.silent;
 
-    for (chunk_idx, url_chunk) in url_chunks.into_iter().enumerate() {
-        let url_vec = url_chunk.to_vec();
-        let testers_clone: Vec<_> = testers.iter().map(|t| t.clone_box()).collect();
-        let verbose = args.verbose;
-        let check_status = should_check_status;
-        let extract_links = args.extract_links;
-        let silent = args.silent;
+    let url_chunks: Vec<Vec<String>> = transformed_urls
+        .chunks(10)
+        .map(|chunk| chunk.to_vec())
+        .collect();
 
-        let task = task::spawn(async move {
-            let mut result_urls = Vec::new();
+    let chunk_results: Vec<Vec<output::UrlData>> =
+        stream::iter(url_chunks.into_iter().map(|url_vec| {
+            let testers_clone: Vec<_> = testers.iter().map(|t| t.clone_box()).collect();
+            let test_bar = test_bar.clone();
+            let completed = Arc::clone(&completed);
 
-            for url in url_vec {
-                let mut status_result = None;
-                let mut links_result = None;
+            async move {
+                let mut result_urls = Vec::new();
 
-                // Process URL with each tester
-                for (i, tester) in testers_clone.iter().enumerate() {
-                    match tester.test_url(&url).await {
-                        Ok(results) => {
-                            if i == 0 && check_status {
-                                // Status checker results (first tester if check_status is enabled)
-                                status_result = Some(results);
-                            } else if extract_links {
-                                // Link extractor results
-                                links_result = Some(results);
+                for url in url_vec {
+                    let mut status_result = None;
+                    let mut links_result = None;
+
+                    // Process URL with each tester
+                    for (i, tester) in testers_clone.iter().enumerate() {
+                        match tester.test_url(&url).await {
+                            Ok(results) => {
+                                if i == 0 && check_status {
+                                    // Status checker results (first tester if check_status is enabled)
+                                    status_result = Some(results);
+                                } else if extract_links {
+                                    // Link extractor results
+                                    links_result = Some(results);
+                                }
                             }
-                        }
-                        Err(e) => {
-                            if verbose && !silent {
-                                eprintln!("Error testing URL {url}: {e}");
+                            Err(e) => {
+                                if verbose && !silent {
+                                    eprintln!("Error testing URL {url}: {e}");
+                                }
                             }
                         }
                     }
-                }
 
-                // Create UrlData for this URL
-                if let Some(status_urls) = status_result {
-                    for status_url in status_urls {
-                        // Parse the status URL (format: "{url} - {status}")
-                        result_urls.push(output::UrlData::from_string(status_url));
-                    }
-                } else {
-                    // If no status but URL should be included anyway
-                    if check_status {
-                        let url_data = output::UrlData::with_status(
-                            url.clone(),
-                            "Status check failed".to_string(),
-                        );
-                        result_urls.push(url_data);
+                    // Create UrlData for this URL
+                    if let Some(status_urls) = status_result {
+                        for status_url in status_urls {
+                            // Parse the status URL (format: "{url} - {status}")
+                            result_urls.push(output::UrlData::from_string(status_url));
+                        }
                     } else {
-                        let url_data = output::UrlData::new(url.clone());
-                        result_urls.push(url_data);
+                        // If no status but URL should be included anyway
+                        if check_status {
+                            let url_data = output::UrlData::with_status(
+                                url.clone(),
+                                "Status check failed".to_string(),
+                            );
+                            result_urls.push(url_data);
+                        } else {
+                            let url_data = output::UrlData::new(url.clone());
+                            result_urls.push(url_data);
+                        }
                     }
-                }
 
-                // If we have extracted links, add them to the result
-                if let Some(link_urls) = links_result {
-                    for link_url in link_urls {
-                        result_urls.push(output::UrlData::new(link_url));
+                    // If we have extracted links, add them to the result
+                    if let Some(link_urls) = links_result {
+                        for link_url in link_urls {
+                            result_urls.push(output::UrlData::new(link_url));
+                        }
                     }
+
+                    let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    test_bar.set_position(done.min(total));
                 }
+
+                result_urls
             }
+        }))
+        .buffer_unordered(parallel)
+        .collect()
+        .await;
 
-            (result_urls, chunk_idx)
-        });
-
-        tasks.push(task);
-
-        // Update progress bar
-        test_bar.set_position((chunk_idx as u64 * 10).min(transformed_urls.len() as u64));
-        test_bar.set_message(format!(
-            "Processing chunk {}/{}",
-            chunk_idx + 1,
-            chunk_count
-        ));
-    }
-
-    // Collect results
-    let results = join_all(tasks).await;
-
-    for result in results {
-        match result {
-            Ok((urls, _)) => {
-                for url in urls {
-                    new_urls.push(url);
-                }
-            }
-            Err(e) => {
-                if !args.silent {
-                    eprintln!("Task error: {e}");
-                }
-            }
-        }
+    let mut new_urls = Vec::new();
+    for urls in chunk_results {
+        new_urls.extend(urls);
     }
 
     // Sort URLs by their URL field

--- a/src/utils/url.rs
+++ b/src/utils/url.rs
@@ -90,25 +90,20 @@ impl UrlTransformer {
                     }
                 }
 
-                // Normalize query parameters - sort them alphabetically
-                if url.query().is_some() {
-                    let mut params: Vec<(String, String)> = url
-                        .query_pairs()
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
-                        .collect();
-
-                    // Sort parameters by key
-                    params.sort_by(|a, b| a.0.cmp(&b.0));
-
-                    // Clear existing query and set sorted query
+                // Normalize query parameters by sorting them. We sort the *raw*
+                // `key=value` tokens without decoding, so this stays a lossless
+                // reordering: a bare `?foo` is not rewritten to `?foo=`, and a
+                // literal '+' is not turned into '%20' (query_pairs() decodes
+                // both, which silently mutates the URL the archive recorded).
+                let sorted_query: Option<String> = url.query().map(|query| {
+                    let mut pairs: Vec<&str> = query.split('&').filter(|s| !s.is_empty()).collect();
+                    pairs.sort_unstable();
+                    pairs.join("&")
+                });
+                if let Some(query) = sorted_query {
                     url.set_query(None);
-                    if !params.is_empty() {
-                        let query_string = params
-                            .into_iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join("&");
-                        url.set_query(Some(&query_string));
+                    if !query.is_empty() {
+                        url.set_query(Some(&query));
                     }
                 }
 
@@ -384,6 +379,33 @@ mod tests {
         assert!(result_url.contains("param1=value1"));
         assert!(result_url.contains("param2=value2"));
         assert!(result_url.contains("param3=value3"));
+    }
+
+    #[test]
+    fn test_url_transformer_normalize_preserves_bare_param_and_plus() {
+        let mut transformer = UrlTransformer::new();
+        transformer.with_normalize_url(true);
+
+        let urls = vec![
+            "https://example.com/a?foo".to_string(), // bare param, no '='
+            "https://example.com/b?q=a+b".to_string(), // literal '+'
+            "https://example.com/c?b=2&a=1".to_string(), // still gets sorted
+        ];
+
+        let out = transformer.transform(urls);
+        // Bare param keeps no '='; '+' is not rewritten to '%20'; order sorted.
+        assert!(
+            out.contains(&"https://example.com/a?foo".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            out.contains(&"https://example.com/b?q=a+b".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            out.contains(&"https://example.com/c?a=1&b=2".to_string()),
+            "{out:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A hardening + correctness pass driven by building urx and exercising it against real targets (plus a multi-agent code review). 17 fixes across data-loss, security, API citizenship, output/UX, and performance. All changes are test-covered (**+21 tests, 458 passing**), clippy- and rustfmt-clean.

## Data loss (most impactful)
- **CommonCrawl now paginates the index.** A single request returned only the first block, silently truncating large domains — e.g. `en.wikipedia.org` returned ~920 URLs of ~116k. Probe `&showNumPages=true`, walk every `&page=N` with a `MAX_PAGES` guard + partial-result handling.
- **urlscan now paginates via `search_after`.** `has_more` was ignored, capping every domain at 100 results.
- **OTX pagination guards.** Added a page ceiling + empty-page termination so a stuck `has_next:true` cursor can't loop forever; drop entries with an empty `url`.

## Security
- **VirusTotal API key no longer leaks.** The key rides in the URL query string and a reqwest transport error renders the full URL to stderr/logs; redact it via `without_url()`.
- **sitemap body size cap.** The body was read fully into memory with no limit; read incrementally up to 50 MiB.
- **ZoomEye business-error code surfaced.** A `code != 60000` (expired key / quota) returned as HTTP 200 was treated as "0 results"; it's now an error. Added a page cap.

## API citizenship
- **`--rate-limit` / `--rate-limit-by` now actually throttle.** The configured rate was stored but never enforced; added a minimum-interval limiter applied before every request in the enumeration providers.
- **Rotate API key on retry** instead of hammering the same (possibly rate-limited) key.
- **Honor `Retry-After`** on 429 (and GitHub 403 secondary limit) responses.

## Output / UX
- **No more ANSI color codes leaking into `-o` / `--output-dir` files.**
- **Consistent CSV columns** (header and every row now agree on column count).
- **Fixed visible aliases** that rendered as `----dL`, `----oD`, `----cs`, `----is`, `----es`.
- **`www.<domain>` is treated as the apex in strict mode** — `urx example.com` no longer returns 0 results for a site served entirely on `www`. Other subdomains still require `--subs`.
- **robots.txt**: case-insensitive directives (RFC 9309), best-effort HTTP fallback, skip glob `Disallow` patterns / strip `$` anchors and inline `# comments`.
- **sitemap text fallback** restricted to `.txt` / `text/plain` so XML endpoints serving HTML error pages aren't mined for stray links.
- **`--normalize-url` is now lossless** (preserves literal `+` and bare `?foo` params instead of mangling them).
- **GitHub partial results are flagged** instead of silently dropping the error.

## Performance
- **Tester concurrency is bounded by `--parallel`.** The status/link pipeline chunked URLs and launched every chunk at once, so tens of thousands of URLs could open thousands of simultaneous connections; it now streams through `buffer_unordered` and advances the progress bar on completion.

## Test plan
- `cargo test` — 458 passing, 2 ignored (network)
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- Manual e2e against real domains confirming each behavioral change
