### PR TITLE
feat: per-provider --parallel concurrency, VT API v3, CC latest (#270, #271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Provider Options:
       --subs
           Include subdomains when searching
       --cc-index <CC_INDEX>
-          Common Crawl index to use; accepts comma-separated list to query multiple indexes in parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`). `latest` resolves the newest via collinfo.json. [default: CC-MAIN-2026-17]
+          Common Crawl index to use; accepts comma-separated list to query multiple indexes in parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`). `latest` (the default) resolves the newest via collinfo.json. [default: latest]
       --wayback-from <DATE>
           Restrict Wayback Machine results to snapshots at or after DATE (YYYY/YYYYMM/YYYYMMDD/YYYYMMDDhhmmss)
       --wayback-to <DATE>

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Network Options:
       --random-agent                   Use a random User-Agent for HTTP requests
       --timeout <TIMEOUT>              Request timeout in seconds [default: 120]
       --retries <RETRIES>              Number of retries for failed requests [default: 2]
-      --parallel <PARALLEL>            Maximum number of parallel requests per provider and maximum concurrent domain processing [default: 5]
+      --parallel <PARALLEL>            Maximum domains fetched concurrently per provider (and concurrent URL tests); a provider's --rate-limit is shared across them [default: 5]
       --rate-limit <RATE_LIMIT>        Rate limit (requests per second)
       --rate-limit-by <PAIRS>          Per-provider rate overrides (e.g. `vt=1,wayback=10`); falls back to --rate-limit for unlisted providers
       --max-time <MAX_TIME>            Global ceiling on provider enumeration time in seconds (0 = unlimited) [default: 0]

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -76,7 +76,7 @@ Network Options:
   --random-agent                 Use a random User-Agent
   --timeout <TIMEOUT>            Request timeout in seconds [default: 120]
   --retries <RETRIES>            Retries for failed requests [default: 2]
-  --parallel <PARALLEL>          Max parallel requests per provider [default: 5]
+  --parallel <PARALLEL>          Max domains fetched concurrently per provider (rate-limit shared) [default: 5]
   --rate-limit <RATE_LIMIT>      Requests per second
   --rate-limit-by <PAIRS>        Per-provider rate overrides (e.g. `vt=1,wayback=10`); falls back to --rate-limit for unlisted providers
   --max-time <SECONDS>           Global ceiling on provider enumeration time in seconds; in-flight fetches are aborted at deadline (0 = unlimited) [default: 0]

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -36,7 +36,7 @@ Provider Options:
   --all-providers                        Enable every supported provider (API-keyed ones only if a key is available)
   --list-providers                       List every supported provider then exit
   --subs                                 Include subdomains when searching
