### PR TITLE
Add audio filter presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Display Options:
 
 Filter Options:
   -p, --preset <PRESET>
-          Filter Presets (e.g., "no-resources,no-images,only-js,only-style")
+          Filter Presets (e.g., "no-resources,no-images,no-audio,only-js,only-style")
   -e, --extensions <EXTENSIONS>
           Filter URLs to only include those with specific extensions (comma-separated, e.g., "js,php,aspx")
       --exclude-extensions <EXCLUDE_EXTENSIONS>

--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -56,7 +56,7 @@ Display Options:
       --stats         Print a per-provider summary to stderr at end of run
 
 Filter Options:
-  -p, --preset <PRESET>                     Filter Presets (e.g., "no-resources,no-images,only-js,only-style")
+  -p, --preset <PRESET>                     Filter Presets (e.g., "no-resources,no-images,no-audio,only-js,only-style")
   -e, --extensions <EXTENSIONS>              Filter by extensions (e.g., "js,php,aspx")
       --exclude-extensions <EXTENSIONS>      Exclude extensions (e.g., "html,txt")
       --patterns <PATTERNS>                  Include URLs containing patterns
@@ -116,5 +116,7 @@ Default providers: `wayback,cc,otx`. Providers requiring API keys are automatica
 |--------|-------------|
 | `no-resources` | Exclude resource files (images, CSS, fonts, etc.) |
 | `no-images` | Exclude image files |
+| `no-audio` | Exclude audio files |
 | `only-js` | Only JavaScript files |
 | `only-style` | Only stylesheet files |
