### PR TITLE
refactor(filters): simplify UrlFilter::new()

### DIFF
--- a/src/filters/url_filter.rs
+++ b/src/filters/url_filter.rs
@@ -18,14 +18,7 @@ pub struct UrlFilter {
 impl UrlFilter {
     /// Create a new URL filter
     pub fn new() -> Self {
-        UrlFilter {
-            extensions: Vec::new(),
-            exclude_extensions: Vec::new(),
-            patterns: Vec::new(),
-            exclude_patterns: Vec::new(),
-            min_length: None,
-            max_length: None,
-        }
+        Self::default()
     }
 
     /// Apply filter presets to this URL filter


### PR DESCRIPTION
UrlFilter already derives Default. Thus, its constructor manually re-lists every field with the same value the derive would produce. We can simply call Self::default() to avoid the six-field duplicate.