### PR TITLE
fix(providers): stop discarding collected pages when a later page fails

### DIFF
--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
 
 // Helper function to deserialize null as default value for i32
 fn deserialize_null_i32<'de, D>(deserializer: D) -> Result<i32, D::Error>
@@ -162,11 +163,23 @@ impl Provider for OTXProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             let mut all_urls = Vec::new();
             let mut page = 0;
             let client = self.client_config().build_client()?;
             let limiter = self.rate_limit.as_ref();
+
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
+            }
 
             loop {
                 let url = self.format_url(domain, page);
@@ -289,6 +302,10 @@ impl Provider for OTXProvider {
                             .filter(|url| !url.is_empty()),
                     );
 
+                    if let Some(r) = &reporter {
+                        r.detail(format!("{} URLs…", all_urls.len()));
+                    }
+
                     // Stop when this page returned nothing (there is no more
                     // data, even if the server still claims `has_next`), or when
                     // the API reports no further pages. A full page with
@@ -300,10 +317,22 @@ impl Provider for OTXProvider {
                         break;
                     }
                 } else {
-                    // If we couldn't get a result after all retries, return the error
-                    return Err(last_error.unwrap_or_else(|| {
-                        anyhow::anyhow!("Failed to fetch OTX data after all retries")
-                    }));
+                    // Best effort: a page that failed after all its retries must
+                    // not discard the pages already collected. Only a failure on
+                    // the very first request — where there is nothing to keep —
+                    // is fatal, matching every other paginating provider.
+                    if all_urls.is_empty() {
+                        return Err(last_error.unwrap_or_else(|| {
+                            anyhow::anyhow!("Failed to fetch OTX data after all retries")
+                        }));
+                    }
+                    // We're returning a truncated result. Flag it so the runner
+                    // marks the line partial and warns, rather than presenting an
+                    // incomplete crawl as a clean success.
+                    if let Some(r) = &reporter {
+                        r.mark_partial();
+                    }
+                    break;
                 }
 
                 page += 1;
@@ -667,6 +696,77 @@ mod tests {
         let result = provider.fetch_urls("example.com").await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_keeps_earlier_pages_when_a_later_page_fails() {
+        // Regression: a page that failed after its retries used to `return Err`,
+        // throwing away every page already collected. A domain with 50 good pages
+        // and one flaky page reported the whole provider as failed and yielded
+        // nothing.
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        // A full page (200 rows) so the walk continues to page 2.
+        let rows: Vec<String> = (0..OTX_RESULTS_LIMIT)
+            .map(|i| format!(r#"{{"url":"http://example.com/{i}"}}"#))
+            .collect();
+        let _page1 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=1",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{ "has_next": true, "url_list": [{}] }}"#,
+                rows.join(",")
+            ))
+            .create();
+        // ...and page 2 is permanently broken.
+        let _page2 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=2",
+            )
+            .with_status(503)
+            .create();
+
+        let mut provider = OTXProvider::new();
+        provider.with_base_url(url);
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .expect("page one must survive a later page's failure");
+
+        assert_eq!(urls.len(), OTX_RESULTS_LIMIT as usize);
+        assert!(urls.contains(&"http://example.com/0".to_string()));
+        // The lost page is surfaced as a partial result, not a clean success.
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_errors_when_the_first_page_fails() {
+        // With nothing collected there is nothing to salvage, so the failure
+        // must still propagate.
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let _m = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=1",
+            )
+            .with_status(503)
+            .create();
+
+        let mut provider = OTXProvider::new();
+        provider.with_base_url(url);
+        provider.with_retries(0);
+
+        assert!(provider.fetch_urls("example.com").await.is_err());
     }
 
     #[tokio::test]

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -7,6 +7,7 @@ use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
 
 #[derive(Clone)]
 pub struct UrlscanProvider {
@@ -193,6 +194,14 @@ impl Provider for UrlscanProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             // urlscan.io's public search allows unauthenticated queries
             // (rate-limited to ~30 req/min per IP), so we always query. When no
@@ -217,6 +226,10 @@ impl Provider for UrlscanProvider {
 
             let client = self.client_config().build_client()?;
             let limiter = self.rate_limit.as_ref();
+
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
+            }
 
             // urlscan returns at most 100 results per request and signals more
             // via `has_more`; the next page is requested by passing the last
@@ -245,6 +258,13 @@ impl Provider for UrlscanProvider {
                         if all_urls.is_empty() {
                             return Err(e);
                         }
+                        // ...and flags them as truncated. Without this the run
+                        // reports a clean ✓ over an incomplete crawl, which is
+                        // indistinguishable from "the domain really has this few
+                        // URLs".
+                        if let Some(r) = &reporter {
+                            r.mark_partial();
+                        }
                         break;
                     }
                 };