+| `only-audio` | Only audio files |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -180,7 +180,7 @@ pub struct Args {
     #[clap(long)]
     pub stats: bool,
 
-    /// Filter Presets (e.g., "no-resources,no-images,only-js,only-style")
+    /// Filter Presets (e.g., "no-resources,no-images,no-audio,only-js,only-style")
     #[clap(help_heading = "Filter Options")]
     #[clap(short, long, value_delimiter = ',')]
     pub preset: Vec<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -249,17 +249,13 @@ impl Config {
                 let config_path = config_dir.join("config.toml");
 
                 // Create directory if it doesn't exist
-                if !config_dir.exists() {
-                    if let Err(_) = fs::create_dir_all(&config_dir) {
-                        return None;
-                    }
+                if !config_dir.exists() && fs::create_dir_all(&config_dir).is_err() {
+                    return None;
                 }
 
                 // Create empty config file if it doesn't exist
-                if !config_path.exists() {
-                    if let Err(_) = fs::write(&config_path, "") {
-                        return None;
-                    }
+                if !config_path.exists() && fs::write(&config_path, "").is_err() {
+                    return None;
                 }
 
                 return Some(config_path);
@@ -585,6 +581,7 @@ impl Config {
     }
 }
 
+#[cfg_attr(windows, allow(dead_code))]
 /// Helper function to get the home directory
 fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(PathBuf::from).or({

--- a/src/filters/preset.rs
+++ b/src/filters/preset.rs
@@ -14,12 +14,16 @@ pub enum FilterPreset {
     NoDocuments,
     /// Excludes video files (mp4, mkv, avi, etc.)
     NoVideos,
+    /// Excludes audio files (mp3, wav, flac, etc.)
+    NoAudio,
     /// Only includes font files
     OnlyFonts,
     /// Only includes document files
     OnlyDocuments,
     /// Only includes video files
     OnlyVideos,
+    /// Only includes audio files
+    OnlyAudio,
     /// Only includes image files
     OnlyImages,
 }
@@ -71,11 +75,13 @@ impl FilterPreset {
             "no-font" | "no-fonts" => Some(FilterPreset::NoFonts),
             "no-document" | "no-documents" => Some(FilterPreset::NoDocuments),
             "no-video" | "no-videos" => Some(FilterPreset::NoVideos),
+            "no-audio" | "no-audios" => Some(FilterPreset::NoAudio),
             "only-js" => Some(FilterPreset::OnlyJs),
             "only-style" | "only-styles" => Some(FilterPreset::OnlyStyle),
             "only-fonts" => Some(FilterPreset::OnlyFonts),
             "only-documents" => Some(FilterPreset::OnlyDocuments),
             "only-videos" => Some(FilterPreset::OnlyVideos),
+            "only-audio" | "only-audios" => Some(FilterPreset::OnlyAudio),
             "only-images" => Some(FilterPreset::OnlyImages),
             _ => None,
         }
@@ -101,12 +107,14 @@ impl FilterPreset {
                 DOCUMENT_EXTENSIONS.iter().map(|&s| s.to_string()).collect()
             }
             FilterPreset::NoVideos => VIDEO_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
+            FilterPreset::NoAudio => AUDIO_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
             FilterPreset::OnlyJs | FilterPreset::OnlyStyle => vec![],
             FilterPreset::OnlyFonts => FONT_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
             FilterPreset::OnlyDocuments => {
                 DOCUMENT_EXTENSIONS.iter().map(|&s| s.to_string()).collect()
             }
             FilterPreset::OnlyVideos => VIDEO_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
+            FilterPreset::OnlyAudio => AUDIO_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
             FilterPreset::OnlyImages => IMAGE_EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
         }
     }
@@ -262,6 +270,7 @@ mod tests {
         for preset in [
             FilterPreset::NoResources,
             FilterPreset::NoImages,
+            FilterPreset::NoAudio,
             FilterPreset::OnlyJs,
             FilterPreset::OnlyStyle,
         ] {
@@ -322,6 +331,23 @@ mod tests {
     }
 
     #[test]
+    fn test_no_audio_preset() {
+        let preset = FilterPreset::NoAudio;
+        let exclude_extensions = preset.get_exclude_extensions();
+
+        // Should exclude all audio extensions
+        assert!(exclude_extensions.contains(&"mp3".to_string()));
+        assert!(exclude_extensions.contains(&"wav".to_string()));
+        assert!(exclude_extensions.contains(&"flac".to_string()));
+        assert!(exclude_extensions.contains(&"aac".to_string()));
+        assert!(exclude_extensions.contains(&"ogg".to_string()));
+        assert!(exclude_extensions.contains(&"m4a".to_string()));
+
+        // Should not include any extensions
+        assert!(preset.get_extensions().is_empty());
+    }
+
+    #[test]
     fn test_only_fonts_preset() {
         let preset = FilterPreset::OnlyFonts;
         let exclude_extensions = preset.get_exclude_extensions();
@@ -361,6 +387,21 @@ mod tests {
         assert!(exclude_extensions.contains(&"avi".to_string()));
 
         // get_extensions should be empty for OnlyVideos
+        assert!(preset.get_extensions().is_empty());
+    }
+
+    #[test]
+    fn test_only_audio_preset() {
+        let preset = FilterPreset::OnlyAudio;
+        let exclude_extensions = preset.get_exclude_extensions();
+
+        // OnlyAudio uses exclude_extensions to store audio types
+        assert!(exclude_extensions.contains(&"mp3".to_string()));
+        assert!(exclude_extensions.contains(&"wav".to_string()));
+        assert!(exclude_extensions.contains(&"flac".to_string()));
+        assert!(exclude_extensions.contains(&"aac".to_string()));
+
+        // get_extensions should be empty for OnlyAudio
         assert!(preset.get_extensions().is_empty());
     }
 
@@ -405,6 +446,18 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_preset_from_str_no_audio() {
+        assert!(matches!(
+            FilterPreset::from_str("no-audio"),
+            Some(FilterPreset::NoAudio)
+        ));
+        assert!(matches!(
+            FilterPreset::from_str("no-audios"),
+            Some(FilterPreset::NoAudio)
+        ));
+    }
+
+    #[test]
     fn test_filter_preset_from_str_only_fonts() {
         assert!(matches!(
             FilterPreset::from_str("only-fonts"),
@@ -425,6 +478,18 @@ mod tests {
         assert!(matches!(
             FilterPreset::from_str("only-videos"),
             Some(FilterPreset::OnlyVideos)
+        ));
+    }
+
+    #[test]
+    fn test_filter_preset_from_str_only_audio() {
+        assert!(matches!(
+            FilterPreset::from_str("only-audio"),
+            Some(FilterPreset::OnlyAudio)
+        ));
+        assert!(matches!(
+            FilterPreset::from_str("only-audios"),
+            Some(FilterPreset::OnlyAudio)
         ));
     }
 


### PR DESCRIPTION
## Summary
- add `no-audio` / `no-audios` and `only-audio` / `only-audios` preset parsing
- wire audio presets to the existing audio extension list
- document the new presets in CLI help and docs
- fix small Windows clippy warnings in config handling so lint passes with `--deny warnings`

Closes #296

## Testing
- `cargo +stable-x86_64-pc-windows-gnu test`
- `cargo +stable-x86_64-pc-windows-gnu fmt --check`
- `cargo +stable-x86_64-pc-windows-gnu clippy -- --deny warnings`
- `cargo +stable-x86_64-pc-windows-gnu clippy --tests -- --deny warnings`
- `cargo +stable-x86_64-pc-windows-gnu build --release`
- `./target/release/urx --help` verified the `no-audio` preset example appears