### PR TITLE
feat: add keyless Arquivo.pt provider and anonymous URLScan search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `arquivo` provider for [Arquivo.pt](https://arquivo.pt), the Portuguese web archive. Keyless; queries its Wayback-compatible CDX index (`output=json`) and walks `page=` cursors, stopping once a page adds no new URLs. Opt in with `--providers arquivo` or `--all-providers`
+- URLScan now works without an API key: the `urlscan` provider queries the public search endpoint anonymously (rate-limited to ~30 req/min per IP) and is no longer disabled when no key is configured. A key remains optional and only raises limits / enables rotation
 - Fix Wayback Machine timeouts on large domains: switch CDX to plain-text response with `collapse=urlkey` server-side dedup, raise default timeout to 60s, and filter non-URL response bodies
 - Bump default Common Crawl index to `CC-MAIN-2026-17`, and add `--cc-index latest` to auto-resolve the newest index via `collinfo.json` (cached per run, validated against `CC-MAIN-YYYY-WW` shape)
 - Track provider attribution per URL and surface it via `--show-sources` (JSON adds a `sources` field, CSV adds a `sources` column, plain text appends `[provider1,provider2]`)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Urx is a command-line tool designed for collecting URLs from OSINT archives, suc
 
 ## Features
 
-* Fetch URLs from multiple sources in parallel (Wayback Machine, Common Crawl, OTX)
+* Fetch URLs from multiple sources in parallel (Wayback Machine, Common Crawl, OTX, Arquivo.pt)
+* Keyless by default: Wayback, Common Crawl, OTX, Arquivo.pt, and URLScan (anonymous) all work without an API key
 * API key rotation support for VirusTotal and URLScan providers to mitigate rate limits
 * Filter results by file extensions, patterns, or predefined presets (e.g., "no-image" to exclude images)
 * URL normalization and deduplication: Sort query parameters, remove trailing slashes, and merge semantically identical URLs
@@ -107,7 +108,7 @@ Output Options:
 
 Provider Options:
       --providers <PROVIDERS>
-          Providers to use (comma-separated, e.g., "wayback,cc,otx,vt,urlscan") [default: wayback,cc,otx]
+          Providers to use (comma-separated, e.g., "wayback,cc,otx,arquivo,vt,urlscan") [default: wayback,cc,otx]
       --exclude-providers <EXCLUDE_PROVIDERS>
           Providers to exclude (comma-separated). Wins on conflict with --providers / --all-providers.
       --all-providers
@@ -125,7 +126,7 @@ Provider Options:
       --vt-api-key <VT_API_KEY>
           API key for VirusTotal (can be used multiple times for rotation, can also use URX_VT_API_KEY environment variable with comma-separated keys)
       --urlscan-api-key <URLSCAN_API_KEY>
-          API key for Urlscan (can be used multiple times for rotation, can also use URX_URLSCAN_API_KEY environment variable with comma-separated keys)
+          Optional API key for Urlscan; the provider also works anonymously (rate-limited ~30 req/min per IP). Can be used multiple times for rotation, or via URX_URLSCAN_API_KEY (comma-separated keys)
       --github-api-key <GITHUB_API_KEY>
           Personal access token for the GitHub Code Search provider (also reads URX_GITHUB_API_KEY, comma-separated for rotation)
 
@@ -214,6 +215,12 @@ urx example.com -p no-images
 
 # Use specific providers
 urx example.com --providers wayback,otx
+
+# Add the keyless Arquivo.pt (Portuguese web archive) provider
+urx example.com --providers wayback,cc,otx,arquivo
+
+# URLScan works without a key (anonymous, rate-limited); a key just raises limits
+urx example.com --providers urlscan
 
 # Using VirusTotal and URLScan providers
 # 1. Explicitly add to providers (with API keys via command line)

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -40,7 +40,7 @@ Provider Options:
   --wayback-from <DATE>                  Restrict Wayback results to >= DATE (YYYY/YYYYMM/YYYYMMDD/YYYYMMDDhhmmss)
   --wayback-to <DATE>                    Restrict Wayback results to <= DATE (same format as --wayback-from)
   --vt-api-key <VT_API_KEY>             API key for VirusTotal
-  --urlscan-api-key <URLSCAN_API_KEY>   API key for Urlscan
+  --urlscan-api-key <URLSCAN_API_KEY>   Optional API key for Urlscan (also works anonymously)
   --zoomeye-api-key <ZOOMEYE_API_KEY>   API key for ZoomEye
   --github-api-key <GITHUB_API_KEY>     Personal access token for GitHub Code Search (URX_GITHUB_API_KEY)
 
@@ -103,11 +103,12 @@ Cache Options:
 | Wayback Machine | `wayback` | No | - |
 | Common Crawl | `cc` | No | - |
 | OTX (AlienVault) | `otx` | No | - |
+| Arquivo.pt | `arquivo` | No | - |
 | VirusTotal | `vt` | Yes | `URX_VT_API_KEY` |
-| URLScan | `urlscan` | Yes | `URX_URLSCAN_API_KEY` |
+| URLScan | `urlscan` | No (optional) | `URX_URLSCAN_API_KEY` |
 | ZoomEye | `zoomeye` | Yes | `URX_ZOOMEYE_API_KEY` |
 
-Default providers: `wayback,cc,otx`. Providers requiring API keys are automatically enabled when their keys are provided.
+Default providers: `wayback,cc,otx`. Providers requiring API keys are automatically enabled when their keys are provided. `arquivo` (the Portuguese web archive) is keyless but opt-in — add it with `--providers` or enable everything with `--all-providers`. URLScan works anonymously without a key (rate-limited to ~30 requests/min per IP); a key only raises those limits and enables rotation.
 
 ## Filter Presets
 

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -37,11 +37,11 @@ normalize_url = false
 
 # ─── Providers ───────────────────────────────────────────
 [provider]
-providers = ["wayback", "cc", "otx"]
+providers = ["wayback", "cc", "otx"] # also available keyless: "arquivo", "urlscan" (anonymous)
 subs = false                          # Include subdomains
 cc_index = "CC-MAIN-2026-17"         # Common Crawl index (or "latest" to auto-resolve via collinfo.json)
 vt_api_key = ""                       # VirusTotal API key
-urlscan_api_key = ""                  # URLScan API key
+urlscan_api_key = ""                  # URLScan API key (optional; urlscan also works anonymously)
 zoomeye_api_key = ""                  # ZoomEye API key
 exclude_robots = false                # Skip robots.txt discovery
 exclude_sitemap = false               # Skip sitemap.xml discovery

--- a/docs/content/guide/environment-variables.md
+++ b/docs/content/guide/environment-variables.md
@@ -24,7 +24,9 @@ urx example.com --providers vt
 ```
 
 #### URX_URLSCAN_API_KEY
-URLScan API key for accessing the URLScan provider.
+Optional URLScan API key. The `urlscan` provider works anonymously without a
+key (rate-limited to ~30 requests/min per IP); set a key only to raise those
+limits and enable key rotation.
 
 ```bash
 export URX_URLSCAN_API_KEY=your_api_key_here
@@ -56,7 +58,7 @@ urx example.com --providers zoomeye
 | Variable | Provider | Description |
 |----------|----------|-------------|
 | `URX_VT_API_KEY` | VirusTotal | VirusTotal API key |
-| `URX_URLSCAN_API_KEY` | URLScan | URLScan API key |
+| `URX_URLSCAN_API_KEY` | URLScan | Optional URLScan API key (the provider also works anonymously) |
 | `URX_ZOOMEYE_API_KEY` | ZoomEye | ZoomEye API key |
 
 ### Usage Notes

--- a/docs/content/guide/examples.md
+++ b/docs/content/guide/examples.md
@@ -108,8 +108,11 @@ urx example.com --min-length 50 --max-length 200
 # Only Wayback Machine and OTX
 urx example.com --providers wayback,otx
 
+# Keyless archives only (no API keys needed) — incl. Arquivo.pt and anonymous URLScan
+urx example.com --providers wayback,cc,otx,arquivo,urlscan
+
 # All available providers (with API keys)
-urx example.com --providers wayback,cc,otx,vt,urlscan,zoomeye
+urx example.com --providers wayback,cc,otx,arquivo,vt,urlscan,zoomeye
 ```
 
 ### With API Keys

--- a/docs/content/guide/performance.md
+++ b/docs/content/guide/performance.md
@@ -155,7 +155,7 @@ urx example.com \
 ### Comprehensive Discovery
 ```bash
 urx example.com \
-  --providers wayback,cc,otx,vt,urlscan,zoomeye \
+  --providers wayback,cc,otx,arquivo,vt,urlscan,zoomeye \
   --subs \
   --parallel 15 \
   --timeout 120 \

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -38,7 +38,7 @@ https://dev.example.com/api/graphql.php
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
     </div>
     <h3>Multi-Source Collection</h3>
-    <p>Fetch URLs from Wayback Machine, Common Crawl, OTX, VirusTotal, URLScan, and ZoomEye in parallel.</p>
+    <p>Fetch URLs from Wayback Machine, Common Crawl, OTX, Arquivo.pt, VirusTotal, URLScan, and ZoomEye in parallel.</p>
   </div>
   <div class="feature-card">
     <div class="feature-icon">

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,7 +59,7 @@ pub struct Args {
     #[clap(long)]
     pub normalize_url: bool,
 
-    /// Providers to use (comma-separated, e.g., "wayback,cc,otx,vt,urlscan")
+    /// Providers to use (comma-separated, e.g., "wayback,cc,otx,arquivo,vt,urlscan")
     #[clap(help_heading = "Provider Options")]
     #[clap(long, value_delimiter = ',', default_value = "wayback,cc,otx")]
     pub providers: Vec<String>,
@@ -115,7 +115,7 @@ pub struct Args {
     pub vt_api_key: Vec<String>,
 
     #[clap(help_heading = "Provider Options")]
-    /// API key for Urlscan (can be used multiple times for rotation, can also use URX_URLSCAN_API_KEY environment variable with comma-separated keys)
+    /// Optional API key for Urlscan. The provider also works anonymously (rate-limited to ~30 req/min per IP); a key only raises those limits. Can be used multiple times for rotation, or via URX_URLSCAN_API_KEY (comma-separated)
     #[clap(long, action = clap::ArgAction::Append)]
     pub urlscan_api_key: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use network::NetworkSettings;
 use output::create_outputter;
 use progress::ProgressManager;
 use providers::{
-    CommonCrawlProvider, GitHubProvider, OTXProvider, Provider, RobotsProvider, SitemapProvider,
-    UrlscanProvider, VirusTotalProvider, WaybackMachineProvider, ZoomEyeProvider,
+    ArquivoProvider, CommonCrawlProvider, GitHubProvider, OTXProvider, Provider, RobotsProvider,
+    SitemapProvider, UrlscanProvider, VirusTotalProvider, WaybackMachineProvider, ZoomEyeProvider,
 };
 use readers::read_urls_from_file;
 use runner::{add_provider, process_domains, ProviderRunResult};
@@ -72,6 +72,12 @@ fn provider_catalog() -> &'static [ProviderInfo] {
             summary: "AlienVault Open Threat Exchange passive DNS / URLs",
         },
         ProviderInfo {
+            id: "arquivo",
+            display_name: "Arquivo.pt",
+            requires_key: false,
+            summary: "Arquivo.pt Portuguese web archive CDX index",
+        },
+        ProviderInfo {
             id: "vt",
             display_name: "VirusTotal",
             requires_key: true,
@@ -80,8 +86,8 @@ fn provider_catalog() -> &'static [ProviderInfo] {
         ProviderInfo {
             id: "urlscan",
             display_name: "Urlscan",
-            requires_key: true,
-            summary: "Urlscan.io search (URX_URLSCAN_API_KEY)",
+            requires_key: false,
+            summary: "Urlscan.io search (anonymous; URX_URLSCAN_API_KEY raises rate limits)",
         },
         ProviderInfo {
             id: "zoomeye",
@@ -282,7 +288,6 @@ fn effective_provider_ids(args: &Args) -> Vec<String> {
                 }
                 match p.id {
                     "vt" => !vt_api_keys.is_empty(),
-                    "urlscan" => !urlscan_api_keys.is_empty(),
                     "zoomeye" => !zoomeye_api_keys.is_empty(),
                     "github" => !github_api_keys.is_empty(),
                     _ => false,
@@ -443,6 +448,18 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
         );
     }
 
+    if providers_list.iter().any(|p| p == "arquivo") {
+        add_provider(
+            args,
+            network_settings,
+            &mut providers,
+            &mut provider_names,
+            "arquivo",
+            "Arquivo.pt".to_string(),
+            ArquivoProvider::new,
+        );
+    }
+
     if providers_list.iter().any(|p| p == "vt") {
         if !vt_api_keys.is_empty() {
             add_provider(
@@ -460,19 +477,19 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
     }
 
     if providers_list.iter().any(|p| p == "urlscan") {
-        if !urlscan_api_keys.is_empty() {
-            add_provider(
-                args,
-                network_settings,
-                &mut providers,
-                &mut provider_names,
-                "urlscan",
-                "Urlscan".to_string(),
-                || UrlscanProvider::new_with_keys(urlscan_api_keys.clone()),
-            );
-        } else if !args.silent && !suppress_key_errors {
-            eprintln!("Error: The Urlscan provider (urlscan) requires an API key. Please use --urlscan-api-key or set the URX_URLSCAN_API_KEY environment variable.");
-        }
+        // urlscan.io's public search works without a key (rate-limited to
+        // ~30 req/min per IP); a key only raises those limits and enables
+        // rotation. So always instantiate — keys are passed through when
+        // present, but their absence no longer disables the provider.
+        add_provider(
+            args,
+            network_settings,
+            &mut providers,
+            &mut provider_names,
+            "urlscan",
+            "Urlscan".to_string(),
+            || UrlscanProvider::new_with_keys(urlscan_api_keys.clone()),
+        );
     }
 
     if providers_list.iter().any(|p| p == "zoomeye") {
@@ -509,7 +526,7 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
 
     if providers.is_empty() {
         if !args.silent {
-            eprintln!("Error: No valid providers specified. Please use --providers with valid provider names (wayback, cc, otx, vt, urlscan, zoomeye)");
+            eprintln!("Error: No valid providers specified. Please use --providers with valid provider names (wayback, cc, otx, arquivo, vt, urlscan, zoomeye)");
         }
         return Err(anyhow::anyhow!("No valid providers specified"));
     }
@@ -1412,6 +1429,77 @@ mod tests {
             Err(err) => assert!(err
                 .to_string()
                 .contains("Unknown provider id(s) in --rate-limit-by")),
+        }
+    }
+
+    #[test]
+    fn test_initialize_providers_enables_urlscan_without_api_key() {
+        // urlscan is keyless: requesting it with no API key must still
+        // instantiate the provider (regression guard for the removed key gate).
+        let _env_lock = env_mutex().lock().unwrap();
+        let old = env::var("URX_URLSCAN_API_KEY").ok();
+        env::remove_var("URX_URLSCAN_API_KEY");
+
+        let mut args = build_test_args();
+        args.providers = vec!["urlscan".to_string()];
+
+        let result = initialize_providers(&args, &NetworkSettings::default());
+
+        match old {
+            Some(val) => env::set_var("URX_URLSCAN_API_KEY", val),
+            None => env::remove_var("URX_URLSCAN_API_KEY"),
+        }
+
+        let (providers, names) = result.expect("urlscan should initialize without an API key");
+        assert!(
+            !providers.is_empty(),
+            "urlscan must be instantiated even without a key"
+        );
+        assert!(names.iter().any(|n| n == "Urlscan"));
+    }
+
+    #[test]
+    fn test_effective_provider_ids_all_providers_keyless() {
+        // --all-providers with no keys must enable every keyless provider
+        // (including the new arquivo and the now-keyless urlscan) while keeping
+        // the keyed providers disabled.
+        let _env_lock = env_mutex().lock().unwrap();
+        let keyed = [
+            "URX_VT_API_KEY",
+            "URX_URLSCAN_API_KEY",
+            "URX_ZOOMEYE_API_KEY",
+            "URX_GITHUB_API_KEY",
+        ];
+        let saved: Vec<(&str, Option<String>)> =
+            keyed.iter().map(|k| (*k, env::var(k).ok())).collect();
+        for (k, _) in &saved {
+            env::remove_var(k);
+        }
+
+        let mut args = build_test_args();
+        args.all_providers = true;
+        args.providers = vec![]; // ignored when --all-providers is set
+
+        let ids = effective_provider_ids(&args);
+
+        for (k, v) in saved {
+            match v {
+                Some(val) => env::set_var(k, val),
+                None => env::remove_var(k),
+            }
+        }
+
+        for id in ["wayback", "cc", "otx", "arquivo", "urlscan"] {
+            assert!(
+                ids.iter().any(|p| p == id),
+                "--all-providers (keyless) must enable {id}; got {ids:?}"
+            );
+        }
+        for id in ["vt", "zoomeye", "github"] {
+            assert!(
+                !ids.iter().any(|p| p == id),
+                "keyed provider {id} must not activate without a key; got {ids:?}"
+            );
         }
     }
 

--- a/src/providers/arquivo.rs
+++ b/src/providers/arquivo.rs
@@ -117,17 +117,15 @@ impl ArquivoProvider {
     /// that sorts after it. Collapsing adjacent duplicate urlkeys yields ~one row
     /// per unique URL per page, so a non-final page always carries new URLs.
     fn query_base(&self, domain: &str) -> String {
-        if self.include_subdomains {
-            format!(
-                "{}/wayback/cdx?url=*.{domain}/*&output=json&collapse=urlkey",
-                self.base_url()
-            )
+        let host = if self.include_subdomains {
+            format!("*.{domain}")
         } else {
-            format!(
-                "{}/wayback/cdx?url={domain}/*&output=json&collapse=urlkey",
-                self.base_url()
-            )
-        }
+            domain.to_string()
+        };
+        format!(
+            "{}/wayback/cdx?url={host}/*&output=json&collapse=urlkey",
+            self.base_url()
+        )
     }
 }
 
@@ -161,10 +159,10 @@ impl Provider for ArquivoProvider {
             // span multiple ZipNum blocks; a domain that fits in a single block
             // ignores `page` and returns the full set on every request. So we
             // stop as soon as a page adds no new URLs (rather than waiting for an
-            // empty page, which never comes for small domains). `seen` both
-            // dedups across pages and drives that no-progress stop condition.
+            // empty page, which never comes for small domains). `seen` is the
+            // single source of truth: it dedups across pages and its growth
+            // drives the no-progress stop condition.
             let mut seen: HashSet<String> = HashSet::new();
-            let mut urls: Vec<String> = Vec::new();
             let mut page = 0usize;
 
             loop {
@@ -183,7 +181,7 @@ impl Provider for ArquivoProvider {
                         // Best effort: a mid-walk failure shouldn't discard the
                         // pages we already pulled. Only a failure on the very
                         // first request (nothing collected) is fatal.
-                        if urls.is_empty() {
+                        if seen.is_empty() {
                             return Err(e);
                         }
                         // We're returning a truncated result. Flag it so the
@@ -196,29 +194,24 @@ impl Provider for ArquivoProvider {
                     }
                 };
 
-                let mut new_in_page = 0usize;
-                for u in parse_records(&text) {
-                    if seen.insert(u.clone()) {
-                        urls.push(u);
-                        new_in_page += 1;
-                    }
-                }
+                let before = seen.len();
+                seen.extend(parse_records(&text));
 
                 if let Some(r) = &reporter {
-                    r.detail(format!("{} URLs…", urls.len()));
+                    r.detail(format!("{} URLs…", seen.len()));
                 }
 
                 // No new URLs ⇒ either this was the last page, or the server is
                 // ignoring `page` and re-serving the same rows. Either way, stop.
-                if new_in_page == 0 {
+                if seen.len() == before {
                     break;
                 }
 
                 page += 1;
             }
 
+            let mut urls: Vec<String> = seen.into_iter().collect();
             urls.sort();
-            urls.dedup();
 
             Ok(urls)
         })

--- a/src/providers/arquivo.rs
+++ b/src/providers/arquivo.rs
@@ -1,0 +1,677 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::Provider;
+use crate::network::client::{get_with_retry, HttpClientConfig};
+use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
+
+/// Hard ceiling on the number of CDX pages walked for one domain. Arquivo.pt's
+/// CDX server paginates large result sets into ZipNum blocks via `page=`, but a
+/// domain small enough to fit in a single block ignores `page` and returns the
+/// full set on every request. We stop as soon as a page contributes no new URLs
+/// (see the fetch loop), so this ceiling is only a runaway backstop — at tens of
+/// thousands of rows per page it covers far more URLs than any real domain has.
+const MAX_PAGES: usize = 1_000;
+
+/// One row of Arquivo.pt's CDX `output=json` response. Each line of the body is
+/// a standalone JSON object (CDXJ / NDJSON); we only need the captured URL.
+#[derive(Debug, Deserialize)]
+struct ArquivoRecord {
+    #[serde(default)]
+    url: String,
+}
+
+/// Parse Arquivo's NDJSON CDX body into the captured URLs. Each non-empty line
+/// is an independent JSON object, so a single malformed line (e.g. a stray
+/// error message) is skipped rather than aborting the whole page. Rows without
+/// a `url` are dropped.
+fn parse_records(text: &str) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            serde_json::from_str::<ArquivoRecord>(line)
+                .ok()
+                .map(|r| r.url)
+                .filter(|u| u.starts_with("http://") || u.starts_with("https://"))
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+pub struct ArquivoProvider {
+    include_subdomains: bool,
+    proxy: Option<String>,
+    proxy_auth: Option<String>,
+    timeout: u64,
+    retries: u32,
+    random_agent: bool,
+    insecure: bool,
+    rate_limit: Option<RateLimiter>,
+    #[cfg(test)]
+    base_url: String,
+}
+
+impl ArquivoProvider {
+    /// Creates a new ArquivoProvider with default settings.
+    pub fn new() -> Self {
+        ArquivoProvider {
+            include_subdomains: false,
+            proxy: None,
+            proxy_auth: None,
+            timeout: 60,
+            retries: 3,
+            random_agent: false,
+            insecure: false,
+            rate_limit: None,
+            #[cfg(test)]
+            base_url: "https://arquivo.pt".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_url(&mut self, url: String) -> &mut Self {
+        self.base_url = url;
+        self
+    }
+
+    /// Build an `HttpClientConfig` from the current provider settings.
+    fn client_config(&self) -> HttpClientConfig {
+        HttpClientConfig {
+            timeout: self.timeout,
+            insecure: self.insecure,
+            random_agent: self.random_agent,
+            proxy: self.proxy.clone(),
+            proxy_auth: self.proxy_auth.clone(),
+        }
+    }
+
+    /// Archive origin. Overridable in tests so the mock server can stand in.
+    fn base_url(&self) -> &str {
+        #[cfg(test)]
+        {
+            &self.base_url
+        }
+        #[cfg(not(test))]
+        {
+            "https://arquivo.pt"
+        }
+    }
+
+    /// Build the CDX query *without* the `page=` cursor. `output=json` streams
+    /// one JSON object per line. A leading `*.` matches subdomains; a trailing
+    /// `/*` matches the host and all of its paths — the same wildcard forms the
+    /// Wayback provider uses, which Arquivo's CDX server honours as well.
+    ///
+    /// `collapse=urlkey` is essential, not just an optimisation: Arquivo returns
+    /// one row per *capture*, and popular URLs accumulate thousands of captures
+    /// (observed ~3.7× row inflation). Without collapsing, a single
+    /// heavily-recaptured URL can fill an entire `page`, which the walk would
+    /// see as "no new URLs" and stop early — silently under-collecting every URL
+    /// that sorts after it. Collapsing adjacent duplicate urlkeys yields ~one row
+    /// per unique URL per page, so a non-final page always carries new URLs.
+    fn query_base(&self, domain: &str) -> String {
+        if self.include_subdomains {
+            format!(
+                "{}/wayback/cdx?url=*.{domain}/*&output=json&collapse=urlkey",
+                self.base_url()
+            )
+        } else {
+            format!(
+                "{}/wayback/cdx?url={domain}/*&output=json&collapse=urlkey",
+                self.base_url()
+            )
+        }
+    }
+}
+
+impl Provider for ArquivoProvider {
+    fn clone_box(&self) -> Box<dyn Provider> {
+        Box::new(self.clone())
+    }
+
+    fn fetch_urls<'a>(
+        &'a self,
+        domain: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        Box::pin(async move {
+            let client = self.client_config().build_client()?;
+            let query_base = self.query_base(domain);
+            let limiter = self.rate_limit.as_ref();
+
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
+            }
+
+            // Walk the `page=` cursor. Arquivo only paginates result sets that
+            // span multiple ZipNum blocks; a domain that fits in a single block
+            // ignores `page` and returns the full set on every request. So we
+            // stop as soon as a page adds no new URLs (rather than waiting for an
+            // empty page, which never comes for small domains). `seen` both
+            // dedups across pages and drives that no-progress stop condition.
+            let mut seen: HashSet<String> = HashSet::new();
+            let mut urls: Vec<String> = Vec::new();
+            let mut page = 0usize;
+
+            loop {
+                if page >= MAX_PAGES {
+                    break;
+                }
+
+                let url = format!("{query_base}&page={page}");
+
+                if let Some(rl) = &limiter {
+                    rl.acquire().await;
+                }
+                let text = match get_with_retry(&client, &url, self.retries).await {
+                    Ok(text) => text,
+                    Err(e) => {
+                        // Best effort: a mid-walk failure shouldn't discard the
+                        // pages we already pulled. Only a failure on the very
+                        // first request (nothing collected) is fatal.
+                        if urls.is_empty() {
+                            return Err(e);
+                        }
+                        // We're returning a truncated result. Flag it so the
+                        // caller can mark the line partial and warn rather than
+                        // present an incomplete crawl as a clean success.
+                        if let Some(r) = &reporter {
+                            r.mark_partial();
+                        }
+                        break;
+                    }
+                };
+
+                let mut new_in_page = 0usize;
+                for u in parse_records(&text) {
+                    if seen.insert(u.clone()) {
+                        urls.push(u);
+                        new_in_page += 1;
+                    }
+                }
+
+                if let Some(r) = &reporter {
+                    r.detail(format!("{} URLs…", urls.len()));
+                }
+
+                // No new URLs ⇒ either this was the last page, or the server is
+                // ignoring `page` and re-serving the same rows. Either way, stop.
+                if new_in_page == 0 {
+                    break;
+                }
+
+                page += 1;
+            }
+
+            urls.sort();
+            urls.dedup();
+
+            Ok(urls)
+        })
+    }
+
+    fn with_subdomains(&mut self, include: bool) {
+        self.include_subdomains = include;
+    }
+
+    fn with_proxy(&mut self, proxy: Option<String>) {
+        self.proxy = proxy;
+    }
+
+    fn with_proxy_auth(&mut self, auth: Option<String>) {
+        self.proxy_auth = auth;
+    }
+
+    fn with_timeout(&mut self, seconds: u64) {
+        self.timeout = seconds;
+    }
+
+    fn with_retries(&mut self, count: u32) {
+        self.retries = count;
+    }
+
+    fn with_random_agent(&mut self, enabled: bool) {
+        self.random_agent = enabled;
+    }
+
+    fn with_insecure(&mut self, enabled: bool) {
+        self.insecure = enabled;
+    }
+
+    fn with_rate_limit(&mut self, rate_limit: Option<f32>) {
+        self.rate_limit = RateLimiter::from_rate(rate_limit);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_provider() {
+        let provider = ArquivoProvider::new();
+        assert!(!provider.include_subdomains);
+        assert_eq!(provider.proxy, None);
+        assert_eq!(provider.proxy_auth, None);
+        assert_eq!(provider.timeout, 60);
+        assert_eq!(provider.retries, 3);
+        assert!(!provider.random_agent);
+        assert!(!provider.insecure);
+        assert!(provider.rate_limit.is_none());
+    }
+
+    #[test]
+    fn test_with_subdomains() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_subdomains(true);
+        assert!(provider.include_subdomains);
+    }
+
+    #[test]
+    fn test_with_proxy() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_proxy(Some("http://proxy.example.com:8080".to_string()));
+        assert_eq!(
+            provider.proxy,
+            Some("http://proxy.example.com:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_proxy_auth() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_proxy_auth(Some("user:pass".to_string()));
+        assert_eq!(provider.proxy_auth, Some("user:pass".to_string()));
+    }
+
+    #[test]
+    fn test_with_timeout() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_timeout(30);
+        assert_eq!(provider.timeout, 30);
+    }
+
+    #[test]
+    fn test_with_retries() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_retries(5);
+        assert_eq!(provider.retries, 5);
+    }
+
+    #[test]
+    fn test_with_random_agent() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_random_agent(true);
+        assert!(provider.random_agent);
+    }
+
+    #[test]
+    fn test_with_insecure() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_insecure(true);
+        assert!(provider.insecure);
+    }
+
+    #[test]
+    fn test_with_rate_limit() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_rate_limit(Some(2.5));
+        assert!(provider.rate_limit.is_some());
+    }
+
+    #[test]
+    fn test_clone_box() {
+        let provider = ArquivoProvider::new();
+        let _cloned = provider.clone_box();
+    }
+
+    #[test]
+    fn test_client_config() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_timeout(45);
+        provider.with_insecure(true);
+        provider.with_random_agent(true);
+        provider.with_proxy(Some("http://proxy:8080".to_string()));
+        provider.with_proxy_auth(Some("user:pass".to_string()));
+
+        let config = provider.client_config();
+        assert_eq!(config.timeout, 45);
+        assert!(config.insecure);
+        assert!(config.random_agent);
+        assert_eq!(config.proxy, Some("http://proxy:8080".to_string()));
+        assert_eq!(config.proxy_auth, Some("user:pass".to_string()));
+    }
+
+    #[test]
+    fn test_query_base_without_subdomains() {
+        let provider = ArquivoProvider::new();
+        assert_eq!(
+            provider.query_base("example.com"),
+            "https://arquivo.pt/wayback/cdx?url=example.com/*&output=json&collapse=urlkey"
+        );
+    }
+
+    #[test]
+    fn test_query_base_with_subdomains() {
+        let mut provider = ArquivoProvider::new();
+        provider.with_subdomains(true);
+        assert_eq!(
+            provider.query_base("example.com"),
+            "https://arquivo.pt/wayback/cdx?url=*.example.com/*&output=json&collapse=urlkey"
+        );
+    }
+
+    #[test]
+    fn test_parse_records_extracts_urls_and_skips_junk() {
+        let body =
+            "{\"urlkey\":\"com,example)/\",\"url\":\"http://example.com/a\",\"status\":\"200\"}\n\
+                    \n\
+                    not-json-just-an-error-line\n\
+                    {\"url\":\"https://example.com/b\"}\n\
+                    {\"timestamp\":\"20200101\"}\n\
+                    {\"url\":\"ftp://example.com/skip\"}\n";
+        let urls = parse_records(body);
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "https://example.com/b".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_integration() {
+        let mut server = mockito::Server::new_async().await;
+        // Page 0 carries results (with a duplicate to prove dedup); page 1 is
+        // empty, which terminates the walk.
+        let page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
+                mockito::Matcher::UrlEncoded("output".into(), "json".into()),
+                mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "0".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "text/x-ndjson")
+            .with_body(
+                "{\"url\":\"http://example.com/page1\"}\n\
+                 {\"url\":\"http://example.com/page2\"}\n\
+                 {\"url\":\"http://example.com/page1\"}\n",
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(urls.len(), 2);
+        assert_eq!(urls[0], "http://example.com/page1");
+        assert_eq!(urls[1], "http://example.com/page2");
+
+        page0.assert();
+        page1.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_integration_with_subdomains() {
+        let mut server = mockito::Server::new_async().await;
+        let page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "*.example.com/*".into()),
+                mockito::Matcher::UrlEncoded("output".into(), "json".into()),
+                mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("page".into(), "0".into()),
+            ]))
+            .with_status(200)
+            .with_body("{\"url\":\"http://sub.example.com/page1\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let _page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_subdomains(true);
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(urls, vec!["http://sub.example.com/page1".to_string()]);
+        page0.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_paginates_across_pages() {
+        let mut server = mockito::Server::new_async().await;
+        // Page 0 and page 1 overlap on /b to prove cross-page dedup; page 2 is
+        // empty so the walk terminates.
+        let page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n{\"url\":\"http://example.com/b\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/b\"}\n{\"url\":\"http://example.com/c\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "2".into()))
+            .with_status(200)
+            .with_body("")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+                "http://example.com/c".to_string(),
+            ]
+        );
+        page0.assert();
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_stops_when_page_param_ignored() {
+        // A small domain fits in one ZipNum block, so Arquivo ignores `page` and
+        // re-serves the same rows. The walk must stop after the first repeat
+        // (page 1 adds no new URLs) instead of looping forever.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n{\"url\":\"http://example.com/b\"}\n")
+            .expect(2)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        // Exactly two requests: page 0 (new rows) then page 1 (all duplicates).
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_integration_empty_response() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(urls.len(), 0);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_errors_when_first_request_fails() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_retries(0);
+
+        // Nothing collected yet → a hard failure must propagate.
+        assert!(provider.fetch_urls("example.com").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_keeps_partial_results_on_midwalk_failure() {
+        let mut server = mockito::Server::new_async().await;
+        // Page 0 succeeds...
+        let _page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n{\"url\":\"http://example.com/b\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        // ...but the follow-up page fails. We should keep page 0 rather than err.
+        let _page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_paces_page_requests() {
+        use std::time::{Duration, Instant};
+        let mut server = mockito::Server::new_async().await;
+        // Page 0 has new rows so a second request (page 1) is made.
+        let _page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let _page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/b\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+        // Page 2 empty → terminate.
+        let _page2 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "2".into()))
+            .with_status(200)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        // 5 req/s ⇒ a 200ms minimum gap between page requests.
+        provider.with_rate_limit(Some(5.0));
+
+        let start = Instant::now();
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls.len(), 2);
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "rate limit was not applied; elapsed {:?}",
+            start.elapsed()
+        );
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 mod api_key_rotation;
+mod arquivo;
 mod commoncrawl;
 mod github;
 mod otx;
@@ -13,6 +14,7 @@ mod vt;
 pub mod wayback;
 mod zoomeye;
 pub use api_key_rotation::ApiKeyRotator;
+pub use arquivo::ArquivoProvider;
 pub use commoncrawl::CommonCrawlProvider;
 pub use github::GitHubProvider;
 pub use otx::OTXProvider;

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -194,10 +194,11 @@ impl Provider for UrlscanProvider {
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
-            // Skip if no API keys are provided
-            if !self.api_key_rotator.has_keys() {
-                return Ok(Vec::new());
-            }
+            // urlscan.io's public search allows unauthenticated queries
+            // (rate-limited to ~30 req/min per IP), so we always query. When no
+            // API key is configured the request simply omits the API-Key header
+            // (see `fetch_page`); a key only raises the limits and enables
+            // rotation.
 
             // Use the url crate for encoding the domain
             let encoded_domain =
@@ -504,13 +505,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_urls_with_empty_api_key() {
-        let provider = UrlscanProvider::new("".to_string());
-        let result = provider.fetch_urls("example.com").await;
+    async fn test_fetch_urls_keyless_queries_without_api_key_header() {
+        // With no API key, urlscan still queries the public search endpoint —
+        // it must just omit the API-Key header rather than returning nothing.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Any)
+            .match_header("API-Key", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"status":200,"has_more":false,"results":[{"page":{"domain":"example.com","url":"https://example.com/anon","status":"200"}}]}"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
 
-        assert!(result.is_ok(), "Expected success with empty API key");
-        let urls = result.unwrap();
-        assert_eq!(urls.len(), 0, "Expected empty URLs list with empty API key");
+        let mut provider = UrlscanProvider::new("".to_string());
+        provider.with_base_url(server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["https://example.com/anon".to_string()]);
+        mock.assert();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Expands urx's **keyless** provider coverage with two changes, both verified against live endpoints:

### 1. New `arquivo` provider — Arquivo.pt (Portuguese web archive)
- Queries Arquivo.pt's Wayback-compatible CDX index (`https://arquivo.pt/wayback/cdx`) with `output=json` (NDJSON) and `collapse=urlkey`.
- An **independent corpus** from the Internet Archive — surfaces URLs Wayback doesn't have, especially for European/Portuguese-language sites.
- **No API key required.** Opt in with `--providers arquivo` or `--all-providers`; defaults stay `wayback,cc,otx`.

**Pagination notes (verified against the live API):** Arquivo's CDX exposes no `resumeKey`/`showNumPages` cursor and ignores `offset`. The `page=` parameter only paginates result sets that span multiple ZipNum blocks; a small domain ignores `page` and re-serves the full set on every request. So the provider walks `page=0,1,2,…` and stops as soon as a page contributes **no new URLs** (tracked via a `HashSet`), capped by `MAX_PAGES`.

`collapse=urlkey` is **required, not just an optimisation**: Arquivo returns one row per *capture*, and popular URLs accumulate thousands of captures (observed ~3.7× row inflation: 49,981 rows → 13,279 unique URLs on a single page). Without collapsing, a single heavily-recaptured URL could fill an entire page of duplicates and trip the no-new-URLs stop early, silently under-collecting. Collapsing yields ~one row per unique URL per page, so a non-final page always carries new URLs.

### 2. URLScan is now keyless
- urlscan.io's public search works anonymously (rate-limited to ~30 req/min per IP), so urx no longer disables the provider when no key is configured.
- Removed the no-key early return in the provider and the instantiation key gate; flipped `requires_key` → `false` so `--all-providers` enables it. The `API-Key` header was already conditional, so anonymous requests omit it.
- An API key stays **optional** and only raises limits / enables rotation.

## Testing
- `cargo test --bin urx` — **496 pass** (+22 arquivo provider tests, +1 updated urlscan keyless test, +2 wiring regression tests covering keyless enablement in `initialize_providers`/`effective_provider_ids`).
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- **Live E2E:** `urx hahwul.com --providers arquivo` returns real URLs; `urx example.com --providers urlscan` (no key) returns results with no "requires an API key" error.

## Docs
README, CHANGELOG, `--list-providers`, CLI help, and the docs site (provider table, examples, env-vars, configuration, performance, index) all updated.

## Notes
- `--all-providers` (no keys) now resolves to `{wayback, cc, otx, arquivo, urlscan}` while still excluding the keyed providers `{vt, zoomeye, github}`.