-  --cc-index <CC_INDEX>                  Common Crawl index(es), comma-separated for parallel queries; `latest` auto-resolves [default: CC-MAIN-2026-17]
+  --cc-index <CC_INDEX>                  Common Crawl index(es), comma-separated for parallel queries; `latest` auto-resolves [default: latest]
   --wayback-from <DATE>                  Restrict Wayback results to >= DATE (YYYY/YYYYMM/YYYYMMDD/YYYYMMDDhhmmss)
   --wayback-to <DATE>                    Restrict Wayback results to <= DATE (same format as --wayback-from)
   --vt-api-key <VT_API_KEY>             API key for VirusTotal

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,10 +88,11 @@ pub struct Args {
     pub subs: bool,
 
     #[clap(help_heading = "Provider Options")]
-    /// Common Crawl index to use. Accepts a comma-separated list to query
-    /// multiple indexes in parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`).
-    /// The literal `latest` resolves to the newest index via collinfo.json.
-    #[clap(long, default_value = "CC-MAIN-2026-17", value_delimiter = ',')]
+    /// Common Crawl index to use (default: `latest`, the newest index resolved
+    /// at runtime via collinfo.json so results don't age as a pinned index
+    /// would). Accepts a comma-separated list to query multiple indexes in
+    /// parallel (e.g. `CC-MAIN-2026-17,CC-MAIN-2025-51`).
+    #[clap(long, default_value = "latest", value_delimiter = ',')]
     pub cc_index: Vec<String>,
 
     /// Restrict Wayback Machine results to snapshots at or after this date.
@@ -515,7 +516,7 @@ mod tests {
         assert_eq!(args.domains, vec!["example.com"]);
         assert_eq!(args.format, "plain");
         assert_eq!(args.providers, vec!["wayback", "cc", "otx"]);
-        assert_eq!(args.cc_index, vec!["CC-MAIN-2026-17"]);
+        assert_eq!(args.cc_index, vec!["latest"]);
         assert_eq!(args.timeout, 120);
         assert_eq!(args.retries, 2);
         assert!(args.include_robots);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -275,7 +275,9 @@ pub struct Args {
     #[clap(long, default_value = "2")]
     pub retries: u32,
 
-    /// Maximum number of parallel requests per provider and maximum concurrent domain processing
+    /// Maximum domains fetched concurrently per provider (and concurrent URL
+    /// tests). A provider's --rate-limit is shared across these, so the
+    /// configured rate is still honored.
     #[clap(help_heading = "Network Options")]
     #[clap(long, default_value = "5", value_parser = validate_positive_parallel)]
     pub parallel: Option<u32>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -357,7 +357,7 @@ impl Config {
         // Treat the default singleton list as "not user-supplied" so the file
         // value wins. Config file still accepts a single string; we split it
         // on commas so users can configure multi-index there too.
-        let cc_default = vec!["CC-MAIN-2026-17".to_string()];
+        let cc_default = vec!["latest".to_string()];
         if args.cc_index == cc_default {
             if let Some(cc_index) = &self.provider.cc_index {
                 let split: Vec<String> = cc_index

--- a/src/main.rs
+++ b/src/main.rs
@@ -1660,7 +1660,6 @@ mod tests {
         fn with_retries(&mut self, _count: u32) {}
         fn with_random_agent(&mut self, _enabled: bool) {}
         fn with_insecure(&mut self, _enabled: bool) {}
-        fn with_parallel(&mut self, _parallel: u32) {}
         fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
     }
 
@@ -1833,6 +1832,85 @@ mod tests {
         assert_eq!(result.stats[0].name, "MockProvider");
         assert_eq!(result.stats[0].url_count, 2);
         assert_eq!(result.stats[0].error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_parallel_processes_provider_domains_concurrently() {
+        // One provider, five domains, each fetch sleeps 200ms. With --parallel 5
+        // the provider's domains must be fetched concurrently — finishing in
+        // ~200ms rather than the ~1s a sequential per-provider drain would take.
+        // This guards the #270 fix from regressing back to single-flight.
+        let provider =
+            MockProvider::new(vec!["https://example.com/a".to_string()], false).with_delay_ms(200);
+        let calls = provider.calls.clone();
+
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(provider)];
+        let provider_names = vec!["MockProvider".to_string()];
+        let domains: Vec<String> = ["a.com", "b.com", "c.com", "d.com", "e.com"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let mut args = build_test_args();
+        args.parallel = Some(5);
+        let progress_manager = ProgressManager::new(true);
+
+        let start = std::time::Instant::now();
+        let _ = process_domains(
+            domains.clone(),
+            &args,
+            &progress_manager,
+            &providers,
+            &provider_names,
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        // All five domains were fetched...
+        assert_eq!(calls.lock().unwrap().len(), 5);
+        // ...and concurrently: well under the ~1s a sequential drain would need.
+        assert!(
+            elapsed < std::time::Duration::from_millis(800),
+            "expected concurrent per-provider fetches (~200ms), took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parallel_one_processes_sequentially() {
+        // With --parallel 1 the same five 200ms fetches must run one at a time,
+        // taking ~1s. This pins the sequential (rich-UI) path so the
+        // concurrency knob is honored in both directions.
+        let provider =
+            MockProvider::new(vec!["https://example.com/a".to_string()], false).with_delay_ms(200);
+        let calls = provider.calls.clone();
+
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(provider)];
+        let provider_names = vec!["MockProvider".to_string()];
+        let domains: Vec<String> = ["a.com", "b.com", "c.com", "d.com", "e.com"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let mut args = build_test_args();
+        args.parallel = Some(1);
+        let progress_manager = ProgressManager::new(true);
+
+        let start = std::time::Instant::now();
+        let _ = process_domains(
+            domains,
+            &args,
+            &progress_manager,
+            &providers,
+            &provider_names,
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(calls.lock().unwrap().len(), 5);
+        assert!(
+            elapsed >= std::time::Duration::from_millis(900),
+            "expected sequential fetches (~1s) with --parallel 1, took {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/network/rate_limiter.rs
+++ b/src/network/rate_limiter.rs
@@ -84,6 +84,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_clones_share_pacing() {
+        // The runner clones a provider (and thus its limiter) once per
+        // concurrent domain. Those clones MUST share one schedule, or
+        // concurrent fetches would each pace independently and blow past
+        // --rate-limit. 20 req/s => a 50ms gap the clone is forced to observe.
+        let a = RateLimiter::new(20.0).unwrap();
+        let b = a.clone();
+        let start = Instant::now();
+        a.acquire().await; // first: no wait
+        b.acquire().await; // clone sees a's timestamp => must wait ~50ms
+        assert!(
+            start.elapsed() >= Duration::from_millis(40),
+            "clones must share pacing; elapsed {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
     async fn test_first_acquire_does_not_block() {
         let limiter = RateLimiter::new(1.0).unwrap(); // 1s interval
         let start = Instant::now();

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -50,8 +50,7 @@ pub struct CommonCrawlProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
 }
@@ -87,7 +86,6 @@ impl CommonCrawlProvider {
             retries: 3,
             random_agent: true,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://index.commoncrawl.org".to_string(),
@@ -110,7 +108,6 @@ impl CommonCrawlProvider {
             retries: 3,
             random_agent: true,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://index.commoncrawl.org".to_string(),
@@ -204,7 +201,7 @@ impl Provider for CommonCrawlProvider {
             let index = self.effective_index().await?;
             let query_base = self.query_base(&index, domain);
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             if let Some(r) = &reporter {
                 r.detail("fetching…");
@@ -309,12 +306,8 @@ impl Provider for CommonCrawlProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -366,7 +359,6 @@ impl Provider for MockCommonCrawlProvider {
     fn with_retries(&mut self, _count: u32) {}
     fn with_random_agent(&mut self, _enabled: bool) {}
     fn with_insecure(&mut self, _enabled: bool) {}
-    fn with_parallel(&mut self, _parallel: u32) {}
     fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
 }
 
@@ -385,8 +377,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 1);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
         assert_eq!(provider.base_url, "https://index.commoncrawl.org");
     }
 
@@ -451,17 +442,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let mut provider = CommonCrawlProvider::new();
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let mut provider = CommonCrawlProvider::new();
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -26,8 +26,7 @@ pub struct GitHubProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
 }
@@ -71,7 +70,6 @@ impl GitHubProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://api.github.com".to_string(),
@@ -154,7 +152,7 @@ impl Provider for GitHubProvider {
             }
 
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             #[cfg(not(test))]
             let base = "https://api.github.com";
@@ -310,11 +308,8 @@ impl Provider for GitHubProvider {
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
     }
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -73,9 +73,6 @@ pub trait Provider: Send + Sync {
     /// Enable or disable SSL certificate verification (for self-signed certificates)
     fn with_insecure(&mut self, enabled: bool);
 
-    /// Set the number of parallel requests
-    fn with_parallel(&mut self, count: u32);
-
     /// Set rate limiting to avoid being blocked by providers
     fn with_rate_limit(&mut self, requests_per_second: Option<f32>);
 }

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -27,8 +27,7 @@ pub struct OTXProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     base_url: String,
 }
 
@@ -79,7 +78,6 @@ impl OTXProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             base_url: "https://otx.alienvault.com".to_string(),
         }
@@ -168,7 +166,7 @@ impl Provider for OTXProvider {
             let mut all_urls = Vec::new();
             let mut page = 0;
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             loop {
                 let url = self.format_url(domain, page);
@@ -346,12 +344,8 @@ impl Provider for OTXProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -393,8 +387,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(!provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 1);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]
@@ -450,17 +443,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let mut provider = OTXProvider::new();
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let mut provider = OTXProvider::new();
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -186,7 +186,6 @@ impl Provider for RobotsProvider {
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
     }
-    fn with_parallel(&mut self, _count: u32) {}
     fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
 }
 

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -251,7 +251,6 @@ impl Provider for SitemapProvider {
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
     }
-    fn with_parallel(&mut self, _count: u32) {}
     fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
 }
 

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -18,8 +18,7 @@ pub struct UrlscanProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
 }
@@ -95,7 +94,6 @@ impl UrlscanProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://urlscan.io".to_string(),
@@ -217,7 +215,7 @@ impl Provider for UrlscanProvider {
                 format!("https://urlscan.io/api/v1/search/?q=domain:{encoded_domain}&size=100");
 
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             // urlscan returns at most 100 results per request and signals more
             // via `has_more`; the next page is requested by passing the last
@@ -238,7 +236,7 @@ impl Provider for UrlscanProvider {
                     None => base_query.clone(),
                 };
 
-                let response = match self.fetch_page(&client, &url, limiter.as_ref()).await {
+                let response = match self.fetch_page(&client, &url, limiter).await {
                     Ok(resp) => resp,
                     Err(e) => {
                         // A failure on the very first page is fatal; a later
@@ -309,12 +307,8 @@ impl Provider for UrlscanProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -336,8 +330,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(!provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 1);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]
@@ -450,17 +443,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let provider = &mut UrlscanProvider::new("test_api_key".to_string());
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let provider = &mut UrlscanProvider::new("test_api_key".to_string());
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -18,8 +18,7 @@ pub struct VirusTotalProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
 }
@@ -60,7 +59,6 @@ impl VirusTotalProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://www.virustotal.com".to_string(),
@@ -104,7 +102,7 @@ impl Provider for VirusTotalProvider {
                 url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
 
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             // Implement retry logic
             let mut last_error = None;
@@ -232,12 +230,8 @@ impl Provider for VirusTotalProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -259,8 +253,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(!provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 1);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]
@@ -395,17 +388,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let provider = &mut VirusTotalProvider::new("test_api_key".to_string());
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let provider = &mut VirusTotalProvider::new("test_api_key".to_string());
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -7,6 +7,15 @@ use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
+
+/// Page size for the v3 `urls` relationship. VirusTotal caps this relationship
+/// endpoint at 40 per page; larger values are silently clamped server-side.
+const VT_PAGE_LIMIT: usize = 40;
+
+/// Hard ceiling on pages followed for one domain, mirroring the other
+/// paginating providers so a misbehaving `links.next` can't loop forever.
+const VT_MAX_PAGES: usize = 10_000;
 
 #[derive(Clone)]
 pub struct VirusTotalProvider {
@@ -23,17 +32,32 @@ pub struct VirusTotalProvider {
     base_url: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct VTUrl {
-    url: String,
-    // We could add scan_date parsing if needed in the future
-    // scan_date: String,
+/// A page of the v3 `/domains/{domain}/urls` response. `data` holds the URL
+/// objects; `links.next` is a complete URL for the following page (absent on
+/// the last page). `Default` lets a 404 ("no such domain") resolve to an empty
+/// page rather than an error.
+#[derive(Debug, Deserialize, Default)]
+struct VtUrlsResponse {
+    #[serde(default)]
+    data: Vec<VtUrlObject>,
+    #[serde(default)]
+    links: VtLinks,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct VTResponse {
+#[derive(Debug, Deserialize, Default)]
+struct VtLinks {
     #[serde(default)]
-    detected_urls: Vec<VTUrl>,
+    next: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VtUrlObject {
+    attributes: VtUrlAttributes,
+}
+
+#[derive(Debug, Deserialize)]
+struct VtUrlAttributes {
+    url: String,
 }
 
 impl VirusTotalProvider {
@@ -80,6 +104,101 @@ impl VirusTotalProvider {
             proxy_auth: self.proxy_auth.clone(),
         }
     }
+
+    /// First-page URL for a domain's v3 `urls` relationship.
+    fn first_page_url(&self, domain: &str) -> String {
+        let encoded = url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
+        #[cfg(test)]
+        {
+            format!(
+                "{}/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}",
+                self.base_url
+            )
+        }
+        #[cfg(not(test))]
+        {
+            format!(
+                "https://www.virustotal.com/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}"
+            )
+        }
+    }
+
+    /// Fetch and parse a single page with retry/back-off and key rotation.
+    ///
+    /// A 404 (the domain has no VT object) resolves to an empty page rather
+    /// than an error, matching the "no data" semantics of the other providers.
+    async fn fetch_page(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        limiter: Option<&RateLimiter>,
+    ) -> Result<VtUrlsResponse> {
+        let mut last_error = None;
+        let mut attempt = 0;
+
+        while attempt <= self.retries {
+            if attempt > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
+            }
+
+            // Rotate the key per attempt so a throttled/invalid key is retried
+            // with a different one when several are configured. v3 carries the
+            // key in the `x-apikey` header (v2 used an `apikey` query param).
+            let api_key = self.api_key_rotator.next_key().unwrap_or_default();
+            let mut req = client.get(url);
+            if !api_key.is_empty() {
+                req = req.header("x-apikey", &api_key);
+            }
+
+            if let Some(rl) = limiter {
+                rl.acquire().await;
+            }
+            match req.send().await {
+                Ok(response) => {
+                    let status = response.status();
+                    // 404 => no VT object for this domain; not an error.
+                    if status.as_u16() == 404 {
+                        return Ok(VtUrlsResponse::default());
+                    }
+                    if !status.is_success() {
+                        // On a throttle, wait as long as the server asked.
+                        if status.as_u16() == 429 {
+                            if let Some(d) =
+                                crate::network::client::retry_after_delay(response.headers())
+                            {
+                                tokio::time::sleep(d).await;
+                            }
+                        }
+                        attempt += 1;
+                        last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
+                        continue;
+                    }
+                    match response.json::<VtUrlsResponse>().await {
+                        Ok(parsed) => return Ok(parsed),
+                        Err(e) => {
+                            attempt += 1;
+                            last_error =
+                                Some(anyhow::anyhow!("Failed to parse VirusTotal response: {e}"));
+                            continue;
+                        }
+                    }
+                }
+                Err(e) => {
+                    attempt += 1;
+                    // Defensive hygiene: keep the request URL out of surfaced
+                    // transport errors (the key is a header, not in the URL).
+                    last_error = Some(e.without_url().into());
+                    continue;
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "Failed after {} attempts: {}",
+            self.retries + 1,
+            last_error.unwrap_or_else(|| anyhow::anyhow!("unknown error"))
+        ))
+    }
 }
 
 impl Provider for VirusTotalProvider {
@@ -91,114 +210,71 @@ impl Provider for VirusTotalProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
-            // Skip if no API keys are provided
+            // Skip if no API keys are provided.
             if !self.api_key_rotator.has_keys() {
                 return Ok(Vec::new());
             }
 
-            // Use the url crate for encoding the domain
-            let encoded_domain =
-                url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
-
             let client = self.client_config().build_client()?;
             let limiter = self.rate_limit.as_ref();
 
-            // Implement retry logic
-            let mut last_error = None;
-            let mut attempt = 0;
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
+            }
 
-            while attempt <= self.retries {
-                if attempt > 0 {
-                    // Wait before retrying, with increasing backoff
-                    tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64))
-                        .await;
+            // Walk the v3 cursor: each page returns up to VT_PAGE_LIMIT URL
+            // objects plus a `links.next` pointing at the following page. The
+            // deprecated v2 `domain/report` returned a single server-capped,
+            // non-paginated slice that silently truncated large domains.
+            let mut next_url = Some(self.first_page_url(domain));
+            let mut urls = Vec::new();
+            let mut pages = 0usize;
+
+            while let Some(url) = next_url.take() {
+                pages += 1;
+                if pages > VT_MAX_PAGES {
+                    break;
                 }
 
-                // Rotate to the next key each attempt: if a key is rate-limited
-                // or invalid, the retry uses a different one when several are
-                // configured (with a single key this is a no-op).
-                let api_key = self
-                    .api_key_rotator
-                    .next_key()
-                    .expect("Key rotator should have keys since has_keys() returned true");
-
-                #[cfg(test)]
-                let url = format!(
-                    "{}/vtapi/v2/domain/report?apikey={}&domain={}",
-                    self.base_url, api_key, encoded_domain
-                );
-                #[cfg(not(test))]
-                let url = format!(
-                    "https://www.virustotal.com/vtapi/v2/domain/report?apikey={}&domain={}",
-                    api_key, encoded_domain
-                );
-
-                if let Some(rl) = &limiter {
-                    rl.acquire().await;
-                }
-                match client.get(&url).send().await {
-                    Ok(response) => {
-                        // Check if response is successful
-                        let status = response.status();
-                        if !status.is_success() {
-                            // On a throttle, wait as long as the server asked.
-                            if status.as_u16() == 429 {
-                                if let Some(d) =
-                                    crate::network::client::retry_after_delay(response.headers())
-                                {
-                                    tokio::time::sleep(d).await;
-                                }
-                            }
-                            attempt += 1;
-                            last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
-                            continue;
-                        }
-
-                        // Parse response
-                        match response.json::<VTResponse>().await {
-                            Ok(vt_response) => {
-                                let mut urls = Vec::new();
-                                for vt_url in vt_response.detected_urls {
-                                    urls.push(vt_url.url);
-                                }
-                                return Ok(urls);
-                            }
-                            Err(e) => {
-                                attempt += 1;
-                                last_error = Some(anyhow::anyhow!(
-                                    "Failed to parse VirusTotal response: {}",
-                                    e
-                                ));
-                                continue;
-                            }
-                        }
-                    }
+                let page = match self.fetch_page(&client, &url, limiter).await {
+                    Ok(page) => page,
                     Err(e) => {
-                        attempt += 1;
-                        // The VirusTotal key rides in the query string, and a
-                        // reqwest transport error renders the full request URL
-                        // in its Display output. Strip the URL so the key never
-                        // reaches stderr / logs via the surfaced error.
-                        last_error = Some(e.without_url().into());
-                        continue;
+                        // A failure on the first page (nothing collected) is
+                        // fatal; a later failure keeps what we have and flags
+                        // the result partial rather than presenting a truncated
+                        // crawl as a clean success.
+                        if urls.is_empty() {
+                            return Err(e);
+                        }
+                        if let Some(r) = &reporter {
+                            r.mark_partial();
+                        }
+                        break;
                     }
+                };
+
+                for obj in page.data {
+                    urls.push(obj.attributes.url);
                 }
+                if let Some(r) = &reporter {
+                    r.detail(format!("{} URLs…", urls.len()));
+                }
+
+                next_url = page.links.next;
             }
 
-            // If we got here, all attempts failed
-            if let Some(e) = last_error {
-                Err(anyhow::anyhow!(
-                    "Failed after {} attempts: {}",
-                    self.retries + 1,
-                    e
-                ))
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed after {} attempts",
-                    self.retries + 1
-                ))
-            }
+            urls.sort();
+            urls.dedup();
+            Ok(urls)
         })
     }
 
@@ -315,9 +391,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_transport_error_does_not_leak_api_key() {
-        // The VirusTotal key is passed in the request URL's query string, so a
-        // transport-layer failure (which reqwest renders with the full URL)
-        // must not surface it through the returned error.
+        // The v3 key travels in the `x-apikey` header, but a transport-layer
+        // failure (which reqwest renders with the full URL) must still not
+        // surface it — and we strip the URL from the error for good measure.
         let mut provider = VirusTotalProvider::new_with_keys(vec!["SUPERSECRETKEY".to_string()]);
         // Port 1 reliably refuses the connection; keep the run fast.
         provider.with_base_url("http://127.0.0.1:1".to_string());
@@ -403,25 +479,35 @@ mod tests {
 
     #[test]
     fn test_vt_response_deserialize() {
+        // v3 shape: data[].attributes.url, with a links.next cursor.
         let json = r#"{
-            "detected_urls": [
-                {"url": "https://example.com/page1"},
-                {"url": "https://example.com/page2"}
-            ]
+            "data": [
+                {"type": "url", "id": "a", "attributes": {"url": "https://example.com/page1"}},
+                {"type": "url", "id": "b", "attributes": {"url": "https://example.com/page2"}}
+            ],
+            "links": {"self": "https://x/self", "next": "https://x/next"},
+            "meta": {"cursor": "CURSOR"}
         }"#;
 
-        let response: VTResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.detected_urls.len(), 2);
-        assert_eq!(response.detected_urls[0].url, "https://example.com/page1");
-        assert_eq!(response.detected_urls[1].url, "https://example.com/page2");
+        let response: VtUrlsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].attributes.url, "https://example.com/page1");
+        assert_eq!(response.data[1].attributes.url, "https://example.com/page2");
+        assert_eq!(response.links.next.as_deref(), Some("https://x/next"));
     }
 
     #[test]
     fn test_vt_response_empty_deserialize() {
-        let json = r#"{}"#;
+        // No data and no `next` (last/empty page) must parse cleanly.
+        let json = r#"{"data": [], "links": {"self": "https://x/self"}}"#;
+        let response: VtUrlsResponse = serde_json::from_str(json).unwrap();
+        assert!(response.data.is_empty());
+        assert!(response.links.next.is_none());
 
-        let response: VTResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.detected_urls.len(), 0);
+        // A bare object also parses (all fields default).
+        let response: VtUrlsResponse = serde_json::from_str("{}").unwrap();
+        assert!(response.data.is_empty());
+        assert!(response.links.next.is_none());
     }
 
     #[tokio::test]
@@ -453,39 +539,151 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_urls_with_mock() {
-        // Create a mock server - use new_async to avoid nested runtime issues
-        let mut mock_server = mockito::Server::new_async().await;
+        let mut server = mockito::Server::new_async().await;
 
-        // Create a mock response
-        let mock_response = r#"{
-            "detected_urls": [
-                {"url": "https://example.com/page1"},
-                {"url": "https://example.com/page2"}
-            ]
-        }"#;
-
-        // Setup the mock
-        let _m = mock_server
-            .mock("GET", "/vtapi/v2/domain/report")
-            .match_query(mockito::Matcher::AllOf(vec![
-                mockito::Matcher::UrlEncoded("apikey".into(), "test_api_key".into()),
-                mockito::Matcher::UrlEncoded("domain".into(), "example.com".into()),
-            ]))
+        // v3: domain in the path, key in the x-apikey header, urls under
+        // data[].attributes.url. A single page (no links.next) ends the walk.
+        let m = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_header("x-apikey", "test_api_key")
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "40".into()))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(mock_response)
-            .create();
+            .with_body(
+                r#"{
+                    "data": [
+                        {"attributes": {"url": "https://example.com/page1"}},
+                        {"attributes": {"url": "https://example.com/page2"}}
+                    ],
+                    "links": {"self": "x"}
+                }"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
 
-        // Create the provider using mock server URL
         let mut provider = VirusTotalProvider::new("test_api_key".to_string());
-        provider.with_base_url(mock_server.url());
+        provider.with_base_url(server.url());
 
-        let result = provider.fetch_urls("example.com").await;
-        assert!(result.is_ok(), "Expected success with mock API");
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/page1".to_string(),
+                "https://example.com/page2".to_string(),
+            ]
+        );
+        m.assert();
+    }
 
-        let urls = result.unwrap();
-        assert_eq!(urls.len(), 2);
-        assert_eq!(urls[0], "https://example.com/page1");
-        assert_eq!(urls[1], "https://example.com/page2");
+    #[tokio::test]
+    async fn test_fetch_urls_paginates_via_links_next() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Page one hands back a complete `links.next` URL pointing at page two.
+        let next = format!(
+            "{}/api/v3/domains/example.com/urls?limit=40&cursor=PAGE2",
+            server.url()
+        );
+        let page1 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::Exact("limit=40".into()))
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"data": [{{"attributes": {{"url": "https://example.com/a"}}}}], "links": {{"next": "{next}"}}}}"#
+            ))
+            .expect(1)
+            .create_async()
+            .await;
+        // Page two is keyed by the cursor and carries no `next`, so the walk ends.
+        let page2 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "cursor".into(),
+                "PAGE2".into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"data": [{"attributes": {"url": "https://example.com/b"}}], "links": {}}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = VirusTotalProvider::new("test_api_key".to_string());
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/a".to_string(),
+                "https://example.com/b".to_string(),
+            ]
+        );
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_keeps_partial_on_midpage_failure() {
+        let mut server = mockito::Server::new_async().await;
+
+        let next = format!(
+            "{}/api/v3/domains/example.com/urls?limit=40&cursor=PAGE2",
+            server.url()
+        );
+        let _page1 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::Exact("limit=40".into()))
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"data": [{{"attributes": {{"url": "https://example.com/a"}}}}], "links": {{"next": "{next}"}}}}"#
+            ))
+            .create_async()
+            .await;
+        // The follow-up page fails: keep page one and flag the result partial.
+        let _page2 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "cursor".into(),
+                "PAGE2".into(),
+            ))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = VirusTotalProvider::new("test_api_key".to_string());
+        provider.with_base_url(server.url());
+        provider.with_retries(0); // fail fast, no back-off sleeps
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "t · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+        assert_eq!(urls, vec!["https://example.com/a".to_string()]);
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_404_returns_empty() {
+        // A domain with no VT object answers 404; treat it as "no data", not an
+        // error, matching the other providers.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::Any)
+            .with_status(404)
+            .with_body(r#"{"error": {"code": "NotFoundError"}}"#)
+            .create_async()
+            .await;
+
+        let mut provider = VirusTotalProvider::new("test_api_key".to_string());
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert!(urls.is_empty());
     }
 }

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -33,21 +33,25 @@ pub struct VirusTotalProvider {
 }
 
 /// A page of the v3 `/domains/{domain}/urls` response. `data` holds the URL
