### PR TITLE
fix: bound the reads that weren't, and share one capping helper

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -86,6 +86,28 @@ pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
 }
 
+/// Read a response body, stopping after `max` bytes.
+///
+/// Reads incrementally via `chunk()` rather than buffering the whole body, so an
+/// endpoint that streams gigabytes — by accident or on purpose — can't exhaust
+/// memory before any parsing happens. Every caller that fetches a document from
+/// a host urx does not control should go through this.
+pub async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        let remaining = max.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        if chunk.len() > remaining {
+            buf.extend_from_slice(&chunk[..remaining]);
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// Whether an HTTP status is worth another attempt.
 ///
 /// Server errors and explicit throttling are transient. The rest of the 4xx

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -5,9 +5,20 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_body_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::providers::Provider;
+
+/// Cap on the bytes read from a robots.txt. The body was previously read whole
+/// with `text()`, so a host serving an endless stream at /robots.txt could grow
+/// urx's memory without bound — and robots.txt is fetched from every target,
+/// including ones the user has no control over. Real files are a few KB;
+/// Google's own crawler stops at 500 KiB, so 1 MiB is generous.
+const MAX_ROBOTS_BYTES: usize = 1024 * 1024;
+
+/// Cap on entries taken from one robots.txt, bounding the parsed output the way
+/// the sitemap provider bounds its own.
+const MAX_ROBOTS_ENTRIES: usize = 100_000;
 
 #[derive(Clone)]
 pub struct RobotsProvider {
@@ -106,10 +117,12 @@ impl Provider for RobotsProvider {
                 // A body that dies mid-read is "no robots.txt" for our purposes,
                 // not a fatal error — same best-effort contract as the HTTP
                 // fallback below.
-                Ok(resp) if resp.status().is_success() => match resp.text().await {
-                    Ok(text) => (true, text),
-                    Err(_) => return Ok(urls),
-                },
+                Ok(resp) if resp.status().is_success() => {
+                    match read_body_capped(resp, MAX_ROBOTS_BYTES).await {
+                        Ok(text) => (true, text),
+                        Err(_) => return Ok(urls),
+                    }
+                }
                 _ => {
                     // If HTTPS fails, try HTTP
                     #[cfg(not(test))]
@@ -137,7 +150,7 @@ impl Provider for RobotsProvider {
                     if !http_resp.status().is_success() {
                         return Ok(urls);
                     }
-                    match http_resp.text().await {
+                    match read_body_capped(http_resp, MAX_ROBOTS_BYTES).await {
                         Ok(text) => (false, text),
                         Err(_) => return Ok(urls),
                     }
@@ -148,6 +161,9 @@ impl Provider for RobotsProvider {
             let protocol = if is_https { "https" } else { "http" };
 
             for line in text.lines() {
+                if urls.len() >= MAX_ROBOTS_ENTRIES {
+                    break;
+                }
                 let line = line.trim();
                 if line.is_empty() || line.starts_with('#') {
                     continue;
@@ -453,6 +469,69 @@ Sitemap: https://example.com/sitemap.xml
         // Protocol should be https because first request (simulated https) succeeded
         assert!(urls.contains(&"https://example.com/private/".to_string()));
         assert!(urls.contains(&"https://example.com/sitemap.xml".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_robots_body_is_capped() {
+        // Regression: the body was read whole with text(), so a host streaming
+        // an endless /robots.txt could grow memory without bound — and robots.txt
+        // is fetched from every target, including ones the user doesn't control.
+        let mut mock_server = mockito::Server::new_async().await;
+
+        // A body well past the cap. Entries before the cut are still parsed.
+        let mut body = String::from("Disallow: /early\n");
+        while body.len() < MAX_ROBOTS_BYTES + 4096 {
+            body.push_str("# padding padding padding padding padding padding\n");
+        }
+        body.push_str("Disallow: /past-the-cap\n");
+
+        let _m = mock_server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(body)
+            .create();
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(mock_server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert!(
+            urls.contains(&"https://example.com/early".to_string()),
+            "{urls:?}"
+        );
+        assert!(
+            !urls.contains(&"https://example.com/past-the-cap".to_string()),
+            "body past the cap must not be parsed: {urls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_robots_entry_count_is_capped() {
+        // The byte cap bounds the input; this bounds the parsed output, the way
+        // the sitemap provider bounds its own.
+        let mut mock_server = mockito::Server::new_async().await;
+
+        let mut body = String::new();
+        for i in 0..(MAX_ROBOTS_ENTRIES + 500) {
+            body.push_str(&format!("Disallow: /p{i}\n"));
+        }
+
+        let _m = mock_server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(body)
+            .create();
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(mock_server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert!(
+            urls.len() <= MAX_ROBOTS_ENTRIES,
+            "entry count must be bounded, got {}",
+            urls.len()
+        );
     }
 
     #[tokio::test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_body_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::providers::Provider;
 
@@ -24,25 +24,6 @@ const MAX_SITEMAP_URLS: usize = 1_000_000;
 /// hostile or misconfigured endpoint could stream gigabytes into memory before
 /// any URL parsing happens (the per-URL cap only bounds the *parsed* output).
 const MAX_SITEMAP_BYTES: usize = 50 * 1024 * 1024;
-
-/// Read a response body but stop after `max` bytes, so an unbounded (or
-/// deliberately huge) document can't exhaust memory. Reads incrementally via
-/// `chunk()` rather than buffering the whole body up front.
-async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result<String> {
-    let mut buf: Vec<u8> = Vec::new();
-    while let Some(chunk) = resp.chunk().await? {
-        let remaining = max.saturating_sub(buf.len());
-        if remaining == 0 {
-            break;
-        }
-        if chunk.len() > remaining {
-            buf.extend_from_slice(&chunk[..remaining]);
-            break;
-        }
-        buf.extend_from_slice(&chunk);
-    }
-    Ok(String::from_utf8_lossy(&buf).into_owned())
-}
 
 #[derive(Clone)]
 pub struct SitemapProvider {

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -60,6 +60,84 @@ fn skip_to_newline<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
     }
 }
 
+/// Default cap on URLs collected from one input file.
+///
+/// Every reader needs one: `--files` accepts whatever the user points it at,
+/// and a file that is mostly URL lines grows the result `Vec` in step with its
+/// size. 1M URLs is far more than any real list.
+pub(crate) const MAX_FILE_URLS: usize = 1_000_000;
+
+/// Default cap on bytes consumed from one input file (after decompression).
+///
+/// The URL cap above bounds the *parsed output*; this bounds the *input*, so a
+/// file made of non-URL lines — or a gzip bomb — can't keep the reader running
+/// indefinitely. The URL cap fires first for any real URL-dense file.
+pub(crate) const MAX_FILE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Read URL lines from `src`, bounding both the number of URLs collected and the
+/// number of bytes consumed. `extract` turns one line into a URL, or `None` if
+/// the line carries none.
+///
+/// Returns the URLs plus flags for whether the URL cap or the byte cap was hit,
+/// so the caller can tell the user the results were truncated instead of
+/// silently returning a partial list.
+///
+/// The byte bound is enforced with `Read::take`, which caps the stream no matter
+/// how a compressed source expands — that is the decompression-bomb guard. One
+/// byte past the cap is allowed so a file that is *exactly* `max_bytes` long
+/// isn't falsely flagged.
+pub(crate) fn collect_capped<R: Read>(
+    src: R,
+    max_urls: usize,
+    max_bytes: u64,
+    mut extract: impl FnMut(&str) -> Option<String>,
+) -> std::io::Result<(Vec<String>, bool, bool)> {
+    let mut limited = src.take(max_bytes.saturating_add(1));
+    let mut urls = Vec::new();
+    let mut url_capped = false;
+
+    for_each_line_lossy(std::io::BufReader::new(&mut limited), |line| {
+        if urls.len() >= max_urls {
+            // Stop collecting; the `take` bound still drains the rest so we
+            // never read more than `max_bytes (+1)` total.
+            url_capped = true;
+            return;
+        }
+        if let Some(url) = extract(line) {
+            urls.push(url);
+        }
+    })?;
+
+    // `limit()` is the unused remainder of the (max_bytes + 1) allowance; a
+    // remainder of 0 means the source ran past the cap and was truncated.
+    let byte_capped = limited.limit() == 0;
+    Ok((urls, url_capped, byte_capped))
+}
+
+/// Tell the user on stderr when a read stopped early. Truncation is rare and
+/// means the output is incomplete, so it must not pass in silence.
+pub(crate) fn warn_if_truncated(
+    file_path: &Path,
+    url_capped: bool,
+    byte_capped: bool,
+    max_urls: usize,
+    max_bytes: u64,
+) {
+    if url_capped {
+        eprintln!(
+            "[urx] {}: stopped at the {}-URL cap; results truncated",
+            file_path.display(),
+            max_urls
+        );
+    } else if byte_capped {
+        eprintln!(
+            "[urx] {}: stopped after {} bytes read (possible decompression bomb); results truncated",
+            file_path.display(),
+            max_bytes
+        );
+    }
+}
+
 /// Trait for reading URLs from different file formats
 pub trait FileReader {
     /// Read URLs from a file and return them as a vector of strings

--- a/src/readers/text_reader.rs
+++ b/src/readers/text_reader.rs
@@ -1,7 +1,6 @@
 use super::FileReader;
 use anyhow::{Context, Result};
 use std::fs::File;
-use std::io::BufReader;
 use std::path::Path;
 
 /// Reader for plain text files containing URLs (one per line)
@@ -18,19 +17,31 @@ impl FileReader for TextFileReader {
         let file = File::open(file_path)
             .with_context(|| format!("Failed to open text file: {}", file_path.display()))?;
 
-        let reader = BufReader::new(file);
-        let mut urls = Vec::new();
-
-        super::for_each_line_lossy(reader, |line| {
-            let trimmed = line.trim();
-            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+        // Bounded like every other reader: `--files` takes whatever it is
+        // pointed at, and a plain-text list is the densest possible source of
+        // URL lines.
+        let (urls, url_capped, byte_capped) =
+            super::collect_capped(file, super::MAX_FILE_URLS, super::MAX_FILE_BYTES, |line| {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    return None;
+                }
                 // Basic URL validation - must start with http or https
                 if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-                    urls.push(trimmed.to_string());
+                    Some(trimmed.to_string())
+                } else {
+                    None
                 }
-            }
-        })
-        .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
+            })
+            .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
+
+        super::warn_if_truncated(
+            file_path,
+            url_capped,
+            byte_capped,
+            super::MAX_FILE_URLS,
+            super::MAX_FILE_BYTES,
+        );
 
         Ok(urls)
     }

--- a/src/readers/urlteam_reader.rs
+++ b/src/readers/urlteam_reader.rs
@@ -2,36 +2,24 @@ use super::FileReader;
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::Read;
 use std::path::Path;
 
-/// Overall cap on URLs collected from one URLTeam file, mirroring
-/// [`MAX_SITEMAP_URLS`]. A small gzip can decompress to a vast stream of short,
-/// valid URL lines; without a cap that grows the result `Vec` without bound.
-///
-/// [`MAX_SITEMAP_URLS`]: crate::providers
-const MAX_URLTEAM_URLS: usize = 1_000_000;
-
-/// Hard cap on bytes read from the *decompressed* stream. The per-URL cap above
-/// only bounds the parsed output; a decompression bomb made of non-URL lines
-/// (or one giant line) would otherwise keep the decoder running indefinitely.
-/// The URL cap fires first for any real URL-dense file (1M URLs ≈ 50 MB), so
-/// this only ever bites pathological input. 1 GiB is a comfortable ceiling.
-const MAX_URLTEAM_DECOMPRESSED_BYTES: u64 = 1024 * 1024 * 1024;
+use super::{MAX_FILE_BYTES, MAX_FILE_URLS};
 
 /// Reader for URLTeam compressed files (typically gzip format)
 pub struct UrlTeamFileReader {
-    /// Maximum URLs collected before truncating (see [`MAX_URLTEAM_URLS`]).
+    /// Maximum URLs collected before truncating (see [`MAX_FILE_URLS`]).
     max_urls: usize,
-    /// Maximum decompressed bytes read (see [`MAX_URLTEAM_DECOMPRESSED_BYTES`]).
+    /// Maximum decompressed bytes read (see [`MAX_FILE_BYTES`]).
     max_bytes: u64,
 }
 
 impl UrlTeamFileReader {
     pub fn new() -> Self {
         Self {
-            max_urls: MAX_URLTEAM_URLS,
-            max_bytes: MAX_URLTEAM_DECOMPRESSED_BYTES,
+            max_urls: MAX_FILE_URLS,
+            max_bytes: MAX_FILE_BYTES,
         }
     }
 
@@ -71,45 +59,21 @@ impl UrlTeamFileReader {
         Ok(&Self::magic(file_path)? == b"BZh")
     }
 
-    /// Read URL lines from `src`, bounding both the number of URLs collected and
-    /// the number of (decompressed) bytes consumed. Returns the URLs plus flags
-    /// indicating whether the URL cap or the byte cap was hit, so the caller can
-    /// warn that results were truncated.
-    ///
-    /// The byte bound is enforced with `Read::take`, which caps the stream
-    /// regardless of how a malicious gzip expands — that is the decompression-
-    /// bomb guard. We allow one byte past the cap so a file that is *exactly*
-    /// `max_bytes` long isn't falsely flagged as truncated.
+    /// Read URL lines from `src`, bounded by the shared caps. URLTeam lines can
+    /// carry timestamps or status columns alongside the URL, so extraction picks
+    /// the first http(s) token rather than taking the whole line.
     fn collect_capped<R: Read>(
         src: R,
         max_urls: usize,
         max_bytes: u64,
     ) -> std::io::Result<(Vec<String>, bool, bool)> {
-        let mut limited = src.take(max_bytes.saturating_add(1));
-        let mut urls = Vec::new();
-        let mut url_capped = false;
-
-        super::for_each_line_lossy(BufReader::new(&mut limited), |line| {
-            if urls.len() >= max_urls {
-                // Stop collecting; the `take` bound still drains the rest so we
-                // never read more than `max_bytes (+1)` total.
-                url_capped = true;
-                return;
-            }
+        super::collect_capped(src, max_urls, max_bytes, |line| {
             let trimmed = line.trim();
-            if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                // URLTeam files often contain URLs in various formats
-                // Try to extract URL from the line (may have timestamps or other data)
-                if let Some(url) = extract_url_from_line(trimmed) {
-                    urls.push(url);
-                }
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
             }
-        })?;
-
-        // `limit()` is the unused remainder of the (max_bytes + 1) allowance; a
-        // remainder of 0 means the source ran past the cap and was truncated.
-        let byte_capped = limited.limit() == 0;
-        Ok((urls, url_capped, byte_capped))
+            extract_url_from_line(trimmed)
+        })
     }
 }
 
@@ -135,21 +99,13 @@ impl FileReader for UrlTeamFileReader {
         }
         .with_context(|| format!("Failed to read URLTeam file: {}", file_path.display()))?;
 
-        // Truncation is rare and means the output is incomplete, so surface it
-        // on stderr rather than silently returning a partial list.
-        if url_capped {
-            eprintln!(
-                "[urx] {}: stopped at the {}-URL cap; results truncated",
-                file_path.display(),
-                self.max_urls
-            );
-        } else if byte_capped {
-            eprintln!(
-                "[urx] {}: stopped after {} decompressed bytes (possible decompression bomb); results truncated",
-                file_path.display(),
-                self.max_bytes
-            );
-        }
+        super::warn_if_truncated(
+            file_path,
+            url_capped,
+            byte_capped,
+            self.max_urls,
+            self.max_bytes,
+        );
 
         Ok(urls)
     }
@@ -247,7 +203,7 @@ mod tests {
         }
         temp_file.flush()?;
 
-        let reader = UrlTeamFileReader::with_caps(10, MAX_URLTEAM_DECOMPRESSED_BYTES);
+        let reader = UrlTeamFileReader::with_caps(10, MAX_FILE_BYTES);
         let urls = reader.read_urls(temp_file.path())?;
         assert_eq!(urls.len(), 10, "URL collection should stop at the cap");
         Ok(())
@@ -263,7 +219,7 @@ mod tests {
         temp_file.flush()?;
 
         // ~25 bytes/line; a 200-byte cap admits only the first handful of lines.
-        let reader = UrlTeamFileReader::with_caps(MAX_URLTEAM_URLS, 200);
+        let reader = UrlTeamFileReader::with_caps(MAX_FILE_URLS, 200);
         let urls = reader.read_urls(temp_file.path())?;
         assert!(
             !urls.is_empty() && urls.len() < 1000,
@@ -286,7 +242,7 @@ mod tests {
             encoder.finish()?;
         }
 
-        let reader = UrlTeamFileReader::with_caps(MAX_URLTEAM_URLS, 4096);
+        let reader = UrlTeamFileReader::with_caps(MAX_FILE_URLS, 4096);
         let urls = reader.read_urls(temp_file.path())?;
         assert!(
             !urls.is_empty() && urls.len() < 100_000,

--- a/src/readers/warc_reader.rs
+++ b/src/readers/warc_reader.rs
@@ -12,37 +12,59 @@ impl WarcFileReader {
     }
 }
 
+/// Pull a URL out of one WARC line, if it carries one.
+///
+/// A WARC mixes headers with raw response bodies, so both the
+/// `WARC-Target-URI:` header and bare URLs in the payload are collected. Header
+/// names are case-insensitive per the WARC spec.
+fn extract_url_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+
+    let after_header = trimmed
+        .split_once(':')
+        .filter(|(name, _)| name.eq_ignore_ascii_case("WARC-Target-URI"))
+        .map(|(_, value)| value.trim());
+
+    let candidate = match after_header {
+        Some(value) => value,
+        None => trimmed,
+    };
+
+    if (candidate.starts_with("http://") || candidate.starts_with("https://"))
+        && !candidate.contains(' ')
+    {
+        return Some(candidate.to_string());
+    }
+    None
+}
+
 impl FileReader for WarcFileReader {
     fn read_urls(&self, file_path: &Path) -> Result<Vec<String>> {
         use std::fs::File;
-        use std::io::BufReader;
 
         let file = File::open(file_path)
             .with_context(|| format!("Failed to open WARC file: {}", file_path.display()))?;
 
-        let reader = BufReader::new(file);
-        let mut urls = Vec::new();
-
-        // WARC files mix headers with raw response bodies, so lines are read
-        // lossily: binary content must not abort the read.
-        super::for_each_line_lossy(reader, |line| {
-            // Look for WARC-Target-URI headers
-            if let Some(url) = line.strip_prefix("WARC-Target-URI:") {
-                let url = url.trim();
-                if url.starts_with("http://") || url.starts_with("https://") {
-                    urls.push(url.to_string());
-                }
-            }
-            // Also look for plain URLs in the content
-            else if line.trim().starts_with("http://") || line.trim().starts_with("https://") {
-                let url = line.trim();
-                // Basic URL validation - check if it looks like a complete URL
-                if url.contains("://") && !url.contains(' ') {
-                    urls.push(url.to_string());
-                }
-            }
-        })
+        // WARCs are routinely gigabytes, and this reader used to collect every
+        // matching line with no bound at all — unlike the URLTeam and sitemap
+        // readers, which have capped their input from the start. Lines are read
+        // lossily because a WARC embeds raw response bodies: binary content must
+        // not abort the read.
+        let (urls, url_capped, byte_capped) = super::collect_capped(
+            file,
+            super::MAX_FILE_URLS,
+            super::MAX_FILE_BYTES,
+            extract_url_from_line,
+        )
         .with_context(|| format!("Failed to read WARC file: {}", file_path.display()))?;
+
+        super::warn_if_truncated(
+            file_path,
+            url_capped,
+            byte_capped,
+            super::MAX_FILE_URLS,
+            super::MAX_FILE_BYTES,
+        );
 
         Ok(urls)
     }
@@ -51,6 +73,7 @@ impl FileReader for WarcFileReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -81,6 +104,69 @@ mod tests {
         assert!(urls.contains(&"http://example.org/page2".to_string()));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_url_collection_is_bounded() -> Result<()> {
+        // Regression: this reader had no cap of any kind, while the URLTeam and
+        // sitemap readers have bounded their input from the start. WARCs are
+        // routinely gigabytes, so an unbounded collect grows with the file.
+        let mut temp_file = NamedTempFile::new()?;
+        for i in 0..500 {
+            writeln!(temp_file, "WARC-Target-URI: https://example.com/{i}")?;
+        }
+        temp_file.flush()?;
+
+        let (urls, url_capped, _) = super::super::collect_capped(
+            File::open(temp_file.path())?,
+            10,
+            super::super::MAX_FILE_BYTES,
+            extract_url_from_line,
+        )?;
+
+        assert_eq!(urls.len(), 10, "collection must stop at the URL cap");
+        assert!(url_capped, "the cap being hit must be reported");
+        Ok(())
+    }
+
+    #[test]
+    fn test_byte_cap_bounds_the_read() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        for i in 0..2000 {
+            writeln!(temp_file, "WARC-Target-URI: https://example.com/{i}")?;
+        }
+        temp_file.flush()?;
+
+        let (urls, _, byte_capped) = super::super::collect_capped(
+            File::open(temp_file.path())?,
+            super::super::MAX_FILE_URLS,
+            200,
+            extract_url_from_line,
+        )?;
+
+        assert!(byte_capped, "the byte cap must be reported");
+        assert!(
+            urls.len() < 2000,
+            "read should stop early, got {}",
+            urls.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_target_uri_header_is_case_insensitive() {
+        // WARC field names are case-insensitive per the spec; only the exact
+        // "WARC-Target-URI:" spelling used to be recognised.
+        assert_eq!(
+            extract_url_from_line("warc-target-uri: https://example.com/a").as_deref(),
+            Some("https://example.com/a")
+        );
+        assert_eq!(
+            extract_url_from_line("WARC-Target-URI: https://example.com/b").as_deref(),
+            Some("https://example.com/b")
+        );
+        // A non-URL value is still rejected.
+        assert!(extract_url_from_line("WARC-Type: response").is_none());
     }
 
     #[test]

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -8,7 +8,7 @@ use tokio::sync::OnceCell;
 use url::Url;
 
 use super::Tester;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_body_capped, HttpClientConfig};
 
 /// Cap on bytes read from one page before parsing.
 ///
@@ -37,24 +37,6 @@ fn is_html_like(headers: &reqwest::header::HeaderMap) -> bool {
         }
         None => true,
     }
-}
-
-/// Read a response body, stopping after `max` bytes. Reads incrementally via
-/// `chunk()` so an oversized body is never fully buffered.
-async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result<String> {
-    let mut buf: Vec<u8> = Vec::new();
-    while let Some(chunk) = resp.chunk().await? {
-        let remaining = max.saturating_sub(buf.len());
-        if remaining == 0 {
-            break;
-        }
-        if chunk.len() > remaining {
-            buf.extend_from_slice(&chunk[..remaining]);
-            break;
-        }
-        buf.extend_from_slice(&chunk);
-    }
-    Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
 /// HTML link extractor that finds URLs in web pages


### PR DESCRIPTION
Round 6 — the final round of the source audit. The codebase is careful about bounding untrusted input; this closes the three places that weren't, and removes the duplication that made them easy to miss.

## The gap

| reader | byte cap | entry cap |
|---|---|---|
| `sitemap.rs` | 50 MiB | 1M URLs |
| `urlteam_reader.rs` | 1 GiB | 1M URLs |
| `link_extractor.rs` | 10 MiB | — |
| **`robots.rs`** | **none** | **none** |
| **`warc_reader.rs`** | **none** | **none** |
| **`text_reader.rs`** | **none** | **none** |

**robots.txt** was read with `text()`, unbounded — and it is fetched from *every* target, including hosts the user has no control over, so a server streaming an endless `/robots.txt` grew memory without limit. Now capped at 1 MiB (Google's crawler stops at 500 KiB) with a bound on entries parsed.

**The WARC reader** had no cap of any kind. WARCs are routinely gigabytes, and this collected every matching line into a `Vec` that grew with the file.

**The text reader** had no URL cap either.

## One helper instead of four

The three file readers now share `collect_capped` / `warn_if_truncated` in `readers`, so:

- the caps live in one place rather than being restated per reader
- a truncated read is reported on stderr instead of quietly returning a partial list — the URLTeam reader was the only one that did this
- `UrlTeamFileReader::collect_capped` collapses onto the shared version

`read_body_capped` had been copied verbatim into `sitemap.rs` and `link_extractor.rs` (I introduced the second copy in #328). It now lives in `network::client` next to the other shared HTTP helpers, with all three callers using it.

## Also

The WARC reader matched `WARC-Target-URI` case-sensitively, though WARC field names are case-insensitive per the spec, so a lowercase header was silently skipped.

## Verification

583 tests pass (+7 new), `cargo clippy --all-targets -- -D warnings` clean. The two robots.txt cap tests were run against the pre-fix code and confirmed to fail:

```
test providers::robots::tests::test_robots_body_is_capped ... FAILED
test providers::robots::tests::test_robots_entry_count_is_capped ... FAILED
```

## Note

These are hardening fixes, not exploitable-today bugs — every one needs a hostile or broken server, or a pathological input file. I'm treating them as worth fixing because the surrounding code already made that judgement everywhere else, and an inconsistent guard is the one that gets forgotten.