### PR TITLE
docs: fix inaccurate config keys and document GitHub provider

### DIFF
--- a/docs/content/guide/cli-options.md
+++ b/docs/content/guide/cli-options.md
@@ -57,6 +57,7 @@ Display Options:
   -v, --verbose       Show verbose output
       --silent        Silent mode (no output)
       --no-progress   No progress bar
+      --no-color      Disable ANSI color (NO_COLOR is also honored)
       --show-sources  Annotate output URLs with the providers that returned them
       --stats         Print a per-provider summary to stderr at end of run
 
@@ -72,9 +73,10 @@ Filter Options:
       --min-length <MIN_LENGTH>              Minimum URL length
       --max-length <MAX_LENGTH>              Maximum URL length
       --strict                               Enforce exact host validation (default)
+      --no-strict                            Disable host validation entirely (wins over --strict)
 
 Network Options:
-  --network-scope <SCOPE>        Apply settings to: all, providers, testers [default: all]
+  --network-scope <SCOPE>        Apply settings to: all, providers, testers, providers,testers [default: all]
   --proxy <PROXY>                HTTP proxy (e.g., http://proxy:8080)
   --proxy-auth <PROXY_AUTH>      Proxy credentials (username:password)
   --insecure                     Skip SSL certificate verification
@@ -112,16 +114,29 @@ Cache Options:
 | VirusTotal | `vt` | Yes | `URX_VT_API_KEY` |
 | URLScan | `urlscan` | No (optional) | `URX_URLSCAN_API_KEY` |
 | ZoomEye | `zoomeye` | Yes | `URX_ZOOMEYE_API_KEY` |
+| GitHub Code Search | `github` | Yes | `URX_GITHUB_API_KEY` |
 
-Default providers: `wayback,cc,otx`. Providers requiring API keys are automatically enabled when their keys are provided. `arquivo` (the Portuguese web archive) is keyless but opt-in — add it with `--providers` or enable everything with `--all-providers`. URLScan works anonymously without a key (rate-limited to ~30 requests/min per IP); a key only raises those limits and enables rotation.
+Default providers: `wayback,cc,otx`. Providers requiring API keys are automatically enabled when their keys are provided. `arquivo` (the Portuguese web archive) is keyless but opt-in — add it with `--providers` or enable everything with `--all-providers`. URLScan works anonymously without a key (rate-limited to ~30 requests/min per IP); a key only raises those limits and enables rotation. `github` searches GitHub Code Search and requires a personal access token (`--github-api-key` or `URX_GITHUB_API_KEY`).
+
+Run `urx --list-providers` to print the full catalog (id, API-key requirement, and a one-line summary) directly from the binary.
 
 ## Filter Presets
 
+Exclude a family with a `no-*` preset, or keep only a family with an `only-*`
+preset. Singular spellings (e.g. `no-image`, `only-font`) are accepted too.
+
 | Preset | Description |
 |--------|-------------|
-| `no-resources` | Exclude resource files (images, CSS, fonts, etc.) |
+| `no-resources` | Exclude resource files (images, CSS, fonts, documents, videos, audio) |
 | `no-images` | Exclude image files |
+| `no-fonts` | Exclude font files |
+| `no-documents` | Exclude document files |
+| `no-videos` | Exclude video files |
 | `no-audio` | Exclude audio files |
 | `only-js` | Only JavaScript files |
 | `only-style` | Only stylesheet files |
+| `only-fonts` | Only font files |
+| `only-documents` | Only document files |
+| `only-videos` | Only video files |
 | `only-audio` | Only audio files |
+| `only-images` | Only image files |

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -31,25 +31,27 @@ domains = ["example.com", "example.org"]
 # ─── Output ──────────────────────────────────────────────
 [output]
 output = "results.txt"
-format = "plain"           # plain, json, csv
+format = "plain"           # plain, json, jsonl, csv
 merge_endpoint = false
-normalize_url = false
+stream = false             # Write URLs as providers report them (unsorted, bypasses cache)
 
 # ─── Providers ───────────────────────────────────────────
 [provider]
 providers = ["wayback", "cc", "otx"] # also available keyless: "arquivo", "urlscan" (anonymous)
 subs = false                          # Include subdomains
 cc_index = "CC-MAIN-2026-17"         # Common Crawl index (or "latest" to auto-resolve via collinfo.json)
+from = ""                             # Restrict CDX providers to captures >= this date (YYYY/YYYYMM/YYYYMMDD)
+to = ""                               # Restrict CDX providers to captures <= this date
+archive_status = []                   # Keep only captures the archive recorded with these status codes
+archive_exclude_status = []           # Drop captures with these recorded status codes
+archive_mime = []                     # Keep only captures with these recorded MIME types
+archive_exclude_mime = []             # Drop captures with these recorded MIME types
 vt_api_key = ""                       # VirusTotal API key
 urlscan_api_key = ""                  # URLScan API key (optional; urlscan also works anonymously)
 zoomeye_api_key = ""                  # ZoomEye API key
+github_api_key = ""                   # GitHub Code Search personal access token
 exclude_robots = false                # Skip robots.txt discovery
 exclude_sitemap = false               # Skip sitemap.xml discovery
-
-# ─── Display ─────────────────────────────────────────────
-verbose = false
-silent = false
-no_progress = false
 
 # ─── Filters ─────────────────────────────────────────────
 [filter]
@@ -63,11 +65,10 @@ show_only_path = false
 show_only_param = false
 min_length = 10
 max_length = 500
-strict = true
 
 # ─── Network ─────────────────────────────────────────────
 [network]
-network_scope = "all"                  # all, providers, testers
+network_scope = "all"                  # all, providers, testers, or providers,testers
 proxy = "http://proxy.example.com:8080"
 proxy_auth = "username:password"
 insecure = false
@@ -137,14 +138,17 @@ timeout = 60
 [provider]
 providers = ["wayback", "cc", "otx"]
 
-silent = true
-
 [cache]
 incremental = true
 cache_type = "redis"
 redis_url = "redis://cache-server:6379"
 cache_ttl = 43200
 ```
+
+> Run this with `--silent` on the command line — display flags such as
+> `--silent`, `--verbose`, and `--no-progress`, along with host-validation
+> flags (`--strict` / `--no-strict`), are CLI-only and have no config file
+> equivalent.
 
 ### Config File Location
 

--- a/docs/content/guide/environment-variables.md
+++ b/docs/content/guide/environment-variables.md
@@ -53,6 +53,21 @@ export URX_ZOOMEYE_API_KEY=key1,key2,key3
 urx example.com --providers zoomeye
 ```
 
+#### URX_GITHUB_API_KEY
+GitHub personal access token for the `github` provider (GitHub Code Search),
+which requires a token to run.
+
+```bash
+export URX_GITHUB_API_KEY=your_token_here
+urx example.com --providers github
+```
+
+**Multiple Keys (Rotation):**
+```bash
+export URX_GITHUB_API_KEY=token1,token2,token3
+urx example.com --providers github
+```
+
 ### Summary
 
 | Variable | Provider | Description |
@@ -60,6 +75,7 @@ urx example.com --providers zoomeye
 | `URX_VT_API_KEY` | VirusTotal | VirusTotal API key |
 | `URX_URLSCAN_API_KEY` | URLScan | Optional URLScan API key (the provider also works anonymously) |
 | `URX_ZOOMEYE_API_KEY` | ZoomEye | ZoomEye API key |
+| `URX_GITHUB_API_KEY` | GitHub | GitHub Code Search personal access token |
 
 ### Usage Notes
 

--- a/docs/content/guide/examples.md
+++ b/docs/content/guide/examples.md
@@ -112,7 +112,10 @@ urx example.com --providers wayback,otx
 urx example.com --providers wayback,cc,otx,arquivo,urlscan
 
 # All available providers (with API keys)
-urx example.com --providers wayback,cc,otx,arquivo,vt,urlscan,zoomeye
+urx example.com --providers wayback,cc,otx,arquivo,vt,urlscan,zoomeye,github
+
+# Or enable everything at once (keyed providers activate only when a key is present)
+urx example.com --all-providers
 ```
 
 ### With API Keys


### PR DESCRIPTION
While reviewing the `docs/` content against the actual source, I found several places where the docs describe behavior the code does not implement, plus the `github` provider missing entirely from the reference docs.

## Factual errors fixed

**`configuration.md` documented config keys that the loader silently ignores** (there is no `deny_unknown_fields`, so these did nothing):
- `normalize_url` under `[output]` — not a field of `OutputConfig`. The real streaming key `stream` was undocumented; swapped it in.
- top-level `verbose` / `silent` / `no_progress` — no `[display]` section or fields exist; these are CLI-only flags. Removed them (including a `silent = true` in the Redis monitoring example) and added a note.
- `strict` under `[filter]` — not a field of `FilterConfig`; host validation is CLI-only (`--strict` / `--no-strict`). Removed it.

Also documented the real-but-missing provider keys: the `from`/`to`/`archive_*` CDX filters and `github_api_key`, and corrected the `format` comment to include `jsonl`.

## Missing documentation added

- **GitHub provider** (`github`, requires a key via `--github-api-key` / `URX_GITHUB_API_KEY`) is in the provider catalog but was absent from the provider table (`cli-options.md`), the env-vars page, and the examples. Added everywhere.
- `cli-options.md`: added the `--no-color` and `--no-strict` flags, the `providers,testers` network-scope value, and completed the filter-preset table (7 of 13 presets were missing: the `no-*`/`only-*` fonts, documents, videos, plus `only-images`).

All changes are content-only in `docs/content/guide/`. Verified each key/flag/preset against `src/config/mod.rs`, `src/cli/mod.rs`, `src/app/catalog.rs`, and `src/filters/preset.rs`.