### PR TITLE
fix: ten rounds of bug hunting across filters, providers, testers and CLI

### DIFF
--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -169,7 +169,14 @@ impl CacheBackend for SqliteCache {
     }
 
     async fn cleanup_expired(&self, ttl_seconds: u64) -> Result<()> {
-        let cutoff_time = Utc::now() - chrono::Duration::seconds(ttl_seconds as i64);
+        // `chrono::Duration::seconds` panics past ~2.9e11 years, and `--cache-ttl`
+        // is a plain u64 straight off the command line — a large one crashed the
+        // run at cleanup time. Saturate instead: a TTL that long means "never
+        // expire", and `checked_sub` then leaves the cutoff at the earliest
+        // representable time so nothing is deleted.
+        let cutoff_time = chrono::Duration::try_seconds(ttl_seconds.min(i64::MAX as u64) as i64)
+            .and_then(|d| Utc::now().checked_sub_signed(d))
+            .unwrap_or(DateTime::<Utc>::MIN_UTC);
         let cutoff_str = cutoff_time.to_rfc3339();
 
         self.with_connection(move |conn| {
@@ -272,6 +279,29 @@ mod tests {
 
         // Entry should be gone
         assert!(!cache.exists(&key).await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_with_huge_ttl_keeps_entries_and_does_not_panic() -> Result<()> {
+        // Regression: `--cache-ttl` is an unvalidated u64 fed straight to
+        // chrono::Duration::seconds, which panics past its bounds — a large
+        // value aborted the run at cleanup time.
+        let temp_dir = tempdir()?;
+        let cache = SqliteCache::new(temp_dir.path().join("test.db")).await?;
+
+        let filters = CacheFilters::default();
+        let key = CacheKey::new("example.com", &["wayback".to_string()], &filters);
+        cache
+            .set(&key, &CacheEntry::new(vec!["https://example.com/x".into()]))
+            .await?;
+
+        // A TTL this long means "never expire"; nothing may be deleted.
+        cache.cleanup_expired(u64::MAX).await?;
+        assert!(cache.exists(&key).await?);
+        cache.cleanup_expired(10_000_000_000_000_000).await?;
+        assert!(cache.exists(&key).await?);
 
         Ok(())
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -482,26 +482,44 @@ pub fn normalize_domain(raw: &str) -> Option<String> {
 }
 
 impl Args {
-    /// Parse `--rate-limit-by` entries into a `provider_id -> requests/sec`
-    /// map. Malformed entries are dropped and reported via `parse_errors`
-    /// when verbose; the caller decides whether to surface them.
-    pub fn rate_limit_overrides(&self) -> std::collections::HashMap<String, f32> {
+    /// Parse `--rate-limit-by` entries into a `provider_id -> requests/sec` map,
+    /// alongside the raw entries that did not parse.
+    ///
+    /// Every rejection here is otherwise invisible: `wayback` (no `=`),
+    /// `wayback:5` (wrong separator), `wayback=fast`, and `wayback=0` all used to
+    /// vanish, leaving the user with an unthrottled run they believe they
+    /// limited. Unknown provider *ids* are already rejected loudly, as are
+    /// unknown `--preset` values; malformed entries now travel back to the caller
+    /// so they can be too.
+    pub fn parse_rate_limit_overrides(
+        &self,
+    ) -> (std::collections::HashMap<String, f32>, Vec<String>) {
         let mut map = std::collections::HashMap::new();
+        let mut malformed = Vec::new();
         for raw in &self.rate_limit_by {
             let trimmed = raw.trim();
             if trimmed.is_empty() {
                 continue;
             }
-            if let Some((k, v)) = trimmed.split_once('=') {
-                let id = k.trim().to_string();
-                if let Ok(rate) = v.trim().parse::<f32>() {
-                    if !id.is_empty() && rate > 0.0 {
-                        map.insert(id, rate);
-                    }
+            let Some((k, v)) = trimmed.split_once('=') else {
+                malformed.push(trimmed.to_string());
+                continue;
+            };
+            let id = k.trim().to_string();
+            match v.trim().parse::<f32>() {
+                Ok(rate) if !id.is_empty() && rate > 0.0 && rate.is_finite() => {
+                    map.insert(id, rate);
                 }
+                _ => malformed.push(trimmed.to_string()),
             }
         }
-        map
+        (map, malformed)
+    }
+
+    /// Just the successfully parsed overrides. See
+    /// [`Args::parse_rate_limit_overrides`] for what gets rejected.
+    pub fn rate_limit_overrides(&self) -> std::collections::HashMap<String, f32> {
+        self.parse_rate_limit_overrides().0
     }
 
     /// Effective host-validation setting. `--no-strict` wins over `--strict`,
@@ -838,13 +856,34 @@ mod tests {
             "vt=oops,nokey=1,=2,wayback=-1",
             "example.com",
         ]);
-        let map = args.rate_limit_overrides();
-        // "vt=oops" -> not a number, dropped
-        // "nokey=1" -> kept, "nokey" -> 1
-        // "=2" -> empty id, dropped
-        // "wayback=-1" -> non-positive, dropped
+        let (map, malformed) = args.parse_rate_limit_overrides();
+        // "vt=oops" -> not a number, rejected
+        // "nokey=1" -> kept, "nokey" -> 1 (an unknown id, rejected separately)
+        // "=2" -> empty id, rejected
+        // "wayback=-1" -> non-positive, rejected
         assert_eq!(map.len(), 1);
         assert_eq!(map.get("nokey"), Some(&1.0));
+        // ...and every rejection is reported rather than vanishing.
+        assert_eq!(malformed, vec!["vt=oops", "=2", "wayback=-1"]);
+    }
+
+    #[test]
+    fn test_rate_limit_overrides_report_every_silent_rejection() {
+        // Each of these used to leave the run unthrottled with no diagnostic.
+        for entry in ["wayback", "wayback:5", "wayback=fast", "wayback=0"] {
+            let args = Args::parse_from(["urx", "--rate-limit-by", entry, "example.com"]);
+            let (map, malformed) = args.parse_rate_limit_overrides();
+            assert!(map.is_empty(), "{entry}: {map:?}");
+            assert_eq!(malformed, vec![entry.to_string()], "{entry}");
+        }
+    }
+
+    #[test]
+    fn test_rate_limit_overrides_accept_valid_entries_without_complaint() {
+        let args = Args::parse_from(["urx", "--rate-limit-by", "wayback=5", "example.com"]);
+        let (map, malformed) = args.parse_rate_limit_overrides();
+        assert_eq!(map.get("wayback"), Some(&5.0));
+        assert!(malformed.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,15 @@ fn validate_provider_ids(ids: &[String], flag_name: &str) -> Result<()> {
 }
 
 fn validate_rate_limit_override_ids(args: &Args) -> Result<()> {
-    let override_ids: Vec<String> = args.rate_limit_overrides().into_keys().collect();
+    let (overrides, malformed) = args.parse_rate_limit_overrides();
+    if !malformed.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Malformed entr{} in --rate-limit-by: {}. Expected id=requests-per-second with a positive rate, e.g. wayback=5",
+            if malformed.len() == 1 { "y" } else { "ies" },
+            malformed.join(", ")
+        ));
+    }
+    let override_ids: Vec<String> = overrides.into_keys().collect();
     validate_provider_ids(&override_ids, "--rate-limit-by")
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1235,7 +1235,11 @@ async fn process_domains_with_cache(
     }
 
     // Clean up expired cache entries
-    cache.cleanup_expired(args.cache_ttl * 2).await?;
+    // Saturating: `--cache-ttl` is an unvalidated u64, and `* 2` on a large one
+    // overflows (a debug-build panic, a wrap in release).
+    cache
+        .cleanup_expired(args.cache_ttl.saturating_mul(2))
+        .await?;
 
     Ok(final_result)
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -119,6 +119,19 @@ pub async fn read_body_capped(mut resp: reqwest::Response, max: usize) -> Result
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
+/// Read a JSON response body and deserialize it, bounded by
+/// [`MAX_RESPONSE_BYTES`].
+///
+/// `reqwest::Response::json` buffers the entire body first, which the keyed API
+/// providers (urlscan, VirusTotal, ZoomEye, GitHub) must not do for a host urx
+/// does not control — the same reason [`get_with_retry`] reads capped.
+pub async fn read_json_capped<T: serde::de::DeserializeOwned>(
+    resp: reqwest::Response,
+) -> Result<T> {
+    let body = read_body_capped(resp, MAX_RESPONSE_BYTES).await?;
+    Ok(serde_json::from_str(&body)?)
+}
+
 /// Whether an HTTP status is worth another attempt.
 ///
 /// Server errors and explicit throttling are transient. The rest of the 4xx

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -86,6 +86,17 @@ pub fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duratio
     Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
 }
 
+/// Ceiling on a single response body buffered by [`get_with_retry`].
+///
+/// Every provider that walks a CDX index goes through `get_with_retry`, and each
+/// of those requests is already bounded server-side (a 50k-row Wayback page, one
+/// Common Crawl block, one OTX page of 500 records) — a legitimate body is single
+/// -digit megabytes. This limit exists for the case where the remote does *not*
+/// honour that bound: a hostile, misconfigured, or hijacked index answering with
+/// an endless stream would otherwise be buffered in full, in memory, once per
+/// concurrent domain.
+pub const MAX_RESPONSE_BYTES: usize = 128 * 1024 * 1024;
+
 /// Read a response body, stopping after `max` bytes.
 ///
 /// Reads incrementally via `chunk()` rather than buffering the whole body, so an
@@ -163,9 +174,12 @@ pub async fn get_with_retry(client: &Client, url: &str, max_retries: u32) -> Res
                     continue;
                 }
 
-                match response.text().await {
+                // Capped rather than `response.text()`: this helper is the read
+                // path for every archive index urx queries, none of which urx
+                // controls, so an unbounded body must not be buffered in full.
+                match read_body_capped(response, MAX_RESPONSE_BYTES).await {
                     Ok(text) => return Ok(text),
-                    Err(e) => last_error = Some(e.into()),
+                    Err(e) => last_error = Some(e),
                 }
             }
             Err(e) => last_error = Some(e.into()),
@@ -414,6 +428,44 @@ mod tests {
         assert_eq!(get_with_retry(&client, &url, 2).await.unwrap(), "done");
         throttled.assert();
         ok.assert();
+    }
+
+    #[tokio::test]
+    async fn test_read_body_capped_stops_at_limit() {
+        let mut mock_server = mockito::Server::new_async().await;
+        let _m = mock_server
+            .mock("GET", "/big")
+            .with_status(200)
+            .with_body("x".repeat(10_000))
+            .create_async()
+            .await;
+
+        let resp = Client::new()
+            .get(format!("{}/big", mock_server.url()))
+            .send()
+            .await
+            .unwrap();
+        let body = read_body_capped(resp, 128).await.unwrap();
+        assert_eq!(body.len(), 128);
+    }
+
+    #[tokio::test]
+    async fn test_get_with_retry_returns_whole_body_under_cap() {
+        // get_with_retry reads through the capped path; a normal-sized body must
+        // still come back byte-for-byte (including non-ASCII, which the chunked
+        // read must not split incorrectly).
+        let mut mock_server = mockito::Server::new_async().await;
+        let payload = format!("{}\nsegunda linha — ção\n", "https://example.com/a");
+        let _m = mock_server
+            .mock("GET", "/body")
+            .with_status(200)
+            .with_body(&payload)
+            .create_async()
+            .await;
+
+        let client = Client::new();
+        let url = format!("{}/body", mock_server.url());
+        assert_eq!(get_with_retry(&client, &url, 0).await.unwrap(), payload);
     }
 
     #[tokio::test]

--- a/src/network/rate_limiter.rs
+++ b/src/network/rate_limiter.rs
@@ -20,15 +20,26 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
+    /// Longest interval a limiter will enforce, and therefore the slowest rate
+    /// that is distinguishable from "one request an hour". `1/rate` for a rate
+    /// small enough overflows a `Duration` outright — `Duration::from_secs_f32`
+    /// *panics* on that, so `--rate-limit 1e-30` took the whole run down.
+    const MAX_INTERVAL: Duration = Duration::from_secs(3600);
+
     /// Build a limiter for `requests_per_sec`. Returns `None` for a
     /// non-positive or non-finite rate, i.e. "no limiting".
     pub fn new(requests_per_sec: f32) -> Option<Self> {
         if requests_per_sec <= 0.0 || !requests_per_sec.is_finite() {
             return None;
         }
+        // `try_from_secs_f32` is the non-panicking form; an absurdly small rate
+        // is clamped to MAX_INTERVAL rather than crashing.
+        let min_interval = Duration::try_from_secs_f32(1.0 / requests_per_sec)
+            .unwrap_or(Self::MAX_INTERVAL)
+            .min(Self::MAX_INTERVAL);
         Some(Self {
             last: Arc::new(Mutex::new(None)),
-            min_interval: Duration::from_secs_f32(1.0 / requests_per_sec),
+            min_interval,
         })
     }
 
@@ -65,6 +76,22 @@ mod tests {
         assert!(RateLimiter::new(f32::INFINITY).is_none());
         assert!(RateLimiter::from_rate(None).is_none());
         assert!(RateLimiter::from_rate(Some(5.0)).is_some());
+    }
+
+    #[test]
+    fn test_tiny_rate_is_clamped_not_a_panic() {
+        // Regression: `--rate-limit 1e-30` makes 1/rate overflow a Duration, and
+        // Duration::from_secs_f32 panics rather than erroring — the whole run
+        // aborted before a single request went out.
+        for rate in [1e-30f32, f32::MIN_POSITIVE, 1e-12] {
+            let limiter = RateLimiter::new(rate).expect("positive rate must yield a limiter");
+            assert_eq!(limiter.min_interval, RateLimiter::MAX_INTERVAL, "{rate}");
+        }
+        // A sane rate is untouched.
+        assert_eq!(
+            RateLimiter::new(2.0).unwrap().min_interval,
+            Duration::from_millis(500)
+        );
     }
 
     #[tokio::test]

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 use super::ApiKeyRotator;
 use super::Provider;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_json_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
@@ -226,7 +226,7 @@ impl Provider for GitHubProvider {
                                 continue;
                             }
 
-                            match response.json::<SearchResponse>().await {
+                            match read_json_capped::<SearchResponse>(response).await {
                                 Ok(parsed) => {
                                     let was_empty = parsed.items.is_empty();
                                     for item in parsed.items {

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use super::Provider;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_body_capped, HttpClientConfig, MAX_RESPONSE_BYTES};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
@@ -195,7 +195,10 @@ impl Provider for OTXProvider {
                     match client.get(&url).send().await {
                         Ok(response) => {
                             if response.status().is_success() {
-                                match response.text().await {
+                                // Capped: OTX is a third-party host, and an
+                                // unbounded body would be buffered whole before
+                                // serde ever sees it.
+                                match read_body_capped(response, MAX_RESPONSE_BYTES).await {
                                     Ok(text) => {
                                         // Try to parse as OTXResult first
                                         let parse_result = serde_json::from_str::<OTXResult>(&text);

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -99,43 +99,41 @@ impl OTXProvider {
         }
     }
 
-    /// Formats the OTX API URL based on the domain and page number
+    /// Formats the OTX API URL based on the domain and page number.
     ///
-    /// This handles different endpoints for second-level domains and subdomains,
-    /// and accounts for the include_subdomains setting.
+    /// OTX exposes two indicator endpoints, and the choice between them is what
+    /// `--subs` means here:
+    ///
+    /// * `indicators/domain/<d>` — `d` and everything under it.
+    /// * `indicators/hostname/<h>` — that exact host only.
+    ///
+    /// The query is always sent for the domain **as the user typed it**. It used
+    /// to be truncated to its last two labels when `--subs` was set, on the
+    /// assumption that "the last two labels" is the registrable domain. That is
+    /// only true under single-label suffixes: `shop.example.co.uk` was reduced to
+    /// `co.uk`, so urx asked OTX for every URL under an entire public suffix and
+    /// then threw essentially all of it away in host validation. Even where the
+    /// assumption held it was wasteful — `sub.example.com` fetched all of
+    /// `example.com` to keep one subdomain's worth. Deciding registrability needs
+    /// a public-suffix list; not truncating needs none, and is what `--subs` on a
+    /// given host actually asks for.
     fn format_url(&self, domain: &str, page: u32) -> String {
         // AlienVault OTX API pages start at 1, not 0
         let page_number = page + 1;
 
-        // We should always use domain endpoint for second-level domains like example.com
-        // and hostname endpoint for subdomains like sub.example.com
-        if domain.split('.').count() <= 2 {
-            // This is a second-level domain like example.com
-            format!(
-                "{}/api/v1/indicators/domain/{domain}/url_list?limit={OTX_RESULTS_LIMIT}&page={page_number}",
-                self.base_url
-            )
-        } else if self.include_subdomains {
-            // This is a subdomain but we want to include all subdomains
-            // Extract the main domain (e.g., "example.com" from "sub.example.com")
-            let parts: Vec<&str> = domain.split('.').collect();
-            let main_domain = if parts.len() >= 2 {
-                parts[parts.len() - 2..].join(".")
-            } else {
-                domain.to_string()
-            };
-
-            format!(
-                "{}/api/v1/indicators/domain/{main_domain}/url_list?limit={OTX_RESULTS_LIMIT}&page={page_number}",
-                self.base_url
-            )
+        // An apex-looking name is queried through the domain endpoint even
+        // without --subs: the hostname endpoint would exclude `www.<domain>`,
+        // which host validation treats as the apex itself.
+        let endpoint = if self.include_subdomains || domain.split('.').count() <= 2 {
+            "domain"
         } else {
-            // This is a subdomain and we don't want to include other subdomains
-            format!(
-                "{}/api/v1/indicators/hostname/{domain}/url_list?limit={OTX_RESULTS_LIMIT}&page={page_number}",
-                self.base_url
-            )
-        }
+            "hostname"
+        };
+
+        format!(
+            "{}/api/v1/indicators/{endpoint}/{domain}/url_list?limit={OTX_RESULTS_LIMIT}&page={page_number}",
+            self.base_url
+        )
     }
 }
 
@@ -520,8 +518,43 @@ mod tests {
         assert_eq!(
             url,
             format!(
-                "https://otx.alienvault.com/api/v1/indicators/domain/example.com/url_list?limit={OTX_RESULTS_LIMIT}&page=1"
+                "https://otx.alienvault.com/api/v1/indicators/domain/sub.example.com/url_list?limit={OTX_RESULTS_LIMIT}&page=1"
             )
+        );
+    }
+
+    #[test]
+    fn test_format_url_does_not_truncate_multi_label_suffix() {
+        // Regression: --subs used to keep only the last two labels, so a domain
+        // under a multi-label public suffix was reduced to the suffix itself and
+        // urx asked OTX for every URL in `.co.uk`.
+        let mut provider = OTXProvider::new();
+        provider.with_subdomains(true);
+        assert!(
+            provider
+                .format_url("example.co.uk", 0)
+                .contains("/indicators/domain/example.co.uk/"),
+            "{}",
+            provider.format_url("example.co.uk", 0)
+        );
+        assert!(
+            provider
+                .format_url("shop.example.co.uk", 0)
+                .contains("/indicators/domain/shop.example.co.uk/"),
+            "{}",
+            provider.format_url("shop.example.co.uk", 0)
+        );
+    }
+
+    #[test]
+    fn test_format_url_multi_label_suffix_without_subs_uses_hostname() {
+        let provider = OTXProvider::new();
+        assert!(
+            provider
+                .format_url("example.co.uk", 0)
+                .contains("/indicators/hostname/example.co.uk/"),
+            "{}",
+            provider.format_url("example.co.uk", 0)
         );
     }
 

--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -186,6 +186,17 @@ impl Provider for RobotsProvider {
                         if value.contains('*') {
                             continue;
                         }
+                        // RFC 9309 requires the path to begin with '/', and this
+                        // value is pasted directly after the host. Anything else
+                        // does not produce the URL it looks like it does: a bare
+                        // `admin` yields `https://example.comadmin`, and a value
+                        // starting with `@` is worse — `@evil.example/` turns
+                        // `https://example.com` into userinfo and the URL lands on
+                        // evil.example, letting the file under audit put another
+                        // host's URLs into urx's results.
+                        if !value.starts_with('/') {
+                            continue;
+                        }
                         let path = value.strip_suffix('$').unwrap_or(value);
                         if !path.is_empty() && path != "/" {
                             urls.push(format!("{protocol}://{domain}{path}"));
@@ -197,6 +208,12 @@ impl Provider for RobotsProvider {
                     _ => {}
                 }
             }
+
+            // A robots.txt routinely repeats the same Disallow under several
+            // User-agent groups; every other provider returns a deduplicated
+            // list, so this one should too.
+            urls.sort();
+            urls.dedup();
 
             Ok(urls)
         })
@@ -424,6 +441,65 @@ Sitemap: https://example.com/sitemap.xml
         // Inline comment is removed from the Sitemap value.
         assert!(urls.contains(&"https://example.com/sm.xml".to_string()));
         assert!(!urls.iter().any(|u| u.contains('#')), "{urls:?}");
+    }
+
+    #[tokio::test]
+    async fn test_disallow_values_must_be_absolute_paths() {
+        // Regression: the Disallow value was pasted straight after the host.
+        // A value that isn't a path doesn't produce the URL it looks like:
+        // `admin` yields `https://example.comadmin`, and `@evil.example/` makes
+        // `example.com` the userinfo so the URL lands on evil.example — the
+        // audited file putting another host's URLs into urx's results.
+        let mut server = mockito::Server::new_async().await;
+        let robots = "User-agent: *\n\
+                      Disallow: admin\n\
+                      Disallow: @evil.example/pwned\n\
+                      Disallow: /legit\n";
+        let _m = server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(robots)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(server.url());
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert_eq!(
+            urls,
+            vec!["https://example.com/legit".to_string()],
+            "{urls:?}"
+        );
+        // Belt and braces: nothing we emit may resolve to another host.
+        for u in &urls {
+            assert_eq!(
+                url::Url::parse(u).unwrap().host_str(),
+                Some("example.com"),
+                "{u}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_repeated_disallow_entries_are_deduplicated() {
+        // The same path under several User-agent groups is ordinary.
+        let mut server = mockito::Server::new_async().await;
+        let robots = "User-agent: *\n\
+                      Disallow: /admin\n\
+                      User-agent: Googlebot\n\
+                      Disallow: /admin\n";
+        let _m = server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(robots)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(server.url());
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["https://example.com/admin".to_string()]);
     }
 
     #[tokio::test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -25,6 +25,30 @@ const MAX_SITEMAP_URLS: usize = 1_000_000;
 /// any URL parsing happens (the per-URL cap only bounds the *parsed* output).
 const MAX_SITEMAP_BYTES: usize = 50 * 1024 * 1024;
 
+/// Whether a `<loc>` in a sitemap index may be followed from `parent`.
+///
+/// sitemaps.org requires every entry in a sitemap to reside on the same host as
+/// the sitemap itself, and urx never enforced it: a `<sitemapindex>` could point
+/// `<loc>` at any host at all and urx would fetch it and report what it found.
+/// That let the document under audit redirect the provider away from the target
+/// — including at hosts only the machine running urx can reach — and surface
+/// their contents as URLs "discovered" for the domain.
+///
+/// Only the host and any explicit port must match; a sitemap served over HTTPS
+/// listing its children over HTTP (or the reverse) is common enough that scheme
+/// is not compared. `Url::port` reports `None` for a scheme's default port, so
+/// comparing it keeps `https://h` and `https://h:443` equal while still telling
+/// `h` apart from `h:8443`.
+fn same_host_as_parent(parent: &str, child: &str) -> bool {
+    match (url::Url::parse(parent), url::Url::parse(child)) {
+        (Ok(p), Ok(c)) => match (p.host_str(), c.host_str()) {
+            (Some(ph), Some(ch)) => ph.eq_ignore_ascii_case(ch) && p.port() == c.port(),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 #[derive(Clone)]
 pub struct SitemapProvider {
     timeout: Duration,
@@ -139,11 +163,17 @@ impl SitemapProvider {
                             sitemap_node.descendants().find(|n| n.has_tag_name("loc"))
                         {
                             if let Some(nested_sitemap_url) = loc_node.text() {
+                                // A child sitemap must live on the same host as
+                                // the index that names it; anything else is the
+                                // document steering us off the target.
+                                if !same_host_as_parent(sitemap_url, nested_sitemap_url.trim()) {
+                                    continue;
+                                }
                                 // Recursively fetch and parse nested sitemaps.
                                 // Box::pin the future to avoid infinitely sized futures.
                                 let nested_urls = Box::pin(Self::parse_sitemap(
                                     client,
-                                    nested_sitemap_url,
+                                    nested_sitemap_url.trim(),
                                     depth + 1,
                                     visited,
                                     limiter,
@@ -231,6 +261,13 @@ impl Provider for SitemapProvider {
                 urls.extend(found);
             }
 
+            // The https and http candidates are distinct sitemap URLs, so
+            // `visited` doesn't stop a site that serves both from contributing
+            // every URL twice. Every other provider sorts and dedupes its
+            // return; this one didn't.
+            urls.sort();
+            urls.dedup();
+
             Ok(urls)
         })
     }
@@ -263,6 +300,87 @@ impl Provider for SitemapProvider {
 mod tests {
     use super::*;
     use mockito::Server;
+
+    #[test]
+    fn test_same_host_as_parent() {
+        let parent = "https://example.com/sitemap.xml";
+        assert!(same_host_as_parent(parent, "https://example.com/a.xml"));
+        // Scheme may differ; the host may not.
+        assert!(same_host_as_parent(parent, "http://example.com/a.xml"));
+        assert!(same_host_as_parent(parent, "https://EXAMPLE.com/a.xml"));
+
+        assert!(!same_host_as_parent(parent, "https://evil.example/a.xml"));
+        assert!(!same_host_as_parent(
+            parent,
+            "https://cdn.example.com/a.xml"
+        ));
+        assert!(!same_host_as_parent(parent, "http://127.0.0.1:8080/a.xml"));
+        assert!(!same_host_as_parent(parent, "not a url"));
+        // A non-default port is a different endpoint.
+        assert!(!same_host_as_parent(
+            parent,
+            "https://example.com:8443/a.xml"
+        ));
+        // ...but the scheme's own default port is the same endpoint.
+        assert!(same_host_as_parent(parent, "https://example.com:443/a.xml"));
+    }
+
+    #[tokio::test]
+    async fn test_sitemap_index_cannot_redirect_the_fetch_to_another_host() {
+        // Regression: a <sitemapindex> could name any host in <loc> and urx
+        // would fetch it, reporting whatever it found as URLs belonging to the
+        // target — including hosts only the machine running urx can reach.
+        let mut elsewhere = Server::new_async().await;
+        let offsite = elsewhere
+            .mock("GET", "/private.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(
+                r#"<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://leaked.example/secret</loc></url>
+</urlset>"#,
+            )
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+        let index_body = format!(
+            r#"<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>{}/private.xml</loc></sitemap>
+  <sitemap><loc>http://{host}/own.xml</loc></sitemap>
+</sitemapindex>"#,
+            elsewhere.url()
+        );
+        let _index = server
+            .mock("GET", "/sitemap.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(index_body)
+            .create_async()
+            .await;
+        let _own = server
+            .mock("GET", "/own.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(
+                r#"<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/kept</loc></url>
+</urlset>"#,
+            )
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        let urls = provider.fetch_urls(&host).await.unwrap();
+
+        assert_eq!(urls, vec!["https://example.com/kept".to_string()]);
+        offsite.assert(); // never requested
+    }
 
     #[test]
     fn test_new_provider() {

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 
 use super::ApiKeyRotator;
 use super::Provider;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_json_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
@@ -58,6 +58,11 @@ const URLSCAN_MAX_PAGES: usize = 100;
 /// Turn a result's `sort` array into the `search_after` cursor urlscan expects:
 /// the array values rendered as a comma-separated string. Returns `None` when
 /// the result carries no sort key (so we can't page further).
+///
+/// The result is percent-encoded, because it is spliced straight back into the
+/// next request's query string. The values come from urlscan's response, not
+/// from us: a sort value containing `&` or `=` would otherwise end the parameter
+/// and inject arbitrary query parameters into the follow-up request.
 fn sort_to_search_after(sort: &[serde_json::Value]) -> Option<String> {
     if sort.is_empty() {
         return None;
@@ -69,7 +74,7 @@ fn sort_to_search_after(sort: &[serde_json::Value]) -> Option<String> {
             other => other.to_string(),
         })
         .collect();
-    Some(parts.join(","))
+    Some(url::form_urlencoded::byte_serialize(parts.join(",").as_bytes()).collect::<String>())
 }
 
 impl UrlscanProvider {
@@ -159,7 +164,7 @@ impl UrlscanProvider {
                         last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                         continue;
                     }
-                    match response.json::<UrlscanResponse>().await {
+                    match read_json_capped::<UrlscanResponse>(response).await {
                         Ok(parsed) => return Ok(parsed),
                         Err(e) => {
                             attempt += 1;
@@ -340,6 +345,26 @@ impl Provider for UrlscanProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sort_cursor_is_percent_encoded() {
+        // The cursor is spliced into the next request's query string, and its
+        // values come from urlscan's response — an unencoded '&' or '=' used to
+        // end the parameter and inject query parameters of the server's choosing.
+        let sort = vec![
+            serde_json::Value::from(1699999999999i64),
+            serde_json::Value::from("a&size=1&x=y"),
+        ];
+        let cursor = sort_to_search_after(&sort).unwrap();
+        assert!(!cursor.contains('&'), "{cursor}");
+        assert!(!cursor.contains('='), "{cursor}");
+        assert!(cursor.starts_with("1699999999999%2C"), "{cursor}");
+    }
+
+    #[test]
+    fn test_sort_cursor_none_when_absent() {
+        assert!(sort_to_search_after(&[]).is_none());
+    }
 
     #[test]
     fn test_new_provider() {

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 
 use super::ApiKeyRotator;
 use super::Provider;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_json_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
@@ -191,7 +191,7 @@ impl VirusTotalProvider {
                         last_error = Some(anyhow::anyhow!("HTTP error: {status}"));
                         continue;
                     }
-                    match response.json::<VtUrlsResponse>().await {
+                    match read_json_capped::<VtUrlsResponse>(response).await {
                         Ok(parsed) => return Ok(parsed),
                         Err(e) => {
                             attempt += 1;

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 use super::ApiKeyRotator;
 use super::Provider;
-use crate::network::client::HttpClientConfig;
+use crate::network::client::{read_json_capped, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
@@ -207,7 +207,7 @@ impl Provider for ZoomEyeProvider {
                                 continue;
                             }
 
-                            match response.json::<ZoomEyeResponse>().await {
+                            match read_json_capped::<ZoomEyeResponse>(response).await {
                                 Ok(zoomeye_response) => {
                                     // A 200 with a non-success code is an API
                                     // error (rejected key, quota, bad query) —

--- a/src/tester_manager/mod.rs
+++ b/src/tester_manager/mod.rs
@@ -205,8 +205,26 @@ pub async fn process_urls_with_testers(
         new_urls.extend(urls);
     }
 
-    // Sort URLs by their URL field
+    // Sort URLs by their URL field, then collapse repeats.
+    //
+    // Every other path into the output is deduplicated — the batch path builds
+    // from a HashSet, the streaming sink keeps a `seen` set — but this one was
+    // not, and it is the one that manufactures duplicates. `--extract-links`
+    // emits every link found on every page, so a nav entry linked from a hundred
+    // pages was printed a hundred times; a discovered link that is also a
+    // primary URL was printed twice, once with a status and once without.
     new_urls.sort_by(|a, b| a.url.cmp(&b.url));
+    new_urls.dedup_by(|dropped, kept| {
+        if dropped.url != kept.url {
+            return false;
+        }
+        // Keep whichever copy carries the status; a checked URL rediscovered by
+        // the extractor must not lose its status code to the bare copy.
+        if kept.status.is_none() {
+            kept.status = dropped.status.take();
+        }
+        true
+    });
 
     test_bar.finish_with_message(format!("Testing complete, found {} URLs", new_urls.len()));
 
@@ -598,6 +616,104 @@ mod tests {
         assert_eq!(tester.retries, 5);
         assert!(tester.random_agent);
         assert!(tester.insecure);
+    }
+
+    #[tokio::test]
+    async fn test_extracted_links_are_deduplicated() {
+        // Regression: every link found on every page was appended verbatim, so a
+        // nav entry present on many pages was printed once per page.
+        use clap::Parser;
+        let args = Args::parse_from(["urx", "--extract-links", "--silent", "example.com"]);
+        let progress = ProgressManager::new(true);
+        let tester = FixedLinkTester(vec![
+            "https://example.com/contact".to_string(),
+            "https://example.com/about".to_string(),
+        ]);
+
+        // Three seed pages, each yielding the same two links.
+        let out = process_urls_with_testers(
+            vec![
+                "https://example.com/p1".to_string(),
+                "https://example.com/p2".to_string(),
+                "https://example.com/p3".to_string(),
+            ],
+            &args,
+            &progress,
+            vec![Box::new(tester)],
+            false,
+            None,
+        )
+        .await;
+
+        let urls: Vec<String> = out.into_iter().map(|d| d.url).collect();
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/about".to_string(),
+                "https://example.com/contact".to_string(),
+                "https://example.com/p1".to_string(),
+                "https://example.com/p2".to_string(),
+                "https://example.com/p3".to_string(),
+            ],
+            "{urls:?}"
+        );
+    }
+
+    /// A status checker that always reports 200 for whatever it is given.
+    #[derive(Clone)]
+    struct OkStatusTester;
+
+    impl Tester for OkStatusTester {
+        fn clone_box(&self) -> Box<dyn Tester> {
+            Box::new(self.clone())
+        }
+        fn test_url<'a>(
+            &'a self,
+            url: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + 'a>> {
+            let url = url.to_string();
+            Box::pin(async move { Ok(vec![format!("{url} - 200 OK")]) })
+        }
+        fn with_timeout(&mut self, _seconds: u64) {}
+        fn with_retries(&mut self, _count: u32) {}
+        fn with_random_agent(&mut self, _enabled: bool) {}
+        fn with_insecure(&mut self, _enabled: bool) {}
+        fn with_proxy(&mut self, _proxy: Option<String>) {}
+        fn with_proxy_auth(&mut self, _auth: Option<String>) {}
+    }
+
+    #[tokio::test]
+    async fn test_dedup_keeps_the_entry_carrying_the_status() {
+        // A URL that was status-checked and then rediscovered by the extractor
+        // appeared twice — once with its status, once bare. Collapsing the two
+        // must not throw the status away.
+        use clap::Parser;
+        let args = Args::parse_from([
+            "urx",
+            "--check-status",
+            "--extract-links",
+            "--silent",
+            "example.com",
+        ]);
+        let progress = ProgressManager::new(true);
+
+        let out = process_urls_with_testers(
+            vec!["https://example.com/a".to_string()],
+            &args,
+            &progress,
+            vec![
+                Box::new(OkStatusTester),
+                // The page links back to itself.
+                Box::new(FixedLinkTester(vec!["https://example.com/a".to_string()])),
+            ],
+            true,
+            None,
+        )
+        .await;
+
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert_eq!(out[0].url, "https://example.com/a");
+        assert_eq!(out[0].status.as_deref(), Some("200 OK"));
     }
 
     #[test]

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -92,20 +92,60 @@ impl LinkExtractor {
             .await
     }
 
-    /// Extracts links from HTML content, resolving them against a base URL
+    /// Whether an `href` names something a crawler can fetch.
+    ///
+    /// `javascript:`, `mailto:`, `tel:` and `data:` hrefs resolve to perfectly
+    /// valid absolute URLs, so they used to be emitted as discovered links — a
+    /// `mailto:` address reported as a URL urx had found. A bare `#anchor` is
+    /// worse: it resolves to the page urx is already looking at, so every
+    /// in-page anchor came back as a "new" URL that survives host validation.
+    fn is_fetchable_href(href: &str) -> bool {
+        let href = href.trim();
+        if href.is_empty() || href.starts_with('#') {
+            return false;
+        }
+        // A scheme is everything before the first ':' — but only when no '/',
+        // '?' or '#' comes first, otherwise `foo/bar:baz` would read as a scheme.
+        match href.find([':', '/', '?', '#']) {
+            Some(i) if href.as_bytes()[i] == b':' => !matches!(
+                href[..i].to_ascii_lowercase().as_str(),
+                "javascript" | "mailto" | "tel" | "data" | "about" | "blob"
+            ),
+            _ => true,
+        }
+    }
+
+    /// Extracts links from HTML content, resolving them against a base URL.
+    ///
+    /// A `<base href>` in the document overrides `base_url` for relative links —
+    /// that is the entire purpose of the tag, and ignoring it meant every
+    /// relative href on a page that declares one resolved to the wrong absolute
+    /// URL. An unparseable or relative `<base href>` is itself resolved against
+    /// the page URL, as browsers do.
     fn extract_links(base_url: &Url, html_content: &str) -> Vec<String> {
         let document = Html::parse_document(html_content);
         let mut links = Vec::new();
 
-        // Select all <a> tags with href attributes
-        // We unwrap here because "a[href]" is a constant valid selector
+        // Constant, known-valid selectors.
+        let base_selector = Selector::parse("base[href]").unwrap();
         let selector = Selector::parse("a[href]").unwrap();
+
+        // Only the first <base href> in the document has effect.
+        let resolved_base = document
+            .select(&base_selector)
+            .next()
+            .and_then(|el| el.value().attr("href"))
+            .and_then(|href| base_url.join(href).ok())
+            .unwrap_or_else(|| base_url.clone());
 
         // Extract and normalize links
         for element in document.select(&selector) {
             if let Some(href) = element.value().attr("href") {
+                if !Self::is_fetchable_href(href) {
+                    continue;
+                }
                 // Resolve relative URLs to absolute URLs
-                if let Ok(absolute_url) = base_url.join(href) {
+                if let Ok(absolute_url) = resolved_base.join(href.trim()) {
                     links.push(absolute_url.to_string());
                 }
             }
@@ -327,6 +367,77 @@ mod tests {
         let html = "<a>No href</a>";
         let links = LinkExtractor::extract_links(&base_url, html);
         assert!(links.is_empty());
+    }
+
+    #[test]
+    fn test_base_href_overrides_the_page_url() {
+        // Regression: <base href> was ignored, so every relative link on a page
+        // that declares one resolved against the page URL and produced an
+        // absolute URL that does not exist on the site.
+        let base_url = Url::parse("https://example.com/deep/page.html").unwrap();
+        let html = r#"
+            <html><head><base href="https://cdn.example.com/app/"></head>
+            <body><a href="a.js">rel</a><a href="/root">root</a></body></html>
+        "#;
+        let links = LinkExtractor::extract_links(&base_url, html);
+        assert!(
+            links.contains(&"https://cdn.example.com/app/a.js".to_string()),
+            "{links:?}"
+        );
+        assert!(
+            links.contains(&"https://cdn.example.com/root".to_string()),
+            "{links:?}"
+        );
+    }
+
+    #[test]
+    fn test_relative_base_href_is_resolved_against_the_page() {
+        let base_url = Url::parse("https://example.com/a/b/page.html").unwrap();
+        let html = r#"<head><base href="../assets/"></head><a href="x.css">x</a>"#;
+        let links = LinkExtractor::extract_links(&base_url, html);
+        assert_eq!(
+            links,
+            vec!["https://example.com/a/assets/x.css".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_only_the_first_base_href_applies() {
+        let base_url = Url::parse("https://example.com/p").unwrap();
+        let html = r#"<base href="https://one.example/"><base href="https://two.example/"><a href="z">z</a>"#;
+        let links = LinkExtractor::extract_links(&base_url, html);
+        assert_eq!(links, vec!["https://one.example/z".to_string()]);
+    }
+
+    #[test]
+    fn test_non_navigational_hrefs_are_not_reported_as_urls() {
+        // These all resolve to valid absolute URLs, so they used to be emitted
+        // as links urx had discovered.
+        let base_url = Url::parse("https://example.com/start").unwrap();
+        let html = r##"
+            <a href="javascript:void(0)">js</a>
+            <a href="mailto:a@example.com">mail</a>
+            <a href="tel:+15551234">tel</a>
+            <a href="data:text/plain,hi">data</a>
+            <a href="#top">anchor</a>
+            <a href="  ">blank</a>
+            <a href="/real">real</a>
+        "##;
+        let links = LinkExtractor::extract_links(&base_url, html);
+        assert_eq!(links, vec!["https://example.com/real".to_string()]);
+    }
+
+    #[test]
+    fn test_path_containing_a_colon_is_still_followed() {
+        // `is_fetchable_href` must not mistake a colon inside a path segment for
+        // a scheme.
+        let base_url = Url::parse("https://example.com/start").unwrap();
+        let html = r#"<a href="/files/a:b/c.js">x</a><a href="rel:ative/thing">y</a>"#;
+        let links = LinkExtractor::extract_links(&base_url, html);
+        assert!(
+            links.contains(&"https://example.com/files/a:b/c.js".to_string()),
+            "{links:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/utils/url.rs
+++ b/src/utils/url.rs
@@ -150,8 +150,18 @@ impl UrlTransformer {
 
         for url_str in urls {
             if let Ok(url) = Url::parse(&url_str) {
-                // Create a key using host and path
-                let key = format!("{}{}", url.host_str().unwrap_or(""), url.path());
+                // Key on the full origin plus the path. Keying on host+path alone
+                // merged endpoints that are not the same endpoint at all:
+                // `http://host/api?a=1` and `https://host/api?b=2` collapsed into a
+                // single URL that carried one scheme and both origins' parameters,
+                // and `host:8080/api` was folded into `host/api` the same way.
+                let key = format!(
+                    "{}://{}{}{}",
+                    url.scheme(),
+                    url.host_str().unwrap_or(""),
+                    url.port().map(|p| format!(":{p}")).unwrap_or_default(),
+                    url.path()
+                );
 
                 path_groups.entry(key).or_default().push(url_str);
             } else {
@@ -321,6 +331,50 @@ mod tests {
         let out = transformer.transform(urls);
         assert_eq!(out.len(), 1, "{out:?}");
         assert_eq!(out[0], "https://example.com/s?q=a+b&debug");
+    }
+
+    #[test]
+    fn test_merge_endpoints_keeps_origins_apart() {
+        // Regression: the group key was host+path, so a plain-HTTP endpoint and
+        // its HTTPS counterpart (and a non-default port) merged into one URL —
+        // inventing an endpoint that carried parameters never seen on that origin.
+        let mut transformer = UrlTransformer::new();
+        transformer.with_merge_endpoint(true);
+
+        let urls = vec![
+            "http://example.com/api?a=1".to_string(),
+            "https://example.com/api?b=2".to_string(),
+            "https://example.com:8443/api?c=3".to_string(),
+        ];
+
+        let out = transformer.transform(urls);
+        assert_eq!(out.len(), 3, "{out:?}");
+        assert!(
+            out.contains(&"http://example.com/api?a=1".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            out.contains(&"https://example.com/api?b=2".to_string()),
+            "{out:?}"
+        );
+        assert!(
+            out.contains(&"https://example.com:8443/api?c=3".to_string()),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn test_merge_endpoints_still_merges_same_origin() {
+        let mut transformer = UrlTransformer::new();
+        transformer.with_merge_endpoint(true);
+
+        let urls = vec![
+            "https://example.com/api?a=1".to_string(),
+            "https://example.com/api?b=2".to_string(),
+        ];
+
+        let out = transformer.transform(urls);
+        assert_eq!(out, vec!["https://example.com/api?a=1&b=2".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Ten rounds of reading the source for bugs, one fix per commit, each with a regression test.

## What was wrong

| Commit | Bug |
|---|---|
| `f6295e2` | `--merge-endpoint` grouped by host+path only, so `http://h/api?a=1`, `https://h/api?b=2` and `https://h:8443/api?c=3` collapsed into one URL carrying every origin's parameters — an endpoint never observed anywhere. |
| `2c9d067` | `get_with_retry` — the read path for every CDX index — and OTX's direct read both used `response.text()`, buffering an unbounded body from a host urx does not control, once per concurrent domain. |
| `bea8c76` | OTX `--subs` truncated the target to its last two labels. Under a multi-label suffix that is the suffix: `shop.example.co.uk` became `co.uk`, so urx paged through all of `.co.uk` and discarded nearly all of it. |
| `0f3e7d5` | `--extract-links` ignored `<base href>`, so every relative link on a page declaring one resolved to a URL that does not exist on the site. It also reported `javascript:`, `mailto:`, `tel:`, `data:` and bare `#anchor` hrefs as discovered URLs. |
| `33f2d7a` | The four keyed providers parsed with `response.json()` (same unbounded read as above), and urlscan's `search_after` cursor — built from values in the server's own response — was spliced raw into the next query string. |
| `8a26fb0` | `<sitemapindex>` entries were followed wherever `<loc>` pointed. sitemaps.org requires same-host; urx enforced nothing, so the audited document could send the fetch to an unrelated host — including one only the machine running urx can reach. |
| `e1446f4` | **Two panics reachable from the CLI.** `--rate-limit 1e-30` overflows a `Duration` (`from_secs_f32` panics); `--cache-ttl 10000000000000000` is doubled and handed to `chrono::Duration::seconds`, which panics past its bounds. |
| `710f835` | The tested-URL path was the only route to output without dedup, and the only one that manufactures duplicates: `--extract-links` printed a nav entry once per page linking to it. |
| `de411cd` | A robots.txt `Disallow` value was pasted straight after the host. `Disallow: @evil.example/x` makes `example.com` the userinfo, so the URL resolves to `evil.example`. |
| `4796601` | `--rate-limit-by wayback=0` / `wayback:5` / `wayback` were dropped silently, leaving an unthrottled run the user believes they limited. |

## Notes

- The two panics in `e1446f4` were reproduced on the built binary and re-checked after the fix; both now exit cleanly.
- `8a26fb0` and `de411cd` are the same shape: a document urx fetches could steer urx's *requests* at another host. Strict mode (on by default) filtered the results, but the requests still went out.
- No behaviour was changed beyond the defects described. `--rate-limit-by` is the one case that turns a previously-silent input into a hard error, matching how unknown provider ids and unknown `--preset` values already behave.

## Verification

`cargo test --bin urx`: **610 passed, 0 failed** (591 before this branch; +19 regression tests).
`cargo clippy --all-targets`: clean.