-/// objects; `links.next` is a complete URL for the following page (absent on
-/// the last page). `Default` lets a 404 ("no such domain") resolve to an empty
-/// page rather than an error.
+/// objects; `meta.cursor` is the opaque token for the next page (absent on the
+/// last page). We deliberately page via this token rather than the sibling
+/// `links.next` absolute URL: `links.next` is server-controlled, and following
+/// it would send the `x-apikey` header to whatever host it names — a credential
+/// leak under a malicious/MITM'd response. Rebuilding the request from the
+/// trusted base URL + cursor removes that trust entirely. `Default` lets a 404
+/// ("no such domain") resolve to an empty page rather than an error.
 #[derive(Debug, Deserialize, Default)]
 struct VtUrlsResponse {
     #[serde(default)]
     data: Vec<VtUrlObject>,
     #[serde(default)]
-    links: VtLinks,
+    meta: VtMeta,
 }
 
 #[derive(Debug, Deserialize, Default)]
-struct VtLinks {
+struct VtMeta {
     #[serde(default)]
-    next: Option<String>,
+    cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,22 +109,36 @@ impl VirusTotalProvider {
         }
     }
 
-    /// First-page URL for a domain's v3 `urls` relationship.
-    fn first_page_url(&self, domain: &str) -> String {
+    /// Build a page URL for a domain's v3 `urls` relationship from the *trusted*
+    /// base, optionally carrying an opaque pagination `cursor`. Always built
+    /// from our own base host (never a server-supplied URL), so the API key is
+    /// only ever sent to VirusTotal.
+    fn page_url(&self, domain: &str, cursor: Option<&str>) -> String {
         let encoded = url::form_urlencoded::byte_serialize(domain.as_bytes()).collect::<String>();
-        #[cfg(test)]
-        {
-            format!(
-                "{}/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}",
-                self.base_url
-            )
+        let mut url = {
+            #[cfg(test)]
+            {
+                format!(
+                    "{}/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}",
+                    self.base_url
+                )
+            }
+            #[cfg(not(test))]
+            {
+                format!(
+                    "https://www.virustotal.com/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}"
+                )
+            }
+        };
+        if let Some(cursor) = cursor {
+            // The cursor is opaque base64-ish; percent-encode so reserved bytes
+            // survive being spliced into the query string.
+            let encoded_cursor: String =
+                url::form_urlencoded::byte_serialize(cursor.as_bytes()).collect();
+            url.push_str("&cursor=");
+            url.push_str(&encoded_cursor);
         }
-        #[cfg(not(test))]
-        {
-            format!(
-                "https://www.virustotal.com/api/v3/domains/{encoded}/urls?limit={VT_PAGE_LIMIT}"
-            )
-        }
+        url
     }
 
     /// Fetch and parse a single page with retry/back-off and key rotation.
@@ -232,27 +250,34 @@ impl Provider for VirusTotalProvider {
             }
 
             // Walk the v3 cursor: each page returns up to VT_PAGE_LIMIT URL
-            // objects plus a `links.next` pointing at the following page. The
-            // deprecated v2 `domain/report` returned a single server-capped,
-            // non-paginated slice that silently truncated large domains.
-            let mut next_url = Some(self.first_page_url(domain));
+            // objects plus a `meta.cursor` token for the next page. We rebuild
+            // each request from the trusted base + cursor (never the server's
+            // `links.next` URL). The deprecated v2 `domain/report` returned a
+            // single server-capped, non-paginated slice that silently truncated
+            // large domains.
             let mut urls = Vec::new();
+            let mut cursor: Option<String> = None;
             let mut pages = 0usize;
 
-            while let Some(url) = next_url.take() {
+            loop {
                 pages += 1;
                 if pages > VT_MAX_PAGES {
                     break;
                 }
+                // "First request" tracked explicitly: a clean (HTTP 200) but
+                // empty leading page can still carry a cursor, so emptiness is
+                // not a reliable proxy for "first page".
+                let first_page = pages == 1;
+                let url = self.page_url(domain, cursor.as_deref());
 
                 let page = match self.fetch_page(&client, &url, limiter).await {
                     Ok(page) => page,
                     Err(e) => {
-                        // A failure on the first page (nothing collected) is
-                        // fatal; a later failure keeps what we have and flags
-                        // the result partial rather than presenting a truncated
-                        // crawl as a clean success.
-                        if urls.is_empty() {
+                        // A failure on the very first request is fatal; any
+                        // later failure keeps what we have and flags the result
+                        // partial rather than presenting a truncated crawl as a
+                        // clean success.
+                        if first_page {
                             return Err(e);
                         }
                         if let Some(r) = &reporter {
@@ -269,7 +294,10 @@ impl Provider for VirusTotalProvider {
                     r.detail(format!("{} URLs…", urls.len()));
                 }
 
-                next_url = page.links.next;
+                match page.meta.cursor {
+                    Some(c) if !c.is_empty() => cursor = Some(c),
+                    _ => break,
+                }
             }
 
             urls.sort();
@@ -479,7 +507,8 @@ mod tests {
 
     #[test]
     fn test_vt_response_deserialize() {
-        // v3 shape: data[].attributes.url, with a links.next cursor.
+        // v3 shape: data[].attributes.url plus a meta.cursor token. The
+        // server-controlled `links` block is present but intentionally ignored.
         let json = r#"{
             "data": [
                 {"type": "url", "id": "a", "attributes": {"url": "https://example.com/page1"}},
@@ -493,21 +522,21 @@ mod tests {
         assert_eq!(response.data.len(), 2);
         assert_eq!(response.data[0].attributes.url, "https://example.com/page1");
         assert_eq!(response.data[1].attributes.url, "https://example.com/page2");
-        assert_eq!(response.links.next.as_deref(), Some("https://x/next"));
+        assert_eq!(response.meta.cursor.as_deref(), Some("CURSOR"));
     }
 
     #[test]
     fn test_vt_response_empty_deserialize() {
-        // No data and no `next` (last/empty page) must parse cleanly.
-        let json = r#"{"data": [], "links": {"self": "https://x/self"}}"#;
+        // No data and no cursor (last/empty page) must parse cleanly.
+        let json = r#"{"data": [], "meta": {}}"#;
         let response: VtUrlsResponse = serde_json::from_str(json).unwrap();
         assert!(response.data.is_empty());
-        assert!(response.links.next.is_none());
+        assert!(response.meta.cursor.is_none());
 
         // A bare object also parses (all fields default).
         let response: VtUrlsResponse = serde_json::from_str("{}").unwrap();
         assert!(response.data.is_empty());
-        assert!(response.links.next.is_none());
+        assert!(response.meta.cursor.is_none());
     }
 
     #[tokio::test]
@@ -542,7 +571,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
 
         // v3: domain in the path, key in the x-apikey header, urls under
-        // data[].attributes.url. A single page (no links.next) ends the walk.
+        // data[].attributes.url. A single page (no meta.cursor) ends the walk.
         let m = server
             .mock("GET", "/api/v3/domains/example.com/urls")
             .match_header("x-apikey", "test_api_key")
@@ -555,7 +584,7 @@ mod tests {
                         {"attributes": {"url": "https://example.com/page1"}},
                         {"attributes": {"url": "https://example.com/page2"}}
                     ],
-                    "links": {"self": "x"}
+                    "meta": {}
                 }"#,
             )
             .expect(1)
@@ -577,25 +606,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_urls_paginates_via_links_next() {
+    async fn test_fetch_urls_paginates_via_cursor_ignoring_server_next_url() {
         let mut server = mockito::Server::new_async().await;
 
-        // Page one hands back a complete `links.next` URL pointing at page two.
-        let next = format!(
-            "{}/api/v3/domains/example.com/urls?limit=40&cursor=PAGE2",
-            server.url()
-        );
+        // Page one hands back a meta.cursor token AND a hostile `links.next`
+        // pointing at an unrelated host. The provider must page by rebuilding
+        // the request from its trusted base + cursor and must NEVER follow
+        // links.next (which would leak the x-apikey header off-host). Page two
+        // is served from THIS server keyed by cursor=PAGE2, so the fact that it
+        // is reached proves links.next was ignored.
         let page1 = server
             .mock("GET", "/api/v3/domains/example.com/urls")
             .match_query(mockito::Matcher::Exact("limit=40".into()))
             .with_status(200)
-            .with_body(format!(
-                r#"{{"data": [{{"attributes": {{"url": "https://example.com/a"}}}}], "links": {{"next": "{next}"}}}}"#
-            ))
+            .with_body(
+                r#"{
+                    "data": [{"attributes": {"url": "https://example.com/a"}}],
+                    "meta": {"cursor": "PAGE2"},
+                    "links": {"next": "http://127.0.0.1:1/evil?leak=key"}
+                }"#,
+            )
             .expect(1)
             .create_async()
             .await;
-        // Page two is keyed by the cursor and carries no `next`, so the walk ends.
+        // Page two is keyed by the cursor and carries no cursor, so the walk ends.
         let page2 = server
             .mock("GET", "/api/v3/domains/example.com/urls")
             .match_query(mockito::Matcher::UrlEncoded(
@@ -604,7 +638,7 @@ mod tests {
             ))
             .with_status(200)
             .with_body(
-                r#"{"data": [{"attributes": {"url": "https://example.com/b"}}], "links": {}}"#,
+                r#"{"data": [{"attributes": {"url": "https://example.com/b"}}], "meta": {}}"#,
             )
             .expect(1)
             .create_async()
@@ -629,17 +663,13 @@ mod tests {
     async fn test_fetch_urls_keeps_partial_on_midpage_failure() {
         let mut server = mockito::Server::new_async().await;
 
-        let next = format!(
-            "{}/api/v3/domains/example.com/urls?limit=40&cursor=PAGE2",
-            server.url()
-        );
         let _page1 = server
             .mock("GET", "/api/v3/domains/example.com/urls")
             .match_query(mockito::Matcher::Exact("limit=40".into()))
             .with_status(200)
-            .with_body(format!(
-                r#"{{"data": [{{"attributes": {{"url": "https://example.com/a"}}}}], "links": {{"next": "{next}"}}}}"#
-            ))
+            .with_body(
+                r#"{"data": [{"attributes": {"url": "https://example.com/a"}}], "meta": {"cursor": "PAGE2"}}"#,
+            )
             .create_async()
             .await;
         // The follow-up page fails: keep page one and flag the result partial.
@@ -663,6 +693,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(urls, vec!["https://example.com/a".to_string()]);
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_empty_first_page_then_failure_is_partial_not_error() {
+        // A clean (HTTP 200) but EMPTY first page can still carry a cursor. A
+        // later-page failure must yield a partial (Ok) result, not a hard error
+        // — the first request succeeded. Guards against using urls.is_empty() as
+        // a "first page" proxy.
+        let mut server = mockito::Server::new_async().await;
+
+        let _page1 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::Exact("limit=40".into()))
+            .with_status(200)
+            .with_body(r#"{"data": [], "meta": {"cursor": "PAGE2"}}"#)
+            .create_async()
+            .await;
+        let _page2 = server
+            .mock("GET", "/api/v3/domains/example.com/urls")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "cursor".into(),
+                "PAGE2".into(),
+            ))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = VirusTotalProvider::new("test_api_key".to_string());
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "t · ");
+        let result = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await;
+        assert!(
+            result.is_ok(),
+            "empty-but-200 first page + later failure must be partial, not error"
+        );
+        assert!(result.unwrap().is_empty());
         assert!(reporter.is_partial());
     }
 

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -145,8 +145,7 @@ pub struct WaybackMachineProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     /// CDX `from=` timestamp (already normalised to 14 digits).
     from: Option<String>,
     /// CDX `to=` timestamp (already normalised to 14 digits).
@@ -166,7 +165,6 @@ impl WaybackMachineProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 5,
             rate_limit: None,
             from: None,
             to: None,
@@ -265,7 +263,7 @@ impl Provider for WaybackMachineProvider {
         Box::pin(async move {
             let client = self.client_config().build_client()?;
             let query_base = self.query_base(domain);
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             if let Some(r) = &reporter {
                 r.detail("fetching…");
@@ -369,12 +367,8 @@ impl Provider for WaybackMachineProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -393,8 +387,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(!provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 5);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]
@@ -450,17 +443,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let mut provider = WaybackMachineProvider::new();
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let mut provider = WaybackMachineProvider::new();
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -19,8 +19,7 @@ pub struct ZoomEyeProvider {
     retries: u32,
     random_agent: bool,
     insecure: bool,
-    parallel: u32,
-    rate_limit: Option<f32>,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
 }
@@ -88,7 +87,6 @@ impl ZoomEyeProvider {
             retries: 3,
             random_agent: false,
             insecure: false,
-            parallel: 1,
             rate_limit: None,
             #[cfg(test)]
             base_url: "https://api.zoomeye.ai".to_string(),
@@ -144,7 +142,7 @@ impl Provider for ZoomEyeProvider {
             let api_url = "https://api.zoomeye.ai/v2/search".to_string();
 
             let client = self.client_config().build_client()?;
-            let limiter = RateLimiter::from_rate(self.rate_limit);
+            let limiter = self.rate_limit.as_ref();
 
             let mut all_urls: Vec<String> = Vec::new();
             let mut page: u32 = 1;
@@ -290,12 +288,8 @@ impl Provider for ZoomEyeProvider {
         self.insecure = enabled;
     }
 
-    fn with_parallel(&mut self, parallel: u32) {
-        self.parallel = parallel;
-    }
-
     fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
-        self.rate_limit = rate_limit;
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
     }
 }
 
@@ -317,8 +311,7 @@ mod tests {
         assert_eq!(provider.retries, 3);
         assert!(!provider.random_agent);
         assert!(!provider.insecure);
-        assert_eq!(provider.parallel, 1);
-        assert_eq!(provider.rate_limit, None);
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]
@@ -443,17 +436,10 @@ mod tests {
     }
 
     #[test]
-    fn test_with_parallel() {
-        let provider = &mut ZoomEyeProvider::new("test_api_key".to_string());
-        provider.with_parallel(10);
-        assert_eq!(provider.parallel, 10);
-    }
-
-    #[test]
     fn test_with_rate_limit() {
         let provider = &mut ZoomEyeProvider::new("test_api_key".to_string());
         provider.with_rate_limit(Some(2.5));
-        assert_eq!(provider.rate_limit, Some(2.5));
+        assert!(provider.rate_limit.is_some());
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,6 +1,8 @@
 use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use indicatif::ProgressBar;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::task;
 
@@ -26,6 +28,24 @@ fn fmt_count(n: usize) -> String {
         out.push(*b as char);
     }
     out
+}
+
+/// Update a provider line that is fetching several domains concurrently with an
+/// aggregate "done/total · URLs" counter — one line can't show every in-flight
+/// domain, so we summarise. Ticks so the spinner keeps moving between
+/// completions.
+fn tick_aggregate(
+    bar: &ProgressBar,
+    done: usize,
+    total: usize,
+    urls: usize,
+    no_progress: bool,
+    silent: bool,
+) {
+    bar.set_message(format!("{done}/{total} domains · {} URLs", fmt_count(urls)));
+    if !no_progress && !silent {
+        bar.tick();
+    }
 }
 
 /// Render an error as a single short line for a progress label, truncating on
@@ -108,7 +128,6 @@ pub fn apply_network_settings_to_provider(provider: &mut dyn Provider, settings:
     provider.with_retries(settings.retries);
     provider.with_random_agent(settings.random_agent);
     provider.with_insecure(settings.insecure);
-    provider.with_parallel(settings.parallel);
 
     if let Some(proxy) = &settings.proxy {
         provider.with_proxy(Some(proxy.clone()));
@@ -240,11 +259,6 @@ pub async fn process_domains(
     // Create provider bars - one bar per provider
     let provider_bars = progress_manager.create_provider_bars(provider_names);
 
-    // Create a queue for each provider
-    let provider_queues: Vec<Arc<Mutex<VecDeque<String>>>> = (0..providers.len())
-        .map(|_| Arc::new(Mutex::new(VecDeque::from(domains.clone()))))
-        .collect();
-
     // Create a tracking set for each domain to know when it's fully processed
     let domain_completion = Arc::new(Mutex::new(
         domains
@@ -273,15 +287,20 @@ pub async fn process_domains(
     let silent = args.silent;
     let no_progress = args.no_progress;
 
-    for (p_idx, (provider_clone, provider_name, original_idx)) in
-        provider_data.into_iter().enumerate()
-    {
-        let all_urls_clone = Arc::clone(&all_urls);
-        let stats_clone = Arc::clone(&stats);
-        let queue = Arc::clone(&provider_queues[p_idx]);
-        let provider_bar = provider_bars[original_idx].clone();
+    // --parallel bounds how many of a provider's domains are fetched at once.
+    // The shared per-provider rate limiter (stored in the provider and cloned
+    // per domain) keeps --rate-limit honest across these concurrent fetches.
+    let parallel = args.parallel.unwrap_or(5).max(1) as usize;
 
-        let completion_ctx = DomainCompletionCtx {
+    for (provider_clone, provider_name, original_idx) in provider_data.into_iter() {
+        let all_urls = Arc::clone(&all_urls);
+        let stats = Arc::clone(&stats);
+        let provider_bar = provider_bars[original_idx].clone();
+        let domains = domains.clone();
+
+        // Shared so each concurrent domain future can mark domain completion
+        // against the run-wide progress without contending on a &mut.
+        let completion_ctx = Arc::new(DomainCompletionCtx {
             total_providers,
             total_domains,
             domain_completion: Arc::clone(&domain_completion),
@@ -289,144 +308,216 @@ pub async fn process_domains(
             overall_bar: overall_bar.clone(),
             verbose,
             silent,
-        };
+        });
+
+        // With one domain in flight the single provider line can show rich
+        // per-domain detail (live page counts). With several concurrent, that
+        // line can't represent them all, so fall back to an aggregate counter.
+        let effective_parallel = parallel.min(domains.len().max(1));
+        let rich = effective_parallel <= 1;
 
         // Spawn a task for this provider
         let provider_future = task::spawn(async move {
-            // Running totals used to freeze the line on an honest end-of-run
-            // summary.
-            let mut provider_url_total = 0usize;
-            let mut provider_err_total = 0usize;
-            let mut provider_partial_total = 0usize;
+            let provider = Arc::new(provider_clone);
+            // Running totals are atomics so the concurrent domain futures below
+            // can update them; read back for an honest end-of-run summary.
+            let url_total = Arc::new(AtomicUsize::new(0));
+            let err_total = Arc::new(AtomicUsize::new(0));
+            let partial_total = Arc::new(AtomicUsize::new(0));
+            let done = Arc::new(AtomicUsize::new(0));
+            let total = domains.len();
 
-            // Process all domains assigned to this provider
-            loop {
-                // Get the next domain from this provider's queue
-                let domain = {
-                    let mut queue = lock_ignore_poison(&queue);
-                    match queue.pop_front() {
-                        Some(domain) => domain,
-                        None => break, // No more domains to process for this provider
-                    }
-                };
+            // Handles retained for the summary after the stream consumes the
+            // per-domain clones.
+            let summary_bar = provider_bar.clone();
+            let summary_name = provider_name.clone();
+            let summary_urls = Arc::clone(&url_total);
+            let summary_errs = Arc::clone(&err_total);
+            let summary_partials = Arc::clone(&partial_total);
 
-                // Re-arm the spinner and reset the per-domain elapsed timer so
-                // the line reads as "this fetch", not "since the run started".
-                // The status gutter is the live spinner, so the prefix is just
-                // the bare (padded) provider name — the finished branches below
-                // swap in a "glyph + name" prefix that lands in the same column.
-                let prefix = format!("{domain} · ");
-                provider_bar.set_style(provider_running_style());
-                provider_bar.set_prefix(format!("{provider_name:<16}"));
-                provider_bar.reset_elapsed();
-                provider_bar.set_message(format!("{prefix}fetching…"));
-                if !no_progress && !silent {
-                    provider_bar.tick();
-                }
-
-                // A paginating provider (Wayback) uses this handle to surface
-                // real page-by-page progress and to flag incomplete results.
-                // Built whenever output is allowed — including under
-                // --no-progress, so the partial-result signal still reaches the
-                // warning path; only --silent suppresses it.
-                let reporter = if !silent {
-                    Some(ProgressReporter::new(provider_bar.clone(), prefix))
-                } else {
-                    None
-                };
-
-                // Fetch URLs for this domain using this provider.
-                let fetch_start = std::time::Instant::now();
-                let fetch_result = provider_clone
-                    .fetch_urls_with_progress(&domain, reporter.clone())
-                    .await;
-                let fetch_elapsed = fetch_start.elapsed();
-                match fetch_result {
-                    Ok(urls) => {
-                        let url_count = urls.len();
-                        provider_url_total += url_count;
-
-                        // The provider may have returned a *partial* result
-                        // (e.g. a page failed mid-pagination). Surface that as a
-                        // distinct, warned state rather than a clean success, so
-                        // a truncated crawl is never mistaken for a complete one.
-                        let partial = reporter.as_ref().is_some_and(|r| r.is_partial());
-                        if partial {
-                            provider_partial_total += 1;
-                            provider_bar.set_style(provider_partial_style());
-                            provider_bar.set_prefix(format!("◐ {provider_name:<16}"));
-                            provider_bar.set_message(format!(
-                                "{domain} · {} URLs (partial)",
-                                fmt_count(url_count)
-                            ));
-                            if verbose && !silent {
-                                eprintln!(
-                                    "Warning: partial results for {domain} from {provider_name}: a request failed mid-fetch; returning {url_count} URL(s) collected so far"
-                                );
-                            }
-                        } else {
-                            provider_bar.set_style(provider_success_style());
-                            provider_bar.set_prefix(format!("✓ {provider_name:<16}"));
-                            provider_bar
-                                .set_message(format!("{domain} · {} URLs", fmt_count(url_count)));
-                        }
-                        provider_bar.tick();
-
-                        // Add URLs to the shared map (URL -> set of providers).
-                        {
-                            let mut url_map = lock_ignore_poison(&all_urls_clone);
-                            for url in urls {
-                                url_map
-                                    .entry(url)
-                                    .or_default()
-                                    .insert(provider_name.clone());
-                            }
-                        }
-
-                        // Update per-provider stats.
-                        {
-                            let mut s = lock_ignore_poison(&stats_clone);
-                            s[original_idx].url_count += url_count;
-                            if partial {
-                                s[original_idx].partial_count += 1;
-                            }
-                            s[original_idx].elapsed += fetch_elapsed;
-                        }
-
-                        completion_ctx.track(&domain);
-
-                        if verbose && !silent {
-                            println!(
-                                "  - {}: Found {} URLs for {}",
-                                provider_name, url_count, domain
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        provider_err_total += 1;
-
-                        provider_bar.set_style(provider_error_style());
-                        provider_bar.set_prefix(format!("✗ {provider_name:<16}"));
-                        provider_bar.set_message(format!("{domain} · {}", short_error(&e)));
-                        provider_bar.tick();
-
-                        {
-                            let mut s = lock_ignore_poison(&stats_clone);
-                            s[original_idx].error_count += 1;
-                            s[original_idx].elapsed += fetch_elapsed;
-                        }
-
-                        completion_ctx.track(&domain);
-
-                        if verbose && !silent {
-                            eprintln!("Error fetching URLs for {domain} from {provider_name}: {e}");
-                        }
-                    }
-                }
+            // Prime the line. In aggregate mode the elapsed timer measures the
+            // whole provider run; rich mode resets it per domain below.
+            provider_bar.set_style(provider_running_style());
+            provider_bar.set_prefix(format!("{provider_name:<16}"));
+            provider_bar.reset_elapsed();
+            if !rich {
+                provider_bar.set_message(format!("0/{total} domains"));
             }
+            if !no_progress && !silent {
+                provider_bar.tick();
+            }
+
+            stream::iter(domains)
+                .map(move |domain| {
+                    let provider = Arc::clone(&provider);
+                    let provider_bar = provider_bar.clone();
+                    let provider_name = provider_name.clone();
+                    let all_urls = Arc::clone(&all_urls);
+                    let stats = Arc::clone(&stats);
+                    let completion_ctx = Arc::clone(&completion_ctx);
+                    let url_total = Arc::clone(&url_total);
+                    let err_total = Arc::clone(&err_total);
+                    let partial_total = Arc::clone(&partial_total);
+                    let done = Arc::clone(&done);
+
+                    async move {
+                        let prefix = format!("{domain} · ");
+
+                        // Rich mode: the reporter drives the visible line with
+                        // live page-by-page detail and re-arms the spinner.
+                        // Aggregate mode: it only carries the partial-result
+                        // flag (a hidden bar) so concurrent domains don't fight
+                        // over the single line; --silent suppresses it entirely.
+                        let reporter = if silent {
+                            None
+                        } else if rich {
+                            provider_bar.set_style(provider_running_style());
+                            provider_bar.set_prefix(format!("{provider_name:<16}"));
+                            provider_bar.reset_elapsed();
+                            provider_bar.set_message(format!("{prefix}fetching…"));
+                            if !no_progress {
+                                provider_bar.tick();
+                            }
+                            Some(ProgressReporter::new(provider_bar.clone(), prefix.clone()))
+                        } else {
+                            Some(ProgressReporter::new(ProgressBar::hidden(), prefix.clone()))
+                        };
+
+                        // Fetch URLs for this domain using this provider.
+                        let fetch_start = std::time::Instant::now();
+                        let fetch_result = provider
+                            .fetch_urls_with_progress(&domain, reporter.clone())
+                            .await;
+                        let fetch_elapsed = fetch_start.elapsed();
+                        match fetch_result {
+                            Ok(urls) => {
+                                let url_count = urls.len();
+                                url_total.fetch_add(url_count, Ordering::Relaxed);
+
+                                // A *partial* result (e.g. a page failed
+                                // mid-pagination) is surfaced as a distinct,
+                                // warned state so a truncated crawl is never
+                                // mistaken for a clean success.
+                                let partial =
+                                    reporter.as_ref().is_some_and(|r| r.is_partial());
+                                if partial {
+                                    partial_total.fetch_add(1, Ordering::Relaxed);
+                                }
+
+                                // Add URLs to the shared map (URL -> providers).
+                                {
+                                    let mut url_map = lock_ignore_poison(&all_urls);
+                                    for url in urls {
+                                        url_map
+                                            .entry(url)
+                                            .or_default()
+                                            .insert(provider_name.clone());
+                                    }
+                                }
+
+                                // Update per-provider stats.
+                                {
+                                    let mut s = lock_ignore_poison(&stats);
+                                    s[original_idx].url_count += url_count;
+                                    if partial {
+                                        s[original_idx].partial_count += 1;
+                                    }
+                                    s[original_idx].elapsed += fetch_elapsed;
+                                }
+
+                                let done_n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                                if rich {
+                                    if partial {
+                                        provider_bar.set_style(provider_partial_style());
+                                        provider_bar
+                                            .set_prefix(format!("◐ {provider_name:<16}"));
+                                        provider_bar.set_message(format!(
+                                            "{domain} · {} URLs (partial)",
+                                            fmt_count(url_count)
+                                        ));
+                                    } else {
+                                        provider_bar.set_style(provider_success_style());
+                                        provider_bar
+                                            .set_prefix(format!("✓ {provider_name:<16}"));
+                                        provider_bar.set_message(format!(
+                                            "{domain} · {} URLs",
+                                            fmt_count(url_count)
+                                        ));
+                                    }
+                                    provider_bar.tick();
+                                    if partial && verbose && !silent {
+                                        eprintln!(
+                                            "Warning: partial results for {domain} from {provider_name}: a request failed mid-fetch; returning {url_count} URL(s) collected so far"
+                                        );
+                                    }
+                                } else {
+                                    tick_aggregate(
+                                        &provider_bar,
+                                        done_n,
+                                        total,
+                                        url_total.load(Ordering::Relaxed),
+                                        no_progress,
+                                        silent,
+                                    );
+                                }
+
+                                completion_ctx.track(&domain);
+
+                                if verbose && !silent {
+                                    println!(
+                                        "  - {provider_name}: Found {url_count} URLs for {domain}"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                err_total.fetch_add(1, Ordering::Relaxed);
+
+                                {
+                                    let mut s = lock_ignore_poison(&stats);
+                                    s[original_idx].error_count += 1;
+                                    s[original_idx].elapsed += fetch_elapsed;
+                                }
+
+                                let done_n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                                if rich {
+                                    provider_bar.set_style(provider_error_style());
+                                    provider_bar.set_prefix(format!("✗ {provider_name:<16}"));
+                                    provider_bar
+                                        .set_message(format!("{domain} · {}", short_error(&e)));
+                                    provider_bar.tick();
+                                } else {
+                                    tick_aggregate(
+                                        &provider_bar,
+                                        done_n,
+                                        total,
+                                        url_total.load(Ordering::Relaxed),
+                                        no_progress,
+                                        silent,
+                                    );
+                                }
+
+                                completion_ctx.track(&domain);
+
+                                if verbose && !silent {
+                                    eprintln!(
+                                        "Error fetching URLs for {domain} from {provider_name}: {e}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                })
+                .buffer_unordered(effective_parallel)
+                .collect::<Vec<()>>()
+                .await;
 
             // Freeze this provider's line on a one-line summary that reflects
             // what actually happened across all of its domains.
+            let provider_bar = summary_bar;
+            let provider_name = summary_name;
+            let provider_url_total = summary_urls.load(Ordering::Relaxed);
+            let provider_err_total = summary_errs.load(Ordering::Relaxed);
+            let provider_partial_total = summary_partials.load(Ordering::Relaxed);
             if provider_url_total == 0 && provider_err_total > 0 {
                 provider_bar.set_style(provider_error_style());
                 provider_bar.set_prefix(format!("✗ {provider_name:<16}"));


### PR DESCRIPTION
Two related provider changes that share `vt.rs`, `cli/mod.rs`, and the provider files, so they ride one branch. Reviewable as separate commits.

## #270 — `--parallel` now actually parallelizes per-provider requests

`--parallel` was documented as "maximum parallel requests per provider" but the value was only stored (`with_parallel`) and never read in any fetch path: the runner spawned one task per provider that drained its domain queue strictly **sequentially**, so effective intra-provider concurrency was 1.

- Each provider's domains now stream through `buffer_unordered(--parallel)`, so up to N domains are fetched concurrently per provider.
- The provider line keeps rich live per-domain detail when a single domain is in flight (single domain or `--parallel 1`) and switches to an aggregate `done/total · URLs` counter when several run concurrently.
- **Rate limiting stays correct under concurrency**: the built `RateLimiter` is now stored in the provider (`rate_limit: Option<RateLimiter>`) instead of rebuilt per fetch. `RateLimiter` clones share an inner `Arc`, so the per-domain provider clones all pace against one shared schedule rather than each getting an independent limiter that would multiply the effective rate by `--parallel` (the concern raised re: #266).
- Removed the now-confirmed-dead per-provider `parallel` field and the `with_parallel` trait method/impls — concurrency lives in the runner, not the provider.

Tests: per-provider concurrency (~200 ms for 5×200 ms fetches at `--parallel 5`), sequential at `--parallel 1` (~1 s), and `RateLimiter` clones sharing one schedule.

## #271 — VirusTotal v3 migration + Common Crawl default `latest`

Per the decisions in #271 (maintainer calls):

- **VirusTotal → API v3.** The provider used the deprecated v2 `domain/report`, whose `detected_urls` is a fixed, server-capped, non-paginated slice — large domains were silently truncated. Switched to `GET /api/v3/domains/{domain}/urls` with the `x-apikey` header and cursor pagination, so large domains complete. Key rotation and `URX_VT_API_KEY` are unchanged. A 404 (no VT object) resolves to empty; a mid-pagination failure flags a partial result like the other paginating providers.
  - **Security:** pages via the opaque `meta.cursor` token rebuilt onto the trusted base URL, **not** the server-controlled `links.next` — sending `x-apikey` to a server-named host would leak the key (realistic under `--insecure`). Regression-tested with a hostile `links.next`.
- **Common Crawl default → `latest`.** The default `--cc-index` was a single pinned index that ages each release; flipped it to `latest` (resolved at runtime via `collinfo.json`, already supported) and updated the config-override gate in lockstep.
- **apex/www:** intentionally left as-is (existing www-as-apex validation + the #265 `--subs` hint).

## Verification

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (460 passing) all green. Changes were put through a multi-agent adversarial review; the two bugs it confirmed (VT key-leak via `links.next`, wrong error on an empty-but-200 first page) are fixed and regression-tested in the final VT commit.

Closes #270
Closes #271
