### PR TITLE
Complete rate-limit/pagination/client-reuse hardening (#266, #267, #268)

### DIFF
--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -10,10 +10,12 @@ use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
-/// Maximum search-result pages we fetch per domain. GitHub Code Search caps
-/// at 1000 results total (10 × 100), and each page costs against a tight
-/// rate limit, so we stop early by default.
-const MAX_PAGES: u32 = 3;
+/// Maximum search-result pages we fetch per domain. GitHub Code Search caps at
+/// 1000 results total (10 × 100), so 10 pages covers everything the API will
+/// return; a smaller cap silently truncated large domains. The page loop still
+/// stops as soon as a page comes back empty, so domains with fewer results
+/// never pay for the extra pages — and `--rate-limit` paces the requests.
+const MAX_PAGES: u32 = 10;
 const PER_PAGE: u32 = 100;
 
 #[derive(Clone)]

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 use crate::providers::Provider;
 
 #[derive(Clone)]
@@ -16,6 +17,7 @@ pub struct RobotsProvider {
     proxy: Option<String>,
     proxy_auth: Option<String>,
     insecure: bool,
+    rate_limit: Option<RateLimiter>,
     #[cfg(test)]
     base_url: String,
     #[cfg(test)]
@@ -31,6 +33,7 @@ impl RobotsProvider {
             proxy: None,
             proxy_auth: None,
             insecure: false,
+            rate_limit: None,
             #[cfg(test)]
             base_url: String::new(),
             #[cfg(test)]
@@ -79,6 +82,7 @@ impl Provider for RobotsProvider {
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             let client = self.build_client()?;
+            let limiter = self.rate_limit.as_ref();
 
             #[cfg(not(test))]
             let https_url = format!("https://{domain}/robots.txt");
@@ -93,6 +97,9 @@ impl Provider for RobotsProvider {
             let mut urls = Vec::new();
 
             // Try HTTPS first
+            if let Some(rl) = &limiter {
+                rl.acquire().await;
+            }
             let https_resp = client.get(&https_url).send().await;
             // Track which protocol was successful
             let (is_https, text) = match https_resp {
@@ -114,6 +121,9 @@ impl Provider for RobotsProvider {
                     // robots.txt discovery is best-effort: a transport failure
                     // on the HTTP fallback means "no robots.txt", not a fatal
                     // error that should sink the whole provider.
+                    if let Some(rl) = &limiter {
+                        rl.acquire().await;
+                    }
                     let http_resp = match client.get(&http_url).send().await {
                         Ok(resp) => resp,
                         Err(_) => return Ok(urls),
@@ -186,7 +196,9 @@ impl Provider for RobotsProvider {
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
     }
-    fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
+    fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
+    }
 }
 
 #[cfg(test)]
@@ -202,8 +214,19 @@ mod tests {
         assert_eq!(provider.proxy, None);
         assert_eq!(provider.proxy_auth, None);
         assert!(!provider.insecure);
+        assert!(provider.rate_limit.is_none());
         assert_eq!(provider.base_url, String::new());
         assert_eq!(provider.base_url_http, String::new());
+    }
+
+    #[test]
+    fn test_with_rate_limit() {
+        let mut provider = RobotsProvider::new();
+        provider.with_rate_limit(Some(2.5));
+        assert!(provider.rate_limit.is_some());
+        // A non-positive rate means "no limiting".
+        provider.with_rate_limit(Some(0.0));
+        assert!(provider.rate_limit.is_none());
     }
 
     #[test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use crate::network::client::HttpClientConfig;
+use crate::network::RateLimiter;
 use crate::providers::Provider;
 
 /// Max nesting depth for sitemap-index → sitemap recursion. A hostile or
@@ -51,6 +52,7 @@ pub struct SitemapProvider {
     proxy: Option<String>,
     proxy_auth: Option<String>,
     insecure: bool,
+    rate_limit: Option<RateLimiter>,
 }
 
 impl SitemapProvider {
@@ -62,6 +64,7 @@ impl SitemapProvider {
             proxy: None,
             proxy_auth: None,
             insecure: false,
+            rate_limit: None,
         }
     }
 
@@ -93,6 +96,7 @@ impl SitemapProvider {
         sitemap_url: &str,
         depth: usize,
         visited: &mut HashSet<String>,
+        limiter: Option<&RateLimiter>,
     ) -> Result<Vec<String>> {
         if depth > MAX_SITEMAP_DEPTH {
             return Ok(Vec::new());
@@ -102,6 +106,11 @@ impl SitemapProvider {
             return Ok(Vec::new());
         }
 
+        // Pace nested-sitemap fetches: a sitemap index can chain to many child
+        // sitemaps, so honor --rate-limit before each request.
+        if let Some(rl) = limiter {
+            rl.acquire().await;
+        }
         let resp = client.get(sitemap_url).send().await?;
         if !resp.status().is_success() {
             return Ok(Vec::new());
@@ -144,6 +153,7 @@ impl SitemapProvider {
                                     nested_sitemap_url,
                                     depth + 1,
                                     visited,
+                                    limiter,
                                 ))
                                 .await?;
                                 urls.extend(nested_urls);
@@ -200,6 +210,7 @@ impl Provider for SitemapProvider {
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             let client = self.build_client()?;
+            let limiter = self.rate_limit.as_ref();
             let mut urls = Vec::new();
             // Shared across all candidate locations so a sitemap reachable from
             // more than one entry point is fetched at most once.
@@ -216,13 +227,19 @@ impl Provider for SitemapProvider {
             ];
 
             for sitemap_url in sitemap_urls {
+                // Pace the candidate-location probes too: this loop fires up to
+                // six back-to-back requests at the target.
+                if let Some(rl) = &limiter {
+                    rl.acquire().await;
+                }
                 let resp = client.get(&sitemap_url).send().await;
 
                 if let Ok(resp) = resp {
                     if resp.status().is_success() {
                         // Found a valid sitemap, parse it
                         let sitemap_urls =
-                            Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited).await?;
+                            Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited, limiter)
+                                .await?;
                         urls.extend(sitemap_urls);
                     }
                 }
@@ -251,7 +268,9 @@ impl Provider for SitemapProvider {
     fn with_insecure(&mut self, enabled: bool) {
         self.insecure = enabled;
     }
-    fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
+    fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
+    }
 }
 
 #[cfg(test)]
@@ -268,6 +287,41 @@ mod tests {
         assert_eq!(provider.proxy, None);
         assert_eq!(provider.proxy_auth, None);
         assert!(!provider.insecure);
+        assert!(provider.rate_limit.is_none());
+    }
+
+    #[test]
+    fn test_with_rate_limit() {
+        let mut provider = SitemapProvider::new();
+        provider.with_rate_limit(Some(2.5));
+        assert!(provider.rate_limit.is_some());
+        // A non-positive rate means "no limiting".
+        provider.with_rate_limit(Some(0.0));
+        assert!(provider.rate_limit.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_paces_probe_requests() {
+        // fetch_urls fires up to six back-to-back candidate-location probes;
+        // --rate-limit must pace them. Before this provider honored the limiter
+        // `with_rate_limit` was a no-op and the probes raced out instantly.
+        let server = Server::new_async().await;
+        let host = server.host_with_port();
+
+        let mut provider = SitemapProvider::new();
+        provider.with_rate_limit(Some(20.0)); // 50ms minimum interval
+
+        let start = std::time::Instant::now();
+        // No mocks: every probe 404s/fails fast, but each acquire() still paces.
+        let _ = provider.fetch_urls(&host).await;
+
+        // Six probes => five enforced ~50ms gaps (~250ms). A no-op limiter would
+        // finish in a few ms; allow generous scheduler slack below that signal.
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "rate limit did not pace the sitemap probe requests: {:?}",
+            start.elapsed()
+        );
     }
 
     #[test]

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
-
+use reqwest::Client;
 use scraper::{Html, Selector};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
 use url::Url;
 
 use super::Tester;
@@ -17,6 +19,15 @@ pub struct LinkExtractor {
     retries: u32,
     random_agent: bool,
     insecure: bool,
+    /// One HTTP client, built lazily on first use and reused for every tested
+    /// URL. `reqwest::Client` pools connections internally, so building it once
+    /// (rather than per URL) lets TLS handshakes and keep-alive connections be
+    /// reused across the many URLs an `--extract-links` run can touch. Shared
+    /// across `clone_box` clones via `Arc<OnceCell>` so all concurrent workers
+    /// share a single connection pool. The cell is populated only after the
+    /// `with_*` setters have applied network settings, so it always reflects
+    /// the final configuration.
+    client: Arc<OnceCell<Client>>,
 }
 
 impl LinkExtractor {
@@ -29,6 +40,7 @@ impl LinkExtractor {
             retries: 3,
             random_agent: false,
             insecure: false,
+            client: Arc::new(OnceCell::new()),
         }
     }
 
@@ -40,6 +52,15 @@ impl LinkExtractor {
             proxy: self.proxy.clone(),
             proxy_auth: self.proxy_auth.clone(),
         }
+    }
+
+    /// Return the shared HTTP client, building it on the first call and reusing
+    /// it thereafter. If a build fails the cell stays empty, so a later call
+    /// retries rather than caching the error.
+    async fn client(&self) -> Result<&Client> {
+        self.client
+            .get_or_try_init(|| async { self.client_config().build_client() })
+            .await
     }
 
     /// Extracts links from HTML content, resolving them against a base URL
@@ -76,7 +97,7 @@ impl Tester for LinkExtractor {
         url: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
-            let client = self.client_config().build_client()?;
+            let client = self.client().await?;
 
             // Perform the request with retries
             let mut last_error = None;
@@ -262,5 +283,57 @@ mod tests {
         let html = "<a>No href</a>";
         let links = LinkExtractor::extract_links(&base_url, html);
         assert!(links.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_client_is_built_once_and_reused() {
+        let extractor = LinkExtractor::new();
+        // Lazy: nothing is built until the first request needs it.
+        assert!(extractor.client.get().is_none());
+
+        let first = extractor.client().await.unwrap() as *const reqwest::Client;
+        let second = extractor.client().await.unwrap() as *const reqwest::Client;
+
+        // Both calls hand back the exact same cached client instead of building
+        // a fresh one per URL — that shared client is what enables connection
+        // pooling across the many URLs an --extract-links run touches.
+        assert_eq!(first, second);
+        assert!(extractor.client.get().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_reused_client_extracts_from_multiple_urls() {
+        let mut server = mockito::Server::new_async().await;
+        let p1 = server
+            .mock("GET", "/p1")
+            .with_status(200)
+            .with_body(r#"<a href="https://example.com/one">x</a>"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let p2 = server
+            .mock("GET", "/p2")
+            .with_status(200)
+            .with_body(r#"<a href="https://example.com/two">y</a>"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let extractor = LinkExtractor::new();
+        let first = extractor
+            .test_url(&format!("{}/p1", server.url()))
+            .await
+            .unwrap();
+        let second = extractor
+            .test_url(&format!("{}/p2", server.url()))
+            .await
+            .unwrap();
+
+        assert_eq!(first, vec!["https://example.com/one".to_string()]);
+        assert_eq!(second, vec!["https://example.com/two".to_string()]);
+        // A single client was built and shared across both requests.
+        assert!(extractor.client.get().is_some());
+        p1.assert();
+        p2.assert();
     }
 }

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
-
+use reqwest::Client;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 use super::Tester;
 use crate::network::client::HttpClientConfig;
@@ -17,6 +19,15 @@ pub struct StatusChecker {
     insecure: bool,
     include_status: Option<Vec<String>>,
     exclude_status: Option<Vec<String>>,
+    /// One HTTP client, built lazily on first use and reused for every tested
+    /// URL. `reqwest::Client` pools connections internally, so building it once
+    /// (rather than per URL) lets TLS handshakes and keep-alive connections be
+    /// reused across the tens of thousands of URLs a `--check-status` run can
+    /// touch. Shared across `clone_box` clones via `Arc<OnceCell>` so all
+    /// concurrent workers share a single connection pool. The cell is populated
+    /// only after the `with_*` setters have applied network settings, so it
+    /// always reflects the final configuration.
+    client: Arc<OnceCell<Client>>,
 }
 
 impl StatusChecker {
@@ -31,6 +42,7 @@ impl StatusChecker {
             insecure: false,
             include_status: None,
             exclude_status: None,
+            client: Arc::new(OnceCell::new()),
         }
     }
 
@@ -52,6 +64,15 @@ impl StatusChecker {
             proxy: self.proxy.clone(),
             proxy_auth: self.proxy_auth.clone(),
         }
+    }
+
+    /// Return the shared HTTP client, building it on the first call and reusing
+    /// it thereafter. If a build fails the cell stays empty, so a later call
+    /// retries rather than caching the error.
+    async fn client(&self) -> Result<&Client> {
+        self.client
+            .get_or_try_init(|| async { self.client_config().build_client() })
+            .await
     }
 
     /// Checks if a status code matches a pattern
@@ -131,7 +152,7 @@ impl Tester for StatusChecker {
         url: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
-            let client = self.client_config().build_client()?;
+            let client = self.client().await?;
 
             // Perform the request with retries
             let mut last_error = None;
@@ -303,5 +324,72 @@ mod tests {
         checker.with_exclude_status(Some(vec!["2xx".to_string()]));
         assert!(checker.should_include_status(200));
         assert!(!checker.should_include_status(201));
+    }
+
+    #[tokio::test]
+    async fn test_client_is_built_once_and_reused() {
+        let checker = StatusChecker::new();
+        // Lazy: nothing is built until the first request needs it.
+        assert!(checker.client.get().is_none());
+
+        let first = checker.client().await.unwrap() as *const reqwest::Client;
+        let second = checker.client().await.unwrap() as *const reqwest::Client;
+
+        // Both calls hand back the exact same cached client instead of building
+        // a fresh one per URL — that shared client is what enables connection
+        // pooling across the many URLs a --check-status run touches.
+        assert_eq!(first, second);
+        assert!(checker.client.get().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_clones_share_one_client() {
+        // The tester manager calls clone_box() once per concurrent worker chunk;
+        // clone_box is `Box::new(self.clone())`, so the derived clone here
+        // exercises the same path. All clones share the Arc<OnceCell>, so a
+        // client built by one is visible to every other — that shared client is
+        // what gives the whole run a single connection pool.
+        let checker = StatusChecker::new();
+        let original = checker.client().await.unwrap() as *const reqwest::Client;
+
+        let cloned = checker.clone();
+        // The clone sees the already-built client without building its own.
+        assert!(cloned.client.get().is_some());
+        let cloned_client = cloned.client().await.unwrap() as *const reqwest::Client;
+        assert_eq!(original, cloned_client);
+    }
+
+    #[tokio::test]
+    async fn test_reused_client_checks_multiple_urls() {
+        let mut server = mockito::Server::new_async().await;
+        let ok = server
+            .mock("GET", "/ok")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+        let missing = server
+            .mock("GET", "/missing")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let checker = StatusChecker::new();
+        let ok_result = checker
+            .test_url(&format!("{}/ok", server.url()))
+            .await
+            .unwrap();
+        let missing_result = checker
+            .test_url(&format!("{}/missing", server.url()))
+            .await
+            .unwrap();
+
+        assert!(ok_result[0].contains("200"));
+        assert!(missing_result[0].contains("404"));
+        // A single client was built and shared across both requests.
+        assert!(checker.client.get().is_some());
+        ok.assert();
+        missing.assert();
     }
 }


### PR DESCRIPTION
Completes three open provider/tester issues. Each is a separate commit.

## #266 — Enforce `--rate-limit` / `--rate-limit-by` everywhere
The earlier enforcement work wired `RateLimiter` into the 7 network/API providers but left **SitemapProvider** and **RobotsProvider** with no-op `with_rate_limit`, so the flag silently didn't cover them. Sitemap is the worst case: it probes 6 candidate locations and recursively walks nested sitemap indexes, firing many back-to-back requests at the target.

- Thread `Option<&RateLimiter>` through the recursive `parse_sitemap`; `acquire()` before every request (probe loop + each nested fetch).
- `acquire()` before both robots.txt requests (HTTPS + HTTP fallback).
- No-rate-limit path is byte-for-byte unchanged.
- All **9 providers** now honor the flag, as the issue intended.

## #267 — Paginate GitHub to its full result ceiling
GitHub Code Search exposes up to 1000 results (10×100), but `MAX_PAGES` was **3**, silently truncating domains with >300 results. Raised to **10**. The loop still breaks on the first empty page, so smaller domains don't pay for extra pages, and `--rate-limit` paces the requests. (CommonCrawl/urlscan/ZoomEye pagination from the prior rounds is already in place.)

## #268 — Reuse one HTTP client across tested URLs
`StatusChecker`/`LinkExtractor` rebuilt a fresh `reqwest::Client` on **every** `test_url`, so the `--check-status` / `--extract-links` hot path paid a new TLS/connection setup per URL and never pooled connections. Now built lazily once via `Arc<OnceCell<Client>>` (the CommonCrawl pattern) and shared across `clone_box` workers → a single connection pool per run. The cell is populated only after the `with_*` setters run, so it always reflects final config.

## Verification
- `cargo test`: **472 passed, 0 failed, 2 ignored** (added: rate-limit storage + sitemap pacing timing test, GitHub past-3-pages test, tester reuse/clone-sharing/multi-URL tests)
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Adversarial multi-agent review (correctness, concurrency/lifecycle, tests, completeness) + a focused review of the new sitemap/robots wiring: **no real bugs** (verified one-acquire-per-send pacing, no Mutex deadlock in the recursion, non-flaky lower-bound timing test).

Closes #266
Closes #267
Closes #268