### PR TITLE
fix(extract-links): apply the user's filters to discovered links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -718,22 +718,9 @@ fn apply_url_filters(
         if args.verbose && !args.silent {
             println!("Enforcing strict host validation...");
         }
-        // Re-resolve the original domain list, normalized the same way as the
-        // fetch targets so the validator's hosts line up with what was queried.
-        // We can't read stdin a second time, so this falls back to whatever
-        // positional args and --domain-list files supplied.
-        let mut domains: Vec<String> = args.domains.clone();
-        for path in &args.domain_list {
-            domains.extend(read_domains_from_file(path)?);
-        }
-        let domains: Vec<String> = domains
-            .iter()
-            .filter_map(|d| cli::normalize_domain(d))
-            .collect();
 
-        if !domains.is_empty() {
+        if let Some(host_validator) = build_host_validator(args)? {
             let before = sorted_urls.len();
-            let host_validator = HostValidator::new(&domains, args.subs);
             sorted_urls.retain(|url| host_validator.is_valid_host(url));
             let removed = before - sorted_urls.len();
 
@@ -770,6 +757,31 @@ fn apply_url_filters(
     Ok(sorted_urls)
 }
 
+/// Re-resolve the original target list into a [`HostValidator`], or `None` when
+/// strict mode is off or no host-bearing target was supplied.
+///
+/// The domains are normalized exactly the way the fetch targets were, so the
+/// validator's hosts line up with what was actually queried. stdin can't be read
+/// a second time, so this falls back to whatever positional args and
+/// `--domain-list` files supplied.
+fn build_host_validator(args: &Args) -> Result<Option<HostValidator>> {
+    if !args.strict_enabled() {
+        return Ok(None);
+    }
+    let mut domains: Vec<String> = args.domains.clone();
+    for path in &args.domain_list {
+        domains.extend(read_domains_from_file(path)?);
+    }
+    let domains: Vec<String> = domains
+        .iter()
+        .filter_map(|d| cli::normalize_domain(d))
+        .collect();
+    if domains.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(HostValidator::new(&domains, args.subs)))
+}
+
 /// Build the filter/transformer pair used by both the batch and streaming
 /// paths, so a streamed run applies exactly the rules a batch run would.
 fn build_url_filter(args: &Args) -> UrlFilter {
@@ -785,6 +797,21 @@ fn build_url_filter(args: &Args) -> UrlFilter {
         .with_min_length(args.min_length)
         .with_max_length(args.max_length);
     url_filter
+}
+
+/// Build the per-URL transformer used everywhere a URL must be decided on its
+/// own: streaming output and links discovered by `--extract-links`.
+///
+/// `--merge-endpoint` is deliberately absent — it folds several URLs into one and
+/// so has no single-URL form (see [`UrlTransformer::transform_one`]).
+fn build_url_transformer(args: &Args) -> UrlTransformer {
+    let mut transformer = UrlTransformer::new();
+    transformer
+        .with_normalize_url(args.normalize_url)
+        .with_show_only_host(args.show_only_host)
+        .with_show_only_path(args.show_only_path)
+        .with_show_only_param(args.show_only_param);
+    transformer
 }
 
 /// Options that need the complete result set and therefore cannot be combined
@@ -864,30 +891,9 @@ fn build_stream_sink(args: &Args) -> Result<Option<Arc<output::StreamSink>>> {
 
     // Host validation mirrors the batch path: only meaningful when strict mode
     // is on and the targets came from the command line rather than a file.
-    let host_validator = if args.strict_enabled() {
-        let mut domains: Vec<String> = args.domains.clone();
-        for path in &args.domain_list {
-            domains.extend(read_domains_from_file(path)?);
-        }
-        let domains: Vec<String> = domains
-            .iter()
-            .filter_map(|d| cli::normalize_domain(d))
-            .collect();
-        if domains.is_empty() {
-            None
-        } else {
-            Some(HostValidator::new(&domains, args.subs))
-        }
-    } else {
-        None
-    };
+    let host_validator = build_host_validator(args)?;
 
-    let mut transformer = UrlTransformer::new();
-    transformer
-        .with_normalize_url(args.normalize_url)
-        .with_show_only_host(args.show_only_host)
-        .with_show_only_path(args.show_only_path)
-        .with_show_only_param(args.show_only_param);
+    let transformer = build_url_transformer(args);
 
     let writer: Box<dyn std::io::Write + Send> = match &args.output {
         Some(path) => Box::new(
@@ -910,6 +916,35 @@ fn build_stream_sink(args: &Args) -> Result<Option<Arc<output::StreamSink>>> {
         &args.format,
         writer,
     )?)))
+}
+
+/// The filter applied to links `--extract-links` discovers, or `None` when the
+/// extractor isn't running.
+///
+/// Links found *inside* pages come into existence after
+/// `apply_url_filters`/`apply_url_transformations` have already run over the
+/// primary list, so they have to be put through the same rules here. Without
+/// this, `--extract-links` silently bypasses every filter the user set: `-e js`
+/// emits non-JS links, and strict host validation (on by default) emits every
+/// off-site link a page happens to point at.
+fn build_extracted_link_filter(
+    args: &Args,
+) -> Result<Option<Arc<tester_manager::ExtractedLinkFilter>>> {
+    if !args.extract_links {
+        return Ok(None);
+    }
+    // File input has no queried domain to validate against, which is why the
+    // batch path skips host validation for it too.
+    let host_validator = if args.files.is_empty() {
+        build_host_validator(args)?
+    } else {
+        None
+    };
+    Ok(Some(Arc::new(tester_manager::ExtractedLinkFilter::new(
+        build_url_filter(args),
+        build_url_transformer(args),
+        host_validator,
+    ))))
 }
 
 /// Apply URL transformations
@@ -1388,6 +1423,8 @@ async fn main() -> Result<()> {
             testers.push(Box::new(link_extractor));
         }
 
+        let link_filter = build_extracted_link_filter(&args)?;
+
         // Process URLs with testers
         process_urls_with_testers(
             transformed_urls,
@@ -1395,6 +1432,7 @@ async fn main() -> Result<()> {
             &progress_manager,
             testers,
             should_check_status,
+            link_filter,
         )
         .await
     } else {
@@ -1661,6 +1699,54 @@ mod tests {
         use clap::Parser;
         let args = Args::parse_from(["urx", "example.com"]);
         assert!(build_stream_sink(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_extract_links_filter_is_wired_up_and_applies_every_rule() {
+        use clap::Parser;
+        // Regression: extracted links were appended straight to the results,
+        // after filtering and host validation had already run — so this filter
+        // has to exist *and* be handed to the tester stage.
+        let args = Args::parse_from([
+            "urx",
+            "--extract-links",
+            "-e",
+            "js",
+            "--silent",
+            "example.com",
+        ]);
+        let filter = build_extracted_link_filter(&args)
+            .unwrap()
+            .expect("--extract-links must build a filter");
+
+        // Extension filter applies...
+        assert_eq!(
+            filter.accept("https://example.com/app.js").as_deref(),
+            Some("https://example.com/app.js")
+        );
+        assert!(filter.accept("https://example.com/index.html").is_none());
+        // ...and so does strict host validation, which is on by default.
+        assert!(filter.accept("https://ads.tracker.net/a.js").is_none());
+    }
+
+    #[test]
+    fn test_no_extract_links_builds_no_filter() {
+        use clap::Parser;
+        let args = Args::parse_from(["urx", "example.com"]);
+        assert!(build_extracted_link_filter(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_extract_links_filter_skips_host_validation_for_file_input() {
+        use clap::Parser;
+        // With --files there is no queried domain to validate against, matching
+        // how the batch path treats file input.
+        let args = Args::parse_from(["urx", "--extract-links", "--files", "urls.txt", "--silent"]);
+        let filter = build_extracted_link_filter(&args).unwrap().unwrap();
+        assert_eq!(
+            filter.accept("https://anywhere.test/x").as_deref(),
+            Some("https://anywhere.test/x")
+        );
     }
 
     #[test]
@@ -2986,6 +3072,7 @@ mod tests {
             &progress_manager,
             testers,
             false, // 여기를 false로 변경 (should_check_status)
+            None,
         )
         .await;
 

--- a/src/tester_manager/mod.rs
+++ b/src/tester_manager/mod.rs
@@ -3,11 +3,53 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::cli::Args;
+use crate::filters::{HostValidator, UrlFilter};
 use crate::network::{NetworkScope, NetworkSettings};
 use crate::output;
 use crate::progress::ProgressManager;
 use crate::testers::Tester;
-use crate::utils::verbose_print;
+use crate::utils::{verbose_print, UrlTransformer};
+
+/// The filtering a URL discovered by `--extract-links` has to pass.
+///
+/// The primary URL list goes through the filters, host validation, and the
+/// `show_only_*`/`--normalize-url` views *before* testing starts. Links found
+/// inside those pages only exist afterwards, so without applying the same rules
+/// here `--extract-links` silently bypasses every filter the user set: `-e js`
+/// would emit non-JS links, and strict mode (on by default) would emit every
+/// off-site link a page happens to point at — ads, CDNs, social buttons.
+pub struct ExtractedLinkFilter {
+    filter: UrlFilter,
+    transformer: UrlTransformer,
+    host_validator: Option<HostValidator>,
+}
+
+impl ExtractedLinkFilter {
+    pub fn new(
+        filter: UrlFilter,
+        transformer: UrlTransformer,
+        host_validator: Option<HostValidator>,
+    ) -> Self {
+        ExtractedLinkFilter {
+            filter,
+            transformer,
+            host_validator,
+        }
+    }
+
+    /// The surviving, transformed form of `url`, or `None` if it is filtered out.
+    pub fn accept(&self, url: &str) -> Option<String> {
+        if !self.filter.matches(url) {
+            return None;
+        }
+        if let Some(v) = &self.host_validator {
+            if !v.is_valid_host(url) {
+                return None;
+            }
+        }
+        self.transformer.transform_one(url)
+    }
+}
 
 /// Helper function to apply network settings to a tester
 pub fn apply_network_settings_to_tester(tester: &mut dyn Tester, settings: &NetworkSettings) {
@@ -37,6 +79,7 @@ pub async fn process_urls_with_testers(
     progress_manager: &ProgressManager,
     testers: Vec<Box<dyn Tester>>,
     should_check_status: bool,
+    link_filter: Option<Arc<ExtractedLinkFilter>>,
 ) -> Vec<output::UrlData> {
     verbose_print(args, "Applying testing options...");
 
@@ -79,6 +122,7 @@ pub async fn process_urls_with_testers(
             let testers_clone: Vec<_> = testers.iter().map(|t| t.clone_box()).collect();
             let test_bar = test_bar.clone();
             let completed = Arc::clone(&completed);
+            let link_filter = link_filter.clone();
 
             async move {
                 let mut result_urls = Vec::new();
@@ -129,10 +173,19 @@ pub async fn process_urls_with_testers(
                         }
                     }
 
-                    // If we have extracted links, add them to the result
+                    // If we have extracted links, add them to the result — after
+                    // putting them through the same filters, host validation and
+                    // views the primary URLs already passed.
                     if let Some(link_urls) = links_result {
                         for link_url in link_urls {
-                            result_urls.push(output::UrlData::new(link_url));
+                            match &link_filter {
+                                Some(f) => {
+                                    if let Some(kept) = f.accept(&link_url) {
+                                        result_urls.push(output::UrlData::new(kept));
+                                    }
+                                }
+                                None => result_urls.push(output::UrlData::new(link_url)),
+                            }
                         }
                     }
 
@@ -261,6 +314,7 @@ mod tests {
             &progress,
             vec![Box::new(FailingTester)],
             true,
+            None,
         )
         .await
     }
@@ -292,6 +346,171 @@ mod tests {
             run_failing_status_check(&["urx", "--es", "404", "--silent", "example.com"]).await;
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].status.as_deref(), Some("Status check failed"));
+    }
+
+    /// A tester that returns a fixed set of "extracted links" for any URL.
+    #[derive(Clone)]
+    struct FixedLinkTester(Vec<String>);
+
+    impl Tester for FixedLinkTester {
+        fn clone_box(&self) -> Box<dyn Tester> {
+            Box::new(self.clone())
+        }
+
+        fn test_url<'a>(
+            &'a self,
+            _url: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+            let links = self.0.clone();
+            Box::pin(async move { Ok(links) })
+        }
+
+        fn with_timeout(&mut self, _seconds: u64) {}
+        fn with_retries(&mut self, _count: u32) {}
+        fn with_random_agent(&mut self, _enabled: bool) {}
+        fn with_insecure(&mut self, _enabled: bool) {}
+        fn with_proxy(&mut self, _proxy: Option<String>) {}
+        fn with_proxy_auth(&mut self, _auth: Option<String>) {}
+    }
+
+    async fn run_extract_links(
+        argv: &[&str],
+        discovered: &[&str],
+        link_filter: Option<Arc<ExtractedLinkFilter>>,
+    ) -> Vec<String> {
+        use clap::Parser;
+        let args = Args::parse_from(argv);
+        let progress = ProgressManager::new(true);
+        let tester = FixedLinkTester(discovered.iter().map(|s| s.to_string()).collect());
+        process_urls_with_testers(
+            vec!["https://example.com/seed".to_string()],
+            &args,
+            &progress,
+            vec![Box::new(tester)],
+            false,
+            link_filter,
+        )
+        .await
+        .into_iter()
+        .map(|d| d.url)
+        .collect()
+    }
+
+    #[tokio::test]
+    async fn test_extracted_links_obey_the_extension_filter() {
+        // Regression: extracted links were appended raw, after the filters had
+        // already run over the primary list — so `-e js` still emitted non-JS
+        // links that the extractor happened to find.
+        let mut filter = UrlFilter::new();
+        filter.with_extensions(vec!["js".to_string()]);
+        let link_filter = Some(Arc::new(ExtractedLinkFilter::new(
+            filter,
+            UrlTransformer::new(),
+            None,
+        )));
+
+        let out = run_extract_links(
+            &[
+                "urx",
+                "--extract-links",
+                "-e",
+                "js",
+                "--silent",
+                "example.com",
+            ],
+            &[
+                "https://example.com/app.js",
+                "https://example.com/index.html",
+            ],
+            link_filter,
+        )
+        .await;
+
+        assert!(
+            out.contains(&"https://example.com/app.js".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            !out.contains(&"https://example.com/index.html".to_string()),
+            "{out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extracted_links_obey_host_validation() {
+        // Strict host validation is on by default, but extracted links skipped
+        // it entirely — so every off-site link a page pointed at (ads, CDNs,
+        // social buttons) landed in the results.
+        let link_filter = Some(Arc::new(ExtractedLinkFilter::new(
+            UrlFilter::new(),
+            UrlTransformer::new(),
+            Some(HostValidator::new(&["example.com".to_string()], false)),
+        )));
+
+        let out = run_extract_links(
+            &["urx", "--extract-links", "--silent", "example.com"],
+            &[
+                "https://example.com/kept",
+                "https://ads.tracker.net/beacon",
+                "https://cdn.other.org/lib.js",
+            ],
+            link_filter,
+        )
+        .await;
+
+        assert!(
+            out.contains(&"https://example.com/kept".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            !out.iter()
+                .any(|u| u.contains("tracker.net") || u.contains("other.org")),
+            "{out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extracted_links_are_transformed_like_the_rest() {
+        // The show-only / normalize views applied to the primary list must apply
+        // to extracted links too, or the output mixes two different shapes.
+        let mut transformer = UrlTransformer::new();
+        transformer.with_show_only_path(true);
+        let link_filter = Some(Arc::new(ExtractedLinkFilter::new(
+            UrlFilter::new(),
+            transformer,
+            None,
+        )));
+
+        let out = run_extract_links(
+            &[
+                "urx",
+                "--extract-links",
+                "--show-only-path",
+                "--silent",
+                "example.com",
+            ],
+            &["https://example.com/a/b?q=1"],
+            link_filter,
+        )
+        .await;
+
+        assert!(out.contains(&"/a/b".to_string()), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn test_no_link_filter_keeps_links_verbatim() {
+        // Without --extract-links no filter is built, so nothing changes for
+        // callers that pass None.
+        let out = run_extract_links(
+            &["urx", "--extract-links", "--silent", "example.com"],
+            &["https://elsewhere.test/x"],
+            None,
+        )
+        .await;
+        assert!(
+            out.contains(&"https://elsewhere.test/x".to_string()),
+            "{out:?}"
+        );
     }
 
     #[test]

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -10,6 +10,53 @@ use url::Url;
 use super::Tester;
 use crate::network::client::HttpClientConfig;
 
+/// Cap on bytes read from one page before parsing.
+///
+/// `--extract-links` runs over whatever the archives recorded, which routinely
+/// includes multi-gigabyte media. The whole body was previously buffered into
+/// memory and handed to the HTML parser, so a single large URL in the list could
+/// exhaust memory. The sitemap provider already caps its documents this way;
+/// this is the same guard for the same reason. 10 MiB is far more than any real
+/// HTML page.
+const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+
+/// Whether a response body is worth handing to the HTML parser.
+///
+/// A missing `Content-Type` is treated as "maybe HTML" and parsed, since plenty
+/// of servers omit it; an explicitly non-HTML type (an image, a video, a zip) is
+/// skipped — running an HTML parser over binary yields nothing but the bytes are
+/// downloaded either way.
+fn is_html_like(headers: &reqwest::header::HeaderMap) -> bool {
+    match headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(ct) => {
+            let ct = ct.to_ascii_lowercase();
+            ct.contains("html") || ct.contains("xml") || ct.contains("text/plain")
+        }
+        None => true,
+    }
+}
+
+/// Read a response body, stopping after `max` bytes. Reads incrementally via
+/// `chunk()` so an oversized body is never fully buffered.
+async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        let remaining = max.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        if chunk.len() > remaining {
+            buf.extend_from_slice(&chunk[..remaining]);
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// HTML link extractor that finds URLs in web pages
 #[derive(Clone)]
 pub struct LinkExtractor {
@@ -113,8 +160,23 @@ impl Tester for LinkExtractor {
                             }
                         };
 
-                        // Get the HTML content
-                        let html_content = response.text().await?;
+                        // An error page still has a body, and its nav/footer is
+                        // full of links — mining those would inject the site's
+                        // chrome into the results as if it had been discovered.
+                        // A non-2xx page has no links worth extracting.
+                        if !response.status().is_success() {
+                            return Ok(Vec::new());
+                        }
+
+                        // Nor is there anything to extract from a response that
+                        // isn't markup.
+                        if !is_html_like(response.headers()) {
+                            return Ok(Vec::new());
+                        }
+
+                        // Get the HTML content, bounded so one huge page can't
+                        // exhaust memory.
+                        let html_content = read_body_capped(response, MAX_BODY_BYTES).await?;
 
                         // Extract links using the helper function
                         let links = Self::extract_links(&base_url, &html_content);
@@ -283,6 +345,122 @@ mod tests {
         let html = "<a>No href</a>";
         let links = LinkExtractor::extract_links(&base_url, html);
         assert!(links.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_error_pages_are_not_mined_for_links() {
+        // Regression: the body of any response was parsed, including 404/500
+        // pages — so a dead URL contributed the site's nav and footer links to
+        // the results as though they had been discovered.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/gone")
+            .with_status(404)
+            .with_header("content-type", "text/html")
+            .with_body(r#"<a href="/nav">home</a><a href="/footer">about</a>"#)
+            .create_async()
+            .await;
+
+        let extractor = LinkExtractor::new();
+        let links = extractor
+            .test_url(&format!("{}/gone", server.url()))
+            .await
+            .unwrap();
+
+        assert!(links.is_empty(), "{links:?}");
+    }
+
+    #[tokio::test]
+    async fn test_non_markup_bodies_are_skipped() {
+        // Running an HTML parser over a JPEG finds nothing; skip it outright.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/photo.jpg")
+            .with_status(200)
+            .with_header("content-type", "image/jpeg")
+            .with_body(r#"<a href="/not-really-html">x</a>"#)
+            .create_async()
+            .await;
+
+        let extractor = LinkExtractor::new();
+        let links = extractor
+            .test_url(&format!("{}/photo.jpg", server.url()))
+            .await
+            .unwrap();
+
+        assert!(links.is_empty(), "{links:?}");
+    }
+
+    #[tokio::test]
+    async fn test_missing_content_type_is_still_parsed() {
+        // Plenty of servers omit Content-Type; treat that as "maybe HTML" rather
+        // than silently dropping the page.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/bare")
+            .with_status(200)
+            .with_body(r#"<a href="https://example.com/found">x</a>"#)
+            .create_async()
+            .await;
+
+        let extractor = LinkExtractor::new();
+        let links = extractor
+            .test_url(&format!("{}/bare", server.url()))
+            .await
+            .unwrap();
+
+        assert_eq!(links, vec!["https://example.com/found".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_body_is_capped() {
+        // A body larger than the cap is truncated rather than buffered whole.
+        // Links before the cut are still found; the run does not blow up.
+        let mut body = String::from(r#"<a href="https://example.com/early">x</a>"#);
+        body.push_str(&"<!-- padding -->".repeat(80_000));
+        body.push_str(r#"<a href="https://example.com/late">y</a>"#);
+        assert!(
+            body.len() > MAX_BODY_BYTES / 10,
+            "test body should be large"
+        );
+
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/big")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let extractor = LinkExtractor::new();
+        let links = extractor
+            .test_url(&format!("{}/big", server.url()))
+            .await
+            .unwrap();
+
+        assert!(
+            links.contains(&"https://example.com/early".to_string()),
+            "{links:?}"
+        );
+    }
+
+    #[test]
+    fn test_is_html_like() {
+        use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+        let with = |v: &'static str| {
+            let mut h = HeaderMap::new();
+            h.insert(CONTENT_TYPE, HeaderValue::from_static(v));
+            h
+        };
+        assert!(is_html_like(&with("text/html; charset=utf-8")));
+        assert!(is_html_like(&with("application/xhtml+xml")));
+        assert!(is_html_like(&with("text/plain")));
+        assert!(!is_html_like(&with("image/png")));
+        assert!(!is_html_like(&with("video/mp4")));
+        assert!(!is_html_like(&with("application/octet-stream")));
+        // Absent header: assume markup rather than drop the page.
+        assert!(is_html_like(&HeaderMap::new()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Round 3 of the source audit. `--extract-links` produced URLs that no filter ever saw.

## The pipeline skipped them

`main.rs` runs `apply_url_filters` and `apply_url_transformations` over the provider results, *then* calls the tester stage. Links discovered inside those pages only come into existence during that stage, and `tester_manager` pushed them straight into the results:

```rust
for link_url in link_urls {
    result_urls.push(output::UrlData::new(link_url));   // never filtered
}
```

So with `--extract-links`:

- `-e js` still emitted every non-JS link a page pointed at
- **strict host validation — the default — was bypassed entirely**, so every off-site link a page carried (ads, CDNs, social buttons) landed in the output
- `--show-only-path` / `--normalize-url` were not applied, so the output mixed two different URL shapes

`ExtractedLinkFilter` now holds the same `UrlFilter`, `UrlTransformer` and `HostValidator` the primary path used, and `build_extracted_link_filter` hands it to the tester stage whenever `--extract-links` is set. File input skips host validation, matching how the batch path already treats `--files`.

## The extractor also mined bodies it shouldn't

- **Error pages**: any status was parsed, so a dead URL contributed the site's nav and footer as though those links had been discovered.
- **Non-markup bodies**: an image, video, or archive was handed to `Html::parse_document`. A missing `Content-Type` is still treated as "maybe HTML" and parsed, since plenty of servers omit it.
- **No body cap**: the whole body was buffered into memory before parsing. `--extract-links` runs over whatever the archives recorded, which routinely includes multi-gigabyte media. Now capped at 10 MiB — `sitemap.rs` already caps its documents for exactly this reason.

## Cleanups this made obvious

Host-validator construction was copy-pasted in three places (`apply_url_filters`, `build_stream_sink`, and now this) — collapsed into one `build_host_validator`. The per-URL transformer setup shared by streaming and extracted links is now `build_url_transformer`.

## Verification

566 tests pass (563 before, +12 new). Each claim was run against the pre-fix code and confirmed to fail there:

- `test_extract_links_filter_is_wired_up_and_applies_every_rule` — FAILED before (this one pins the `main.rs` wiring, not just the component)
- `test_error_pages_are_not_mined_for_links` — FAILED before
- `test_non_markup_bodies_are_skipped` — FAILED before

`cargo clippy --all-targets -- -D warnings` clean.