### PR TITLE
fix: cache-key gaps, URL rewriting on merge, and wasteful retries

### DIFF
--- a/src/cache/redis_impl.rs
+++ b/src/cache/redis_impl.rs
@@ -212,17 +212,8 @@ mod tests {
         };
 
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new("example.com", &["wayback".to_string()], &filters);
@@ -265,17 +256,8 @@ mod tests {
         };
 
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new("example.com", &["wayback".to_string()], &filters);

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -217,17 +217,8 @@ mod tests {
         let cache = SqliteCache::new(&db_path).await?;
 
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new("example.com", &["wayback".to_string()], &filters);
@@ -263,17 +254,8 @@ mod tests {
         let cache = SqliteCache::new(&db_path).await?;
 
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new("example.com", &["wayback".to_string()], &filters);
@@ -302,17 +284,8 @@ mod tests {
         let cache = SqliteCache::new(&db_path).await?;
 
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key1 = CacheKey::new("example.com", &["wayback".to_string()], &filters);

--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -60,8 +60,18 @@ impl std::fmt::Display for CacheKey {
     }
 }
 
-/// Represents the filtering configuration used in a scan
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Everything about a scan's configuration that changes *which URLs it would
+/// produce*. Any option that narrows or widens the result set has to be in
+/// here, or two different runs collide on one cache entry and the second gets
+/// served the first one's answer.
+///
+/// That includes the archive-side predicates, not just the local filters:
+/// `--from 2020` and `--from 2024` ask the CDX index two different questions.
+///
+/// [`Default`] is derived deliberately — it means a new option can be added to
+/// this struct without having to touch every construction site, so the "we
+/// forgot to put the new flag in the cache key" bug can't come back quietly.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CacheFilters {
     pub subs: bool,
     pub extensions: Vec<String>,
@@ -74,6 +84,16 @@ pub struct CacheFilters {
     pub strict: bool,
     pub normalize_url: bool,
     pub merge_endpoint: bool,
+    /// `--cc-index`: distinct Common Crawl indexes are distinct corpora.
+    pub cc_index: Vec<String>,
+    /// `--from` / `--to`: the CDX date window.
+    pub from: Option<String>,
+    pub to: Option<String>,
+    /// `--archive-*`: status-code and MIME predicates the archive applies.
+    pub archive_status: Vec<String>,
+    pub archive_exclude_status: Vec<String>,
+    pub archive_mime: Vec<String>,
+    pub archive_exclude_mime: Vec<String>,
 }
 
 impl CacheFilters {
@@ -109,6 +129,19 @@ impl CacheFilters {
         hasher.update([self.strict as u8]);
         hasher.update([self.normalize_url as u8]);
         hasher.update([self.merge_endpoint as u8]);
+        feed_list(&mut hasher, &self.cc_index);
+        feed(
+            &mut hasher,
+            self.from.as_deref().unwrap_or_default().as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            self.to.as_deref().unwrap_or_default().as_bytes(),
+        );
+        feed_list(&mut hasher, &self.archive_status);
+        feed_list(&mut hasher, &self.archive_exclude_status);
+        feed_list(&mut hasher, &self.archive_mime);
+        feed_list(&mut hasher, &self.archive_exclude_mime);
 
         hasher
             .finalize()
@@ -178,7 +211,7 @@ mod tests {
             max_length: Some(100),
             strict: true,
             normalize_url: true,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new(
@@ -197,29 +230,15 @@ mod tests {
         let filters1 = CacheFilters {
             subs: true,
             extensions: vec!["js".to_string(), "php".to_string()],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
             extensions: vec!["js".to_string(), "php".to_string()],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_eq!(filters1.compute_hash(), filters2.compute_hash());
@@ -230,29 +249,15 @@ mod tests {
         let filters1 = CacheFilters {
             subs: true,
             extensions: vec!["js".to_string()],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: false, // Different
             extensions: vec!["js".to_string()],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -273,17 +278,8 @@ mod tests {
     #[test]
     fn test_cache_key_string_representation() {
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key1 = CacheKey::new("example.com", &["wayback".to_string()], &filters);
@@ -336,29 +332,15 @@ mod tests {
         let filters1 = CacheFilters {
             subs: true,
             extensions: vec!["js".to_string()],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
             extensions: vec!["php".to_string()], // Different
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -368,30 +350,16 @@ mod tests {
     fn test_cache_filters_hash_with_different_patterns() {
         let filters1 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
             patterns: vec!["admin".to_string()],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
             patterns: vec!["api".to_string()], // Different
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -401,30 +369,18 @@ mod tests {
     fn test_cache_filters_hash_with_length_options() {
         let filters1 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
             min_length: Some(10),
             max_length: Some(100),
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
             min_length: Some(20), // Different
             max_length: Some(100),
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -434,30 +390,16 @@ mod tests {
     fn test_cache_filters_hash_with_normalize_url() {
         let filters1 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
             normalize_url: true,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
             normalize_url: false, // Different
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -467,30 +409,16 @@ mod tests {
     fn test_cache_filters_hash_with_merge_endpoint() {
         let filters1 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
             merge_endpoint: true,
+            ..Default::default()
         };
 
         let filters2 = CacheFilters {
             subs: true,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
             merge_endpoint: false, // Different
+            ..Default::default()
         };
 
         assert_ne!(filters1.compute_hash(), filters2.compute_hash());
@@ -499,17 +427,8 @@ mod tests {
     #[test]
     fn test_cache_key_providers_sorted() {
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         // Providers in different order should result in same sorted list
@@ -532,47 +451,69 @@ mod tests {
     fn test_cache_filters_hash_no_field_boundary_collision() {
         // presets=["a"] + min_length=Some(1) must NOT hash the same as
         // presets=["a1"] + min_length=None (the old concatenation collided).
-        let base = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
-            strict: false,
-            normalize_url: false,
-            merge_endpoint: false,
-        };
         let a = CacheFilters {
             presets: vec!["a".to_string()],
             min_length: Some(1),
-            ..base.clone()
+            ..Default::default()
         };
         let b = CacheFilters {
             presets: vec!["a1".to_string()],
             min_length: None,
-            ..base.clone()
+            ..Default::default()
         };
         assert_ne!(a.compute_hash(), b.compute_hash());
     }
 
     #[test]
+    fn test_archive_scope_changes_the_hash() {
+        // Regression: these options were absent from the key, so
+        // `urx example.com --from 2020` and `--from 2024` shared one cache
+        // entry and the second run was served the first one's URLs.
+        let base = CacheFilters::default();
+        let variants = [
+            CacheFilters {
+                cc_index: vec!["CC-MAIN-2025-51".to_string()],
+                ..Default::default()
+            },
+            CacheFilters {
+                from: Some("20200101000000".to_string()),
+                ..Default::default()
+            },
+            CacheFilters {
+                to: Some("20201231235959".to_string()),
+                ..Default::default()
+            },
+            CacheFilters {
+                archive_status: vec!["200".to_string()],
+                ..Default::default()
+            },
+            CacheFilters {
+                archive_exclude_status: vec!["404".to_string()],
+                ..Default::default()
+            },
+            CacheFilters {
+                archive_mime: vec!["application/json".to_string()],
+                ..Default::default()
+            },
+            CacheFilters {
+                archive_exclude_mime: vec!["text/html".to_string()],
+                ..Default::default()
+            },
+        ];
+
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(base.compute_hash());
+        for v in &variants {
+            assert!(
+                seen.insert(v.compute_hash()),
+                "archive scope must alter the cache key: {v:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_cache_key_no_field_boundary_collision() {
-        let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
-            strict: false,
-            normalize_url: false,
-            merge_endpoint: false,
-        };
+        let filters = CacheFilters::default();
         // domain "ab" + provider "c" vs domain "a" + provider "bc".
         let k1 = CacheKey::new("ab", &["c".to_string()], &filters);
         let k2 = CacheKey::new("a", &["bc".to_string()], &filters);
@@ -582,17 +523,8 @@ mod tests {
     #[test]
     fn test_cache_key_empty_providers() {
         let filters = CacheFilters {
-            subs: false,
-            extensions: vec![],
-            exclude_extensions: vec![],
-            patterns: vec![],
-            exclude_patterns: vec![],
-            presets: vec![],
-            min_length: None,
-            max_length: None,
             strict: true,
-            normalize_url: false,
-            merge_endpoint: false,
+            ..Default::default()
         };
 
         let key = CacheKey::new("example.com", &[], &filters);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1015,6 +1015,16 @@ fn create_cache_key(domain: &str, args: &Args) -> CacheKey {
         strict: args.strict_enabled(),
         normalize_url: args.normalize_url,
         merge_endpoint: args.merge_endpoint,
+        // Archive-side scope. These change what the index returns, so leaving
+        // them out would serve a `--from 2020` run the answer cached for a
+        // `--from 2024` one.
+        cc_index: args.cc_index.clone(),
+        from: args.from.clone(),
+        to: args.to.clone(),
+        archive_status: args.archive_status.clone(),
+        archive_exclude_status: args.archive_exclude_status.clone(),
+        archive_mime: args.archive_mime.clone(),
+        archive_exclude_mime: args.archive_exclude_mime.clone(),
     };
 
     CacheKey::new(domain, &effective_provider_ids(args), &filters)
@@ -1310,7 +1320,7 @@ async fn main() -> Result<()> {
         if let Some(sink) = &stream_sink {
             verbose_print(&args, format!("Streamed {} URLs", sink.emitted()));
         }
-        if args.stats {
+        if args.stats && !args.silent {
             print_provider_stats(&run_result.stats);
         }
         return Ok(());

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -86,10 +86,26 @@ pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
 }
 
+/// Whether an HTTP status is worth another attempt.
+///
+/// Server errors and explicit throttling are transient. The rest of the 4xx
+/// range is a deterministic "no" and retrying it only wastes requests and
+/// wall-clock: a 404 from a CDX index is how those APIs say "this domain has no
+/// captures", so re-asking three times with back-off turns an instant miss into
+/// a multi-second one — per domain, per provider.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+}
+
 /// Execute an HTTP GET request with retry and linear back-off.
 ///
 /// `max_retries` is the number of **additional** attempts after the first
-/// failure (i.e. total attempts = 1 + max_retries).
+/// failure (i.e. total attempts = 1 + max_retries). A response the server has
+/// told us not to repeat (see [`is_retryable_status`]) ends the loop early, and
+/// a `Retry-After` header overrides our own back-off so a throttled request
+/// waits as long as the server asked instead of hammering it again.
 ///
 /// On success the response body is returned as a `String`.
 ///
@@ -98,47 +114,46 @@ pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duratio
 /// Returns the last encountered error if all attempts are exhausted.
 pub async fn get_with_retry(client: &Client, url: &str, max_retries: u32) -> Result<String> {
     let mut last_error: Option<anyhow::Error> = None;
-    let mut attempt: u32 = 0;
+    // Server-dictated wait for the *next* attempt, when it sent one.
+    let mut next_delay: Option<Duration> = None;
+    let mut attempts: u32 = 0;
 
-    while attempt <= max_retries {
+    for attempt in 0..=max_retries {
         if attempt > 0 {
-            // Linear back-off: 500ms, 1000ms, 1500ms, …
-            tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+            // Linear back-off: 500ms, 1000ms, 1500ms, … unless the server named
+            // its own delay.
+            let delay = next_delay
+                .take()
+                .unwrap_or_else(|| Duration::from_millis(500 * attempt as u64));
+            tokio::time::sleep(delay).await;
         }
+        attempts += 1;
 
         match client.get(url).send().await {
             Ok(response) => {
-                if !response.status().is_success() {
-                    last_error = Some(anyhow::anyhow!("HTTP error: {}", response.status()));
-                    attempt += 1;
+                let status = response.status();
+                if !status.is_success() {
+                    last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
+                    if !is_retryable_status(status) {
+                        break;
+                    }
+                    next_delay = retry_after_delay(response.headers());
                     continue;
                 }
 
                 match response.text().await {
                     Ok(text) => return Ok(text),
-                    Err(e) => {
-                        last_error = Some(e.into());
-                        attempt += 1;
-                        continue;
-                    }
+                    Err(e) => last_error = Some(e.into()),
                 }
             }
-            Err(e) => {
-                last_error = Some(e.into());
-                attempt += 1;
-                continue;
-            }
+            Err(e) => last_error = Some(e.into()),
         }
     }
 
-    if let Some(e) = last_error {
-        Err(anyhow::anyhow!(
-            "Failed after {} attempts: {}",
-            max_retries + 1,
-            e
-        ))
-    } else {
-        Err(anyhow::anyhow!("Failed after {} attempts", max_retries + 1))
+    let noun = if attempts == 1 { "attempt" } else { "attempts" };
+    match last_error {
+        Some(e) => Err(anyhow::anyhow!("Failed after {attempts} {noun}: {e}")),
+        None => Err(anyhow::anyhow!("Failed after {attempts} {noun}")),
     }
 }
 
@@ -327,6 +342,56 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("Failed after 2 attempts"));
+    }
+
+    #[tokio::test]
+    async fn test_get_with_retry_does_not_retry_client_errors() {
+        let mut mock_server = mockito::Server::new_async().await;
+
+        // A 404 is a definitive answer (for CDX indexes it means "no captures"),
+        // so it must cost exactly one request no matter how many retries were
+        // configured.
+        let m = mock_server
+            .mock("GET", "/missing")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = Client::new();
+        let url = format!("{}/missing", mock_server.url());
+        let err = get_with_retry(&client, &url, 5).await.unwrap_err();
+
+        assert!(err.to_string().contains("Failed after 1 attempt"), "{err}");
+        m.assert();
+    }
+
+    #[tokio::test]
+    async fn test_get_with_retry_retries_throttling() {
+        let mut mock_server = mockito::Server::new_async().await;
+
+        // 429 is transient, and the Retry-After the server names is what we
+        // wait — capped, so a hostile value can't stall the run.
+        let throttled = mock_server
+            .mock("GET", "/slow")
+            .with_status(429)
+            .with_header("retry-after", "0")
+            .expect(1)
+            .create_async()
+            .await;
+        let ok = mock_server
+            .mock("GET", "/slow")
+            .with_status(200)
+            .with_body("done")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = Client::new();
+        let url = format!("{}/slow", mock_server.url());
+        assert_eq!(get_with_retry(&client, &url, 2).await.unwrap(), "done");
+        throttled.assert();
+        ok.assert();
     }
 
     #[tokio::test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -50,10 +50,14 @@ impl UrlData {
 
     /// Parse a URL data entry from a string
     ///
-    /// Can handle strings in the format "{url} - {status}" or plain URLs
+    /// Can handle strings in the format "{url} - {status}" or plain URLs.
+    /// Archived URLs can themselves contain " - " (unencoded spaces do show up
+    /// in CDX rows), so the split takes the *last* separator: the status the
+    /// checker appends is always the final field, whereas the URL is not
+    /// guaranteed to be separator-free.
     pub fn from_string(data: String) -> Self {
         // Parse strings in the format "{url} - {status}" if possible
-        if let Some((url, status)) = data.split_once(" - ") {
+        if let Some((url, status)) = data.rsplit_once(" - ") {
             UrlData {
                 url: url.to_string(),
                 status: Some(status.to_string()),
@@ -186,6 +190,15 @@ mod tests {
             with_status.status,
             Some("301 Moved Permanently".to_string())
         );
+    }
+
+    #[test]
+    fn test_url_data_from_string_url_containing_the_separator() {
+        // A URL with a literal " - " in it used to be truncated at that point,
+        // with the rest of the URL swallowed into the status field.
+        let parsed = UrlData::from_string("https://example.com/a - b/c.pdf - 200 OK".to_string());
+        assert_eq!(parsed.url, "https://example.com/a - b/c.pdf");
+        assert_eq!(parsed.status.as_deref(), Some("200 OK"));
     }
 
     #[test]

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -103,7 +103,13 @@ impl Provider for RobotsProvider {
             let https_resp = client.get(&https_url).send().await;
             // Track which protocol was successful
             let (is_https, text) = match https_resp {
-                Ok(resp) if resp.status().is_success() => (true, resp.text().await?),
+                // A body that dies mid-read is "no robots.txt" for our purposes,
+                // not a fatal error — same best-effort contract as the HTTP
+                // fallback below.
+                Ok(resp) if resp.status().is_success() => match resp.text().await {
+                    Ok(text) => (true, text),
+                    Err(_) => return Ok(urls),
+                },
                 _ => {
                     // If HTTPS fails, try HTTP
                     #[cfg(not(test))]
@@ -131,7 +137,10 @@ impl Provider for RobotsProvider {
                     if !http_resp.status().is_success() {
                         return Ok(urls);
                     }
-                    (false, http_resp.text().await?)
+                    match http_resp.text().await {
+                        Ok(text) => (false, text),
+                        Err(_) => return Ok(urls),
+                    }
                 }
             };
 

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -111,7 +111,14 @@ impl SitemapProvider {
         if let Some(rl) = limiter {
             rl.acquire().await;
         }
-        let resp = client.get(sitemap_url).send().await?;
+        // Sitemap discovery is best-effort and speculative: most of the
+        // candidate locations we probe don't exist. A transport failure or a
+        // non-200 means "nothing here", not an error that should sink the whole
+        // provider — the `visited` insert above already stops us re-asking.
+        let resp = match client.get(sitemap_url).send().await {
+            Ok(resp) => resp,
+            Err(_) => return Ok(Vec::new()),
+        };
         if !resp.status().is_success() {
             return Ok(Vec::new());
         }
@@ -128,7 +135,12 @@ impl SitemapProvider {
                 .map(|ct| ct.to_ascii_lowercase().contains("text/plain"))
                 .unwrap_or(false);
 
-        let content = read_body_capped(resp, MAX_SITEMAP_BYTES).await?;
+        let content = match read_body_capped(resp, MAX_SITEMAP_BYTES).await {
+            Ok(content) => content,
+            // A body that dies mid-stream yields no usable URLs; same
+            // best-effort reasoning as above.
+            Err(_) => return Ok(Vec::new()),
+        };
         let mut urls = Vec::new();
 
         match Document::parse(&content) {
@@ -226,23 +238,16 @@ impl Provider for SitemapProvider {
                 format!("http://{}/sitemap.txt", domain),
             ];
 
+            // `parse_sitemap` does the request itself and reports "nothing here"
+            // for a missing or unreachable location, so probing first would just
+            // fetch every sitemap that *does* exist twice — doubling the requests
+            // aimed at the target and the bytes pulled for a large sitemap.
+            // It also paces each request through the limiter, so this loop's up
+            // to six candidate locations stay rate-limited.
             for sitemap_url in sitemap_urls {
-                // Pace the candidate-location probes too: this loop fires up to
-                // six back-to-back requests at the target.
-                if let Some(rl) = &limiter {
-                    rl.acquire().await;
-                }
-                let resp = client.get(&sitemap_url).send().await;
-
-                if let Ok(resp) = resp {
-                    if resp.status().is_success() {
-                        // Found a valid sitemap, parse it
-                        let sitemap_urls =
-                            Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited, limiter)
-                                .await?;
-                        urls.extend(sitemap_urls);
-                    }
-                }
+                let found =
+                    Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited, limiter).await?;
+                urls.extend(found);
             }
 
             Ok(urls)
@@ -322,6 +327,37 @@ mod tests {
             "rate limit did not pace the sitemap probe requests: {:?}",
             start.elapsed()
         );
+    }
+
+    #[tokio::test]
+    async fn test_sitemap_is_fetched_once_not_probed_then_refetched() {
+        // Regression: fetch_urls used to GET each candidate location to check it
+        // existed and then hand the same URL to parse_sitemap, which fetched it
+        // again — two requests (and two full downloads) for every sitemap that
+        // actually exists.
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+        let sitemap = server
+            .mock("GET", "/sitemap.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/only</loc></url>
+</urlset>"#,
+            )
+            .expect(1)
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        // The https:// candidates can't reach a plain-HTTP mock; the http:// one
+        // does, which is what exercises the single-fetch path.
+        let urls = provider.fetch_urls(&host).await.unwrap();
+
+        assert_eq!(urls, vec!["https://example.com/only".to_string()]);
+        sitemap.assert();
     }
 
     #[test]

--- a/src/readers/urlteam_reader.rs
+++ b/src/readers/urlteam_reader.rs
@@ -45,16 +45,30 @@ impl UrlTeamFileReader {
         }
     }
 
-    /// Determine if file is gzip compressed based on magic bytes
-    fn is_gzip(file_path: &Path) -> Result<bool> {
+    /// Read the file's leading magic bytes, or an empty slice when the file is
+    /// too short to have any.
+    fn magic(file_path: &Path) -> Result<[u8; 3]> {
         let mut file = File::open(file_path)
             .with_context(|| format!("Failed to open file: {}", file_path.display()))?;
 
-        let mut magic = [0u8; 2];
-        match file.read_exact(&mut magic) {
-            Ok(()) => Ok(magic[0] == 0x1f && magic[1] == 0x8b),
-            Err(_) => Ok(false), // File too small or other read error
-        }
+        let mut magic = [0u8; 3];
+        // A short read leaves the tail zeroed, which matches no signature.
+        let _ = file.read(&mut magic);
+        Ok(magic)
+    }
+
+    /// Determine if file is gzip compressed based on magic bytes
+    fn is_gzip(file_path: &Path) -> Result<bool> {
+        let magic = Self::magic(file_path)?;
+        Ok(magic[0] == 0x1f && magic[1] == 0x8b)
+    }
+
+    /// Whether the file is bzip2-compressed. urx has no bzip2 decoder, and
+    /// reading such a file as text yields binary noise with no extractable
+    /// URLs — an empty result that reads as "this archive had nothing". Detect
+    /// it so the user gets told what actually happened.
+    fn is_bzip2(file_path: &Path) -> Result<bool> {
+        Ok(&Self::magic(file_path)? == b"BZh")
     }
 
     /// Read URL lines from `src`, bounding both the number of URLs collected and
@@ -101,6 +115,14 @@ impl UrlTeamFileReader {
 
 impl FileReader for UrlTeamFileReader {
     fn read_urls(&self, file_path: &Path) -> Result<Vec<String>> {
+        if Self::is_bzip2(file_path)? {
+            anyhow::bail!(
+                "{}: bzip2 input is not supported. Decompress it first \
+                 (`bunzip2 -k <file>`) and pass the result to --files.",
+                file_path.display()
+            );
+        }
+
         let file = File::open(file_path)
             .with_context(|| format!("Failed to open URLTeam file: {}", file_path.display()))?;
 
@@ -288,6 +310,22 @@ mod tests {
         assert_eq!(urls.len(), 2);
         assert!(!url_capped);
         assert!(!byte_capped);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bzip2_input_is_reported_not_silently_empty() -> Result<()> {
+        // `--files foo.bz2` routes here (detect_file_format maps .bz2 to
+        // URLTeam), but there is no bzip2 decoder — so the bytes used to be read
+        // as text, yield zero URLs, and look exactly like an empty archive.
+        let mut temp_file = NamedTempFile::new()?;
+        // A bzip2 header is enough; we reject before decoding anything.
+        temp_file.write_all(b"BZh91AY&SY\x00\x00\x00\x00")?;
+        temp_file.flush()?;
+
+        let reader = UrlTeamFileReader::new();
+        let err = reader.read_urls(temp_file.path()).unwrap_err();
+        assert!(err.to_string().contains("bzip2"), "{err}");
         Ok(())
     }
 

--- a/src/tester_manager/mod.rs
+++ b/src/tester_manager/mod.rs
@@ -61,6 +61,13 @@ pub async fn process_urls_with_testers(
     let check_status = should_check_status;
     let extract_links = args.extract_links;
     let silent = args.silent;
+    // With an --include-status allowlist, a URL whose status we could never
+    // resolve has not been shown to match it. Emitting it with a placeholder
+    // status would smuggle it past the very filter the user asked for — so an
+    // allowlist drops unresolvable URLs. An --exclude-status denylist is the
+    // other way round: a failed check matched nothing on the list, so the URL
+    // is kept (flagged) rather than silently discarded.
+    let drop_unresolved = !args.include_status.is_empty();
 
     let url_chunks: Vec<Vec<String>> = transformed_urls
         .chunks(10)
@@ -109,11 +116,13 @@ pub async fn process_urls_with_testers(
                     } else {
                         // If no status but URL should be included anyway
                         if check_status {
-                            let url_data = output::UrlData::with_status(
-                                url.clone(),
-                                "Status check failed".to_string(),
-                            );
-                            result_urls.push(url_data);
+                            if !drop_unresolved {
+                                let url_data = output::UrlData::with_status(
+                                    url.clone(),
+                                    "Status check failed".to_string(),
+                                );
+                                result_urls.push(url_data);
+                            }
                         } else {
                             let url_data = output::UrlData::new(url.clone());
                             result_urls.push(url_data);
@@ -215,6 +224,74 @@ mod tests {
         fn with_proxy_auth(&mut self, auth: Option<String>) {
             self.proxy_auth = auth;
         }
+    }
+
+    /// A tester whose every request fails, standing in for an unreachable host.
+    #[derive(Clone, Default)]
+    struct FailingTester;
+
+    impl Tester for FailingTester {
+        fn clone_box(&self) -> Box<dyn Tester> {
+            Box::new(self.clone())
+        }
+
+        fn test_url<'a>(
+            &'a self,
+            url: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+            let url = url.to_string();
+            Box::pin(async move { Err(anyhow::anyhow!("connection refused for {url}")) })
+        }
+
+        fn with_timeout(&mut self, _seconds: u64) {}
+        fn with_retries(&mut self, _count: u32) {}
+        fn with_random_agent(&mut self, _enabled: bool) {}
+        fn with_insecure(&mut self, _enabled: bool) {}
+        fn with_proxy(&mut self, _proxy: Option<String>) {}
+        fn with_proxy_auth(&mut self, _auth: Option<String>) {}
+    }
+
+    async fn run_failing_status_check(argv: &[&str]) -> Vec<output::UrlData> {
+        use clap::Parser;
+        let args = Args::parse_from(argv);
+        let progress = ProgressManager::new(true);
+        process_urls_with_testers(
+            vec!["https://example.com/a".to_string()],
+            &args,
+            &progress,
+            vec![Box::new(FailingTester)],
+            true,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_include_status_drops_urls_whose_status_never_resolved() {
+        // Regression: an unreachable URL was emitted with a placeholder
+        // "Status check failed" status even under --include-status 200, so the
+        // allowlist leaked URLs that were never shown to return 200.
+        let out =
+            run_failing_status_check(&["urx", "--is", "200", "--silent", "example.com"]).await;
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn test_plain_check_status_still_reports_the_failure() {
+        // Without an allowlist there is nothing to leak past, and the failure is
+        // itself information worth surfacing.
+        let out =
+            run_failing_status_check(&["urx", "--check-status", "--silent", "example.com"]).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].status.as_deref(), Some("Status check failed"));
+    }
+
+    #[tokio::test]
+    async fn test_exclude_status_keeps_urls_whose_status_never_resolved() {
+        // A denylist is the inverse: a failed check matched nothing on the list.
+        let out =
+            run_failing_status_check(&["urx", "--es", "404", "--silent", "example.com"]).await;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].status.as_deref(), Some("Status check failed"));
     }
 
     #[test]

--- a/src/utils/url.rs
+++ b/src/utils/url.rs
@@ -174,16 +174,27 @@ impl UrlTransformer {
                 // Merge parameters from all URLs with the same path
                 if let Ok(base_url) = Url::parse(&group_urls[0]) {
                     let mut merged_url = base_url.clone();
-                    let mut all_params = Vec::new();
+                    let mut all_params: Vec<String> = Vec::new();
                     let mut seen_params = HashSet::new();
 
-                    // Collect parameters from all URLs
+                    // Collect parameters from all URLs. We copy the *raw*
+                    // `key=value` tokens rather than decoding via
+                    // `query_pairs()`: decoding and re-joining silently rewrites
+                    // the URL the archive recorded — a value containing an
+                    // encoded `&` or `=` (`?next=%2Fa%3Fb%3D1`) would come back
+                    // out as extra parameters, `+` would turn into a space, and
+                    // a bare `?foo` would gain an `=`. Merging must only add
+                    // parameters, never alter them.
                     for url_str in &group_urls {
                         if let Ok(url) = Url::parse(url_str) {
-                            for (key, value) in url.query_pairs() {
-                                let pair = (key.to_string(), value.to_string());
-                                if seen_params.insert(pair.clone()) {
-                                    all_params.push(pair);
+                            for pair in url
+                                .query()
+                                .unwrap_or("")
+                                .split('&')
+                                .filter(|s| !s.is_empty())
+                            {
+                                if seen_params.insert(pair.to_string()) {
+                                    all_params.push(pair.to_string());
                                 }
                             }
                         }
@@ -191,17 +202,11 @@ impl UrlTransformer {
 
                     // Set merged parameters
                     if !all_params.is_empty() {
-                        let query_string = all_params
-                            .into_iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join("&");
+                        let query_string = all_params.join("&");
 
                         // Clear existing query and set merged query
                         merged_url.set_query(None);
-                        if !query_string.is_empty() {
-                            merged_url.set_query(Some(&query_string));
-                        }
+                        merged_url.set_query(Some(&query_string));
                     }
 
                     merged_urls.push(merged_url.to_string());
@@ -277,6 +282,45 @@ mod tests {
             &"https://example.com/api?param1=value1&param2=value2&param3=value3".to_string()
         ));
         assert!(transformed.contains(&"https://other.com/path".to_string()));
+    }
+
+    #[test]
+    fn test_merge_endpoints_preserves_encoded_values() {
+        // Regression: merging used to decode each pair with query_pairs() and
+        // re-join the results raw, so an encoded '&' or '=' inside a value broke
+        // out and became extra parameters — silently rewriting the URL the
+        // archive actually recorded.
+        let mut transformer = UrlTransformer::new();
+        transformer.with_merge_endpoint(true);
+
+        let urls = vec![
+            "https://example.com/go?next=%2Fadmin%3Fdebug%3D1".to_string(),
+            "https://example.com/go?ref=home".to_string(),
+        ];
+
+        let out = transformer.transform(urls);
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_eq!(
+            out[0],
+            "https://example.com/go?next=%2Fadmin%3Fdebug%3D1&ref=home"
+        );
+    }
+
+    #[test]
+    fn test_merge_endpoints_preserves_plus_and_bare_params() {
+        // '+' must not become a space, and a valueless `?foo` must not gain an
+        // '=' — both were casualties of the decode/re-encode round trip.
+        let mut transformer = UrlTransformer::new();
+        transformer.with_merge_endpoint(true);
+
+        let urls = vec![
+            "https://example.com/s?q=a+b".to_string(),
+            "https://example.com/s?debug".to_string(),
+        ];
+
+        let out = transformer.transform(urls);
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_eq!(out[0], "https://example.com/s?q=a+b&debug");
     }
 
     #[test]


### PR DESCRIPTION
Defects found while auditing the source. Each fix carries a regression test that was verified to fail against the previous behaviour.

## Correctness

**Cache served the wrong results across different archive queries** — `CacheFilters` carried only the local filters. `--from/--to`, all four `--archive-*` predicates, and `--cc-index` were absent from the key, so `urx example.com --from 2020` and `--from 2024` collided on one entry and the second run silently got the first one's URLs. The struct now derives `Default` as well, so a future flag can be added without every construction site needing an edit — that omission is exactly how this bug arrived.

**`--merge-endpoint` rewrote the URLs it merged** — merging decoded each parameter with `query_pairs()` and re-joined the results raw. Verified against the old code: `?q=a+b` came out as `?q=a%20b`, `?debug` became `?debug=`, and a value holding an encoded `&`/`=` broke out into extra parameters. `--normalize-url` already documented why it avoids `query_pairs()`; merge didn't get the same care.

**`--include-status` leaked unreachable URLs** — a URL whose status check failed was emitted with a `"Status check failed"` placeholder even under `--is 200`, past the very filter the user asked for. Allowlists now drop unresolvable URLs; `--exclude-status` still keeps them flagged, since a failed check matched nothing on the denylist.

## Wasted requests

**4xx were retried and `Retry-After` was ignored** — `get_with_retry` retried every non-2xx. A 404 is how a CDX index says "no captures", so a miss cost three extra requests plus back-off, per domain per provider. Only 5xx/429/408 retry now, and a `Retry-After` header overrides our own back-off. Side effect: the test suite runs in 4s instead of 24s.

**Sitemap provider fetched every sitemap twice** — `fetch_urls` GET each candidate location to confirm it existed, then handed the URL to `parse_sitemap`, which fetched it again. Double the requests and double the bytes for a large sitemap. The probe is gone; `parse_sitemap` reports "nothing here" for unreachable/non-200 rather than propagating, keeping discovery best-effort.

## Smaller

- `--stats` printed under `--silent`, on the streaming path only.
- `UrlData::from_string` split on the *first* `" - "`, truncating URLs containing that sequence and swallowing the rest into the status field.
- robots.txt propagated a mid-body read error instead of treating it as "no robots.txt".
- A `.bz2` file routed to a reader with no bzip2 decoder returned zero URLs, indistinguishable from an empty archive. Now a clear error naming the fix.

## Verification

554 tests pass (543 before, +11 new). `cargo clippy --all-targets -- -D warnings` clean. Smoke-tested `--merge-endpoint` and the bzip2 path through the real binary.

## Noted, not changed

- `ProviderStats.elapsed` is documented as "total wall-clock" but sums per-domain fetch times, so it exceeds real elapsed under `--parallel`.
- `github_api_key` has no config-file field, though the `--all-providers` docs say keyed providers activate "via flag, env, or config file".
- `--cc-index` values reach the URL path unvalidated (only the `latest` alias resolution is checked). User-supplied, so low risk.