@@ -262,6 +282,10 @@ impl Provider for UrlscanProvider {
                 let more = response.has_more;
                 for result in response.results {
                     all_urls.push(result.page.url);
+                }
+
+                if let Some(r) = &reporter {
+                    r.detail(format!("{} URLs…", all_urls.len()));
                 }
 
                 if !more {
@@ -607,6 +631,47 @@ mod tests {
         );
         page1.assert();
         page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_truncated_pagination_is_reported_as_partial() {
+        // Regression: urlscan kept the pages it had when a later page failed, but
+        // only implemented `fetch_urls` — so the trait's default
+        // `fetch_urls_with_progress` dropped the reporter and `mark_partial()`
+        // could never fire. A truncated crawl printed a clean ✓, which looks
+        // exactly like "this domain really has one URL".
+        let mut server = mockito::Server::new_async().await;
+
+        let _page1 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Regex("size=100$".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"status":200,"has_more":true,"results":[{"page":{"domain":"example.com","url":"https://example.com/p1","status":"200"},"sort":[1700000000000,"abc"]}]}"#,
+            )
+            .create_async()
+            .await;
+        // The continuation is permanently broken.
+        let _page2 = server
+            .mock("GET", "/api/v1/search/")
+            .match_query(mockito::Matcher::Regex("search_after=1700000000000".into()))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = UrlscanProvider::new("k".to_string());
+        provider.with_base_url(server.url());
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .expect("page one must survive the continuation's failure");
+
+        assert_eq!(urls, vec!["https://example.com/p1".to_string()]);
+        assert!(reporter.is_partial());
     }
 
     #[tokio::test]

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -8,6 +8,7 @@ use super::ApiKeyRotator;
 use super::Provider;
 use crate::network::client::HttpClientConfig;
 use crate::network::RateLimiter;
+use crate::progress::ProgressReporter;
 
 #[derive(Clone)]
 pub struct ZoomEyeProvider {
@@ -127,9 +128,21 @@ impl Provider for ZoomEyeProvider {
         &'a self,
         domain: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        self.fetch_urls_with_progress(domain, None)
+    }
+
+    fn fetch_urls_with_progress<'a>(
+        &'a self,
+        domain: &'a str,
+        reporter: Option<ProgressReporter>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
         Box::pin(async move {
             if !self.api_key_rotator.has_keys() {
                 return Ok(Vec::new());
+            }
+
+            if let Some(r) = &reporter {
+                r.detail("fetching…");
             }
 
             let dork = self.build_dork(domain);
@@ -234,11 +247,24 @@ impl Provider for ZoomEyeProvider {
                 }
 
                 if let Some(e) = last_error {
-                    return Err(anyhow::anyhow!(
-                        "Failed after {} attempts: {}",
-                        self.retries + 1,
-                        e
-                    ));
+                    // Best effort: a page that failed after all its retries must
+                    // not discard the pages already collected. Only a failure with
+                    // nothing collected is fatal, matching every other paginating
+                    // provider.
+                    if all_urls.is_empty() {
+                        return Err(anyhow::anyhow!(
+                            "Failed after {} attempts: {}",
+                            self.retries + 1,
+                            e
+                        ));
+                    }
+                    // We're returning a truncated result. Flag it so the runner
+                    // marks the line partial and warns instead of presenting an
+                    // incomplete crawl as a clean success.
+                    if let Some(r) = &reporter {
+                        r.mark_partial();
+                    }
+                    break;
                 }
 
                 // A page that returned no rows means the data is exhausted even
@@ -246,6 +272,10 @@ impl Provider for ZoomEyeProvider {
                 // count.
                 let page_was_empty = page_urls.is_empty();
                 all_urls.extend(page_urls);
+
+                if let Some(r) = &reporter {
+                    r.detail(format!("{} URLs…", all_urls.len()));
+                }
 
                 // Check if there are more pages
                 let fetched_so_far = (page as u64) * (pagesize as u64);
@@ -576,6 +606,73 @@ mod tests {
         assert_eq!(urls.len(), 2);
         assert_eq!(urls[0], "https://example.com/page1");
         assert_eq!(urls[1], "https://example.com/page2");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_keeps_earlier_pages_when_a_later_page_fails() {
+        // Regression: a page failing after its retries used to `return Err`,
+        // discarding every page already collected — so one flaky page late in a
+        // large result set reported the whole provider as failed.
+        let mut mock_server = mockito::Server::new_async().await;
+
+        // A full first page (100 rows) with total=200, so the walk continues.
+        let rows: Vec<String> = (0..100)
+            .map(|i| format!(r#"{{"url":"https://example.com/{i}","ip":"1.2.3.4","domain":"example.com","port":443,"title":"t"}}"#))
+            .collect();
+        let _page1 = mock_server
+            .mock("POST", "/v2/search")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"page":1}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{ "code": 60000, "total": 200, "data": [{}] }}"#,
+                rows.join(",")
+            ))
+            .create_async()
+            .await;
+        // ...and page 2 is permanently broken.
+        let _page2 = mock_server
+            .mock("POST", "/v2/search")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"page":2}"#.to_string(),
+            ))
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = ZoomEyeProvider::new("test_api_key".to_string());
+        provider.with_base_url(mock_server.url());
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .expect("page one must survive a later page's failure");
+
+        assert_eq!(urls.len(), 100);
+        assert!(urls.contains(&"https://example.com/0".to_string()));
+        // The lost page is surfaced as a partial result, not a clean success.
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_errors_when_the_first_page_fails() {
+        // Nothing collected means nothing to salvage — the failure propagates.
+        let mut mock_server = mockito::Server::new_async().await;
+        let _m = mock_server
+            .mock("POST", "/v2/search")
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut provider = ZoomEyeProvider::new("test_api_key".to_string());
+        provider.with_base_url(mock_server.url());
+        provider.with_retries(0);
+
+        assert!(provider.fetch_urls("example.com").await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Round 2 of the source audit. One coherent defect class: how the API-backed providers handle a failure partway through pagination.

`wayback`, `cc`, `arquivo`, `vt`, and `github` all agree on the contract — keep the pages you already have, flag the result partial, warn. These three didn't.

## OTX and ZoomEye threw everything away

`otx.rs` and `zoomeye.rs` returned `Err` the moment any page failed after exhausting its retries, **discarding every page already collected**. A domain with fifty good pages and one flaky page reported the whole provider as failed and produced nothing.

Only a failure with nothing collected is fatal now; anything later keeps the pages and marks the result partial.

## urlscan couldn't report a truncated crawl

`urlscan.rs` already kept its pages on a late failure, but it implemented only `fetch_urls`. The trait's default `fetch_urls_with_progress` discards the reporter, so `mark_partial()` had no way to fire — a truncated crawl printed a clean ✓, which reads exactly like "this domain really has that few URLs".

## Also

All three now implement `fetch_urls_with_progress`, so they surface live URL counts on their progress line the way the CDX providers already do.

## Verification

559 tests pass (554 before, +5 new). Each new test was run against the pre-fix code and confirmed to fail:

- `otx::test_fetch_urls_keeps_earlier_pages_when_a_later_page_fails` — FAILED before, passes now
- `urlscan::test_truncated_pagination_is_reported_as_partial` — FAILED before, passes now
- plus first-page-failure tests pinning that a genuine total failure still propagates

`cargo clippy --all-targets -- -D warnings` clean.

## Noted, not changed

`include_subdomains` is dead state in `vt.rs` and `urlscan.rs` — both store `--subs` and never read it, so `--subs` is a silent no-op for those two providers. Implementing it means committing to VirusTotal/urlscan query syntax I can't verify without live API access, and this codebase has repeatedly been bitten by exactly that: a wrong query returns nothing and looks identical to "no data". Worth a follow-up by someone who can test against the real APIs.