### PR TITLE
docs: fix network rustdoc comments

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -86,7 +86,7 @@ pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
 }
 
-/// Execute an HTTP GET request with retry and exponential back-off.
+/// Execute an HTTP GET request with retry and linear back-off.
 ///
 /// `max_retries` is the number of **additional** attempts after the first
 /// failure (i.e. total attempts = 1 + max_retries).
@@ -102,7 +102,7 @@ pub async fn get_with_retry(client: &Client, url: &str, max_retries: u32) -> Res
 
     while attempt <= max_retries {
         if attempt > 0 {
-            // Exponential back-off: 500ms, 1000ms, 1500ms, …
+            // Linear back-off: 500ms, 1000ms, 1500ms, …
             tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
         }
 

--- a/src/network/settings.rs
+++ b/src/network/settings.rs
@@ -1,7 +1,3 @@
-/// Shared network configuration settings for HTTP requests
-///
-/// This struct centralizes common HTTP request settings used throughout
-/// the application to avoid code duplication between providers and testers.
 /// Network scope specifying which components should use the network settings
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum NetworkScope {
@@ -14,6 +10,10 @@ pub enum NetworkScope {
     Testers,
 }
 
+/// Shared network configuration settings for HTTP requests
+///
+/// This struct centralizes common HTTP request settings used throughout
+/// the application to avoid code duplication between providers and testers.
 #[derive(Clone, Debug)]
 pub struct NetworkSettings {
     /// Proxy server URL (e.g., "<http://proxy.example.com:8080>")


### PR DESCRIPTION
## Summary
- correct the retry helper rustdoc/comment to describe linear back-off
- move the NetworkSettings rustdoc block onto the struct and leave NetworkScope with its own enum description

Closes #283.
Closes #284.

## Testing
- git diff --check

Note: I could not run cargo build/test locally because this Windows environment does not currently have Rust/Cargo installed.