### PR TITLE
fix(cli): derive provider error list from catalog

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -526,7 +526,12 @@ fn initialize_providers(args: &Args, network_settings: &NetworkSettings) -> Resu
 
     if providers.is_empty() {
         if !args.silent {
-            eprintln!("Error: No valid providers specified. Please use --providers with valid provider names (wayback, cc, otx, arquivo, vt, urlscan, zoomeye)");
+            let mut valid_providers: Vec<&str> = valid_provider_ids().into_iter().collect();
+            valid_providers.sort_unstable();
+            eprintln!(
+                "Error: No valid providers specified. Please use --providers with valid provider names ({})",
+                valid_providers.join(", ")
+            );
         }
         return Err(anyhow::anyhow!("No valid providers specified"));
     }

--- a/tests/provider_error.rs
+++ b/tests/provider_error.rs
@@ -1,0 +1,39 @@
+use std::process::Command;
+
+#[test]
+fn no_valid_providers_error_lists_every_provider() {
+    let config_dir = tempfile::tempdir().expect("temporary config directory should be created");
+    let config_path = config_dir.path().join("config.toml");
+    let provider_config_path = config_dir.path().join("provider-config.toml");
+    std::fs::write(&config_path, "").expect("empty config should be written");
+    std::fs::write(&provider_config_path, "").expect("empty provider config should be written");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_urx"))
+        .args([
+            "example.com",
+            "--providers",
+            "wayback",
+            "--exclude-providers",
+            "wayback,robots,sitemap",
+        ])
+        .arg("--config")
+        .arg(config_path)
+        .arg("--provider-config")
+        .arg(provider_config_path)
+        .env_remove("URX_VT_API_KEY")
+        .env_remove("URX_URLSCAN_API_KEY")
+        .env_remove("URX_ZOOMEYE_API_KEY")
+        .env_remove("URX_GITHUB_API_KEY")
+        .output()
+        .expect("urx should run");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        stderr.contains(
+            "valid provider names (arquivo, cc, github, otx, robots, sitemap, urlscan, vt, wayback, zoomeye)",
+        ),
+        "unexpected stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

The "No valid providers" error used a hardcoded provider list that had drifted from the canonical provider catalog.

- derive the list from `valid_provider_ids()`
- sort provider IDs for deterministic output
- add an isolated CLI regression test

No provider-selection behavior changes.

## Testing

- `cargo build --locked`
- `cargo test --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo llvm-cov --all-features --workspace`

Fixes #293