### PR TITLE
fix(providers): stop discovery providers reporting failed scans as clean empty results

### DIFF
--- a/src/providers/robots.rs
+++ b/src/providers/robots.rs
@@ -81,6 +81,59 @@ impl RobotsProvider {
     }
 }
 
+/// What one `/robots.txt` request told us.
+///
+/// The distinction between the last two variants is the whole point: a host
+/// that answers "404" has told us there is no robots.txt (a real, successful
+/// answer with zero URLs), while a host we could not connect to has told us
+/// nothing at all — and reporting that as a clean zero-URL success hides a
+/// failed scan behind a ✓.
+enum RobotsFetch {
+    /// 2xx, and the body was read.
+    Body(String),
+    /// The host answered, but there is no robots.txt to read (non-2xx).
+    Absent,
+    /// We never got a usable answer: DNS/connect/TLS failure, a timeout, or a
+    /// body that died mid-read.
+    Failed(anyhow::Error),
+}
+
+/// Issue one robots.txt request, classifying the outcome for the caller.
+async fn fetch_robots(client: &Client, url: &str, limiter: Option<&RateLimiter>) -> RobotsFetch {
+    if let Some(rl) = limiter {
+        rl.acquire().await;
+    }
+    match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            match read_body_capped(resp, MAX_ROBOTS_BYTES).await {
+                Ok(text) => RobotsFetch::Body(text),
+                Err(e) => RobotsFetch::Failed(e),
+            }
+        }
+        Ok(_) => RobotsFetch::Absent,
+        Err(e) => RobotsFetch::Failed(e.into()),
+    }
+}
+
+/// Resolve a `Sitemap:` value into an absolute http(s) URL.
+///
+/// RFC 9309 says the value is an absolute URL, but relative values
+/// (`/sitemap.xml`, `sitemap.xml`) are common in the wild and were emitted
+/// verbatim — `/sitemap.xml` is not a URL, so it was dropped in host validation
+/// and the sitemap it pointed at was silently lost. Resolving against the
+/// robots.txt we actually fetched is exactly what a crawler does.
+///
+/// Anything that doesn't resolve to http(s) (`javascript:`, `ftp:`, junk) is
+/// dropped rather than emitted as a "URL" nothing downstream can fetch.
+fn resolve_sitemap_value(protocol: &str, domain: &str, value: &str) -> Option<String> {
+    let base = url::Url::parse(&format!("{protocol}://{domain}/robots.txt")).ok()?;
+    let joined = base.join(value).ok()?;
+    match joined.scheme() {
+        "http" | "https" => Some(joined.into()),
+        _ => None,
+    }
+}
+
 #[async_trait]
 impl Provider for RobotsProvider {
     fn clone_box(&self) -> Box<dyn Provider> {
@@ -107,58 +160,65 @@ impl Provider for RobotsProvider {
 
             let mut urls = Vec::new();
 
-            // Try HTTPS first
-            if let Some(rl) = &limiter {
-                rl.acquire().await;
+            // Whether *either* scheme managed to get an answer out of the host.
+            // A 404 counts: it means "this host has no robots.txt", which is a
+            // successful scan with zero URLs. Nothing at all means we never
+            // reached the host, and the run must report that as an error rather
+            // than as a clean, empty success.
+            let mut host_answered = false;
+            let mut https_error: Option<anyhow::Error> = None;
+            let mut http_error: Option<anyhow::Error> = None;
+            let mut body: Option<(&str, String)> = None;
+
+            // Try HTTPS first.
+            match fetch_robots(&client, &https_url, limiter).await {
+                RobotsFetch::Body(text) => body = Some(("https", text)),
+                RobotsFetch::Absent => host_answered = true,
+                RobotsFetch::Failed(e) => https_error = Some(e),
             }
-            let https_resp = client.get(&https_url).send().await;
-            // Track which protocol was successful
-            let (is_https, text) = match https_resp {
-                // A body that dies mid-read is "no robots.txt" for our purposes,
-                // not a fatal error — same best-effort contract as the HTTP
-                // fallback below.
-                Ok(resp) if resp.status().is_success() => {
-                    match read_body_capped(resp, MAX_ROBOTS_BYTES).await {
-                        Ok(text) => (true, text),
-                        Err(_) => return Ok(urls),
-                    }
+
+            if body.is_none() {
+                // If HTTPS didn't produce a robots.txt, try HTTP.
+                #[cfg(not(test))]
+                let http_url = format!("http://{domain}/robots.txt");
+
+                #[cfg(test)]
+                let http_url = if !self.base_url_http.is_empty() {
+                    format!("{}/robots.txt", self.base_url_http)
+                } else if !self.base_url.is_empty() {
+                    format!("{}/robots.txt", self.base_url)
+                } else {
+                    format!("http://{domain}/robots.txt")
+                };
+
+                match fetch_robots(&client, &http_url, limiter).await {
+                    RobotsFetch::Body(text) => body = Some(("http", text)),
+                    RobotsFetch::Absent => host_answered = true,
+                    RobotsFetch::Failed(e) => http_error = Some(e),
                 }
-                _ => {
-                    // If HTTPS fails, try HTTP
-                    #[cfg(not(test))]
-                    let http_url = format!("http://{domain}/robots.txt");
+            }
 
-                    #[cfg(test)]
-                    let http_url = if !self.base_url_http.is_empty() {
-                        format!("{}/robots.txt", self.base_url_http)
-                    } else if !self.base_url.is_empty() {
-                        format!("{}/robots.txt", self.base_url)
-                    } else {
-                        format!("http://{domain}/robots.txt")
+            // Use the protocol that worked.
+            let (protocol, text) = match body {
+                Some(found) => found,
+                // The host answered over at least one scheme and said there is
+                // no robots.txt — an empty result, not a failure.
+                None if host_answered => return Ok(urls),
+                // Neither scheme ever got an answer: DNS failure, refused
+                // connection, TLS failure, timeout. Surface it so `--stats`
+                // counts an error instead of showing "0 urls, 0 errors".
+                None => {
+                    let detail = match (https_error, http_error) {
+                        (Some(https), Some(http)) => format!("https: {https}; http: {http}"),
+                        (Some(https), None) => format!("https: {https}"),
+                        (None, Some(http)) => format!("http: {http}"),
+                        (None, None) => "no response".to_string(),
                     };
-
-                    // robots.txt discovery is best-effort: a transport failure
-                    // on the HTTP fallback means "no robots.txt", not a fatal
-                    // error that should sink the whole provider.
-                    if let Some(rl) = &limiter {
-                        rl.acquire().await;
-                    }
-                    let http_resp = match client.get(&http_url).send().await {
-                        Ok(resp) => resp,
-                        Err(_) => return Ok(urls),
-                    };
-                    if !http_resp.status().is_success() {
-                        return Ok(urls);
-                    }
-                    match read_body_capped(http_resp, MAX_ROBOTS_BYTES).await {
-                        Ok(text) => (false, text),
-                        Err(_) => return Ok(urls),
-                    }
+                    return Err(anyhow::anyhow!(
+                        "could not fetch robots.txt for {domain} ({detail})"
+                    ));
                 }
             };
-
-            // Use the protocol that worked
-            let protocol = if is_https { "https" } else { "http" };
 
             for line in text.lines() {
                 if urls.len() >= MAX_ROBOTS_ENTRIES {
@@ -203,7 +263,12 @@ impl Provider for RobotsProvider {
                         }
                     }
                     "sitemap" if !value.is_empty() => {
-                        urls.push(value.to_string());
+                        // Resolved rather than pushed verbatim: a relative
+                        // `Sitemap: /sitemap.xml` is not a URL, and a
+                        // non-http(s) value is not one urx can fetch.
+                        if let Some(resolved) = resolve_sitemap_value(protocol, domain, value) {
+                            urls.push(resolved);
+                        }
                     }
                     _ => {}
                 }
@@ -608,6 +673,133 @@ Sitemap: https://example.com/sitemap.xml
             "entry count must be bounded, got {}",
             urls.len()
         );
+    }
+
+    #[tokio::test]
+    async fn test_unreachable_host_is_an_error_not_an_empty_success() {
+        // Regression: every transport failure was swallowed into `Ok(vec![])`,
+        // so a run against a host urx could not connect to at all reported
+        // "Robots.txt  0 urls  0 errors" in --stats — a failed scan wearing a ✓.
+        // Point both schemes at a closed port so `send()` fails outright.
+        let dead = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener); // nothing is listening on `addr` now
+            format!("http://{addr}")
+        };
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(dead.clone());
+        provider.with_http_base_url(dead);
+        provider.with_timeout(5);
+
+        let err = provider
+            .fetch_urls("example.com")
+            .await
+            .expect_err("an unreachable host must be reported as an error");
+        assert!(
+            err.to_string().contains("could not fetch robots.txt"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_robots_txt_is_a_success_with_zero_urls() {
+        // The other side of the line above: a host that answers 404 has told us
+        // there is no robots.txt. That is a completed scan with no URLs, and it
+        // must stay an `Ok`, not become an error.
+        let mut https = mockito::Server::new_async().await;
+        let mut http = mockito::Server::new_async().await;
+        let _m1 = https
+            .mock("GET", "/robots.txt")
+            .with_status(404)
+            .create_async()
+            .await;
+        let _m2 = http
+            .mock("GET", "/robots.txt")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(https.url());
+        provider.with_http_base_url(http.url());
+
+        let urls = provider
+            .fetch_urls("example.com")
+            .await
+            .expect("a 404 robots.txt is an empty result, not an error");
+        assert!(urls.is_empty(), "{urls:?}");
+    }
+
+    #[tokio::test]
+    async fn test_https_404_with_unreachable_http_fallback_is_still_a_success() {
+        // HTTPS reached the host and said "no robots.txt". The HTTP fallback
+        // failing to connect doesn't change that answer, so this stays Ok.
+        let mut https = mockito::Server::new_async().await;
+        let _m = https
+            .mock("GET", "/robots.txt")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let dead = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            format!("http://{addr}")
+        };
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(https.url());
+        provider.with_http_base_url(dead);
+
+        assert!(provider.fetch_urls("example.com").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_relative_sitemap_directives_are_resolved() {
+        // Regression: relative `Sitemap:` values were emitted verbatim, so
+        // `/sitemap.xml` left the provider as the literal string "/sitemap.xml".
+        // It isn't a URL, so host validation dropped it and the sitemap it
+        // pointed at was silently lost.
+        let mut server = mockito::Server::new_async().await;
+        let robots = "User-agent: *\n\
+                      Sitemap: /sitemap.xml\n\
+                      Sitemap: sitemaps/extra.xml\n\
+                      Sitemap: https://cdn.example.com/absolute.xml\n\
+                      Sitemap: javascript:alert(1)\n";
+        let _m = server
+            .mock("GET", "/robots.txt")
+            .with_status(200)
+            .with_body(robots)
+            .create_async()
+            .await;
+
+        let mut provider = RobotsProvider::new();
+        provider.with_base_url(server.url());
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+
+        assert!(
+            urls.contains(&"https://example.com/sitemap.xml".to_string()),
+            "{urls:?}"
+        );
+        assert!(
+            urls.contains(&"https://example.com/sitemaps/extra.xml".to_string()),
+            "{urls:?}"
+        );
+        // An absolute value is spec-legal cross-submission and is kept as-is.
+        assert!(
+            urls.contains(&"https://cdn.example.com/absolute.xml".to_string()),
+            "{urls:?}"
+        );
+        // A non-http(s) value is not something urx can fetch.
+        assert!(
+            !urls.iter().any(|u| u.starts_with("javascript:")),
+            "{urls:?}"
+        );
+        // Nothing may leave the provider as a bare path.
+        assert!(urls.iter().all(|u| u.starts_with("http")), "{urls:?}");
     }
 
     #[tokio::test]

--- a/src/providers/sitemap.rs
+++ b/src/providers/sitemap.rs
@@ -49,6 +49,21 @@ fn same_host_as_parent(parent: &str, child: &str) -> bool {
     }
 }
 
+/// State threaded through one domain's sitemap walk.
+#[derive(Default)]
+struct Walk {
+    /// Sitemap URLs already fetched, so a cycle (`A → A`, `A → B → A`) or a
+    /// sitemap reachable from two entry points is fetched at most once.
+    visited: HashSet<String>,
+    /// Set once any request produced a definitive answer — a body we read, or
+    /// an HTTP status saying there is nothing at this location. This is what
+    /// separates "this host has no sitemap" (a successful scan with zero URLs)
+    /// from "we never reached this host at all" (an error the run must report).
+    answered: bool,
+    /// The last transport-level failure, surfaced when nothing ever answered.
+    failure: Option<anyhow::Error>,
+}
+
 #[derive(Clone)]
 pub struct SitemapProvider {
     timeout: Duration,
@@ -91,7 +106,7 @@ impl SitemapProvider {
 
     /// Recursively fetch and parse a sitemap (or sitemap index).
     ///
-    /// `visited` records already-fetched sitemap URLs to break cycles
+    /// `walk.visited` records already-fetched sitemap URLs to break cycles
     /// (`A → A`, `A → B → A`); `depth` bounds straight-line nesting; and the
     /// caller stops feeding work once [`MAX_SITEMAP_URLS`] is reached. Together
     /// these stop a malicious sitemap from hanging the run or exhausting memory.
@@ -100,14 +115,14 @@ impl SitemapProvider {
         client: &Client,
         sitemap_url: &str,
         depth: usize,
-        visited: &mut HashSet<String>,
+        walk: &mut Walk,
         limiter: Option<&RateLimiter>,
     ) -> Result<Vec<String>> {
         if depth > MAX_SITEMAP_DEPTH {
             return Ok(Vec::new());
         }
         // A sitemap URL we've already fetched in this walk is a cycle — skip it.
-        if !visited.insert(sitemap_url.to_string()) {
+        if !walk.visited.insert(sitemap_url.to_string()) {
             return Ok(Vec::new());
         }
 
@@ -117,14 +132,22 @@ impl SitemapProvider {
             rl.acquire().await;
         }
         // Sitemap discovery is best-effort and speculative: most of the
-        // candidate locations we probe don't exist. A transport failure or a
-        // non-200 means "nothing here", not an error that should sink the whole
-        // provider — the `visited` insert above already stops us re-asking.
+        // candidate locations we probe don't exist, so a single location that
+        // isn't there means "nothing here", not an error that should sink the
+        // whole provider — the `visited` insert above already stops us re-asking.
+        //
+        // A transport failure is different in kind from a non-200 and is
+        // recorded as such: if *no* location ever answered, the caller turns
+        // that into a real error rather than an empty success.
         let resp = match client.get(sitemap_url).send().await {
             Ok(resp) => resp,
-            Err(_) => return Ok(Vec::new()),
+            Err(e) => {
+                walk.failure = Some(e.into());
+                return Ok(Vec::new());
+            }
         };
         if !resp.status().is_success() {
+            walk.answered = true;
             return Ok(Vec::new());
         }
 
@@ -144,8 +167,12 @@ impl SitemapProvider {
             Ok(content) => content,
             // A body that dies mid-stream yields no usable URLs; same
             // best-effort reasoning as above.
-            Err(_) => return Ok(Vec::new()),
+            Err(e) => {
+                walk.failure = Some(e);
+                return Ok(Vec::new());
+            }
         };
+        walk.answered = true;
         let mut urls = Vec::new();
 
         match Document::parse(&content) {
@@ -175,7 +202,7 @@ impl SitemapProvider {
                                     client,
                                     nested_sitemap_url.trim(),
                                     depth + 1,
-                                    visited,
+                                    walk,
                                     limiter,
                                 ))
                                 .await?;
@@ -193,7 +220,17 @@ impl SitemapProvider {
                             url_node.descendants().find(|n| n.has_tag_name("loc"))
                         {
                             if let Some(url) = loc_node.text() {
-                                urls.push(url.to_string());
+                                // Trimmed, like the sitemap-index branch above:
+                                // XML lets a pretty-printed
+                                // `<loc>\n  https://…\n</loc>` carry the
+                                // surrounding indentation into the text node,
+                                // and the newlines rode along into the emitted
+                                // URL — which then failed host validation, so
+                                // every URL of such a sitemap was silently lost.
+                                let url = url.trim();
+                                if !url.is_empty() {
+                                    urls.push(url.to_string());
+                                }
                             }
                         }
                     }
@@ -236,8 +273,9 @@ impl Provider for SitemapProvider {
             let limiter = self.rate_limit.as_ref();
             let mut urls = Vec::new();
             // Shared across all candidate locations so a sitemap reachable from
-            // more than one entry point is fetched at most once.
-            let mut visited = HashSet::new();
+            // more than one entry point is fetched at most once, and so
+            // reachability is judged over the whole set of probes.
+            let mut walk = Walk::default();
 
             // Try common sitemap locations
             let sitemap_urls = vec![
@@ -257,8 +295,22 @@ impl Provider for SitemapProvider {
             // to six candidate locations stay rate-limited.
             for sitemap_url in sitemap_urls {
                 let found =
-                    Self::parse_sitemap(&client, &sitemap_url, 0, &mut visited, limiter).await?;
+                    Self::parse_sitemap(&client, &sitemap_url, 0, &mut walk, limiter).await?;
                 urls.extend(found);
+            }
+
+            // Not one of the candidate locations produced an HTTP response —
+            // DNS failure, refused connection, TLS failure, timeout. That is a
+            // failed scan, and returning `Ok(vec![])` for it made `--stats`
+            // print "Sitemap  0 urls  0 errors", indistinguishable from a host
+            // that simply publishes no sitemap.
+            if !walk.answered {
+                return Err(match walk.failure {
+                    Some(e) => {
+                        anyhow::anyhow!("could not reach {domain} to look for a sitemap: {e}")
+                    }
+                    None => anyhow::anyhow!("could not reach {domain} to look for a sitemap"),
+                });
             }
 
             // The https and http candidates are distinct sitemap URLs, so
@@ -765,5 +817,82 @@ mod tests {
         assert!(result.is_ok());
         let urls = result.unwrap();
         assert!(urls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unreachable_host_is_an_error_not_an_empty_success() {
+        // Regression: every transport failure was swallowed into `Ok(vec![])`,
+        // so a run against a host urx could not connect to at all reported
+        // "Sitemap  0 urls  0 errors" in --stats — a failed scan wearing a ✓.
+        // Bind a port, drop the listener: nothing answers on it.
+        let addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            addr
+        };
+
+        let mut provider = SitemapProvider::new();
+        provider.with_timeout(5);
+        let err = provider
+            .fetch_urls(&addr.to_string())
+            .await
+            .expect_err("an unreachable host must be reported as an error");
+        assert!(err.to_string().contains("could not reach"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_host_with_no_sitemap_is_a_success_with_zero_urls() {
+        // The other side of the line above: a host that answers 404 at every
+        // candidate location has told us it publishes no sitemap. That is a
+        // completed scan with zero URLs and must stay an `Ok`.
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+        let _m = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        let urls = provider
+            .fetch_urls(&host)
+            .await
+            .expect("a host without a sitemap is an empty result, not an error");
+        assert!(urls.is_empty(), "{urls:?}");
+    }
+
+    #[tokio::test]
+    async fn test_pretty_printed_loc_values_are_trimmed() {
+        // Regression: XML keeps the indentation inside a pretty-printed
+        // `<loc>\n  https://…\n</loc>`, and the surrounding whitespace rode
+        // along into the emitted URL. Such a "URL" fails host validation, so
+        // every URL of a pretty-printed sitemap was silently dropped.
+        let mut server = Server::new_async().await;
+        let host = server.host_with_port();
+        let _m = server
+            .mock("GET", "/sitemap.xml")
+            .with_status(200)
+            .with_header("content-type", "application/xml")
+            .with_body(
+                "<?xml version=\"1.0\"?>\n\
+<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n\
+  <url>\n    <loc>\n      https://example.com/pretty\n    </loc>\n  </url>\n\
+  <url>\n    <loc>   </loc>\n  </url>\n\
+</urlset>",
+            )
+            .create_async()
+            .await;
+
+        let provider = SitemapProvider::new();
+        let urls = provider.fetch_urls(&host).await.unwrap();
+
+        assert_eq!(urls, vec!["https://example.com/pretty".to_string()]);
+        // Belt and braces: nothing we emit may carry stray whitespace.
+        for u in &urls {
+            assert_eq!(u.trim(), u, "{u:?}");
+            assert!(url::Url::parse(u).is_ok(), "{u:?}");
+        }
     }
 }

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -160,6 +160,11 @@ impl Provider for ZoomEyeProvider {
             let mut all_urls: Vec<String> = Vec::new();
             let mut page: u32 = 1;
             let pagesize: u32 = 100;
+            // Rows actually received, counted before we drop the ones without a
+            // `url`. Progress against `total` must be measured from what the
+            // server sent, not from the page size we asked for — see the stop
+            // condition at the bottom of the loop.
+            let mut rows_received: u64 = 0;
 
             loop {
                 let request_body = ZoomEyeRequest {
@@ -172,6 +177,7 @@ impl Provider for ZoomEyeProvider {
                 let mut last_error = None;
                 let mut attempt = 0;
                 let mut page_urls: Vec<String> = Vec::new();
+                let mut page_rows: u64 = 0;
                 let mut total: u64 = 0;
 
                 while attempt <= self.retries {
@@ -220,6 +226,7 @@ impl Provider for ZoomEyeProvider {
                                         break;
                                     }
                                     total = zoomeye_response.total;
+                                    page_rows = zoomeye_response.data.len() as u64;
                                     for entry in zoomeye_response.data {
                                         if !entry.url.is_empty() {
                                             page_urls.push(entry.url);
@@ -269,17 +276,24 @@ impl Provider for ZoomEyeProvider {
 
                 // A page that returned no rows means the data is exhausted even
                 // if `total` claims otherwise — stop rather than loop on a stale
-                // count.
-                let page_was_empty = page_urls.is_empty();
+                // count. Judged on the rows the server sent, not on the URLs we
+                // kept: a page whose rows all lack a `url` is still a page of
+                // data, and treating it as the end truncated the walk.
+                let page_was_empty = page_rows == 0;
+                rows_received += page_rows;
                 all_urls.extend(page_urls);
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", all_urls.len()));
                 }
 
-                // Check if there are more pages
-                let fetched_so_far = (page as u64) * (pagesize as u64);
-                if page_was_empty || fetched_so_far >= total || page >= ZOOMEYE_MAX_PAGES {
+                // Check if there are more pages. `rows_received` is what the
+                // server actually returned; the old code assumed every page held
+                // exactly `pagesize` rows, so a server that clamps the page size
+                // below what we asked for (plan limits, or its own cap) made urx
+                // believe it had seen `page * 100` results and stop after a
+                // fraction of them.
+                if page_was_empty || rows_received >= total || page >= ZOOMEYE_MAX_PAGES {
                     break;
                 }
 
@@ -673,6 +687,95 @@ mod tests {
         provider.with_retries(0);
 
         assert!(provider.fetch_urls("example.com").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_pagination_counts_rows_returned_not_the_requested_page_size() {
+        // Regression: progress against `total` was computed as `page * 100`,
+        // the page size urx *asks* for. A server that returns fewer rows per
+        // page than requested — ZoomEye clamps by plan — made urx believe it
+        // had already seen 100 results after a 10-row page, so it stopped after
+        // 3 pages of a 25-result set and dropped the rest.
+        let mut mock_server = mockito::Server::new_async().await;
+
+        // 25 results served 10 rows at a time: pages 1 and 2 full, page 3 short.
+        for (page, range) in [(1u32, 0..10u32), (2, 10..20), (3, 20..25)] {
+            let rows: Vec<String> = range
+                .map(|i| {
+                    format!(
+                        r#"{{"url":"https://example.com/{i}","ip":"1.2.3.4","domain":"example.com","port":443,"title":"t"}}"#
+                    )
+                })
+                .collect();
+            mock_server
+                .mock("POST", "/v2/search")
+                .match_body(mockito::Matcher::PartialJsonString(format!(
+                    r#"{{"page":{page}}}"#
+                )))
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(format!(
+                    r#"{{ "code": 60000, "total": 25, "data": [{}] }}"#,
+                    rows.join(",")
+                ))
+                .create_async()
+                .await;
+        }
+
+        let mut provider = ZoomEyeProvider::new("test_api_key".to_string());
+        provider.with_base_url(mock_server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls.len(), 25, "walk stopped early: {}", urls.len());
+        assert!(urls.contains(&"https://example.com/24".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_pagination_continues_past_a_page_whose_rows_all_lack_a_url() {
+        // A page of rows without a usable `url` is still a page of data. It used
+        // to read as "no more results" because emptiness was judged after the
+        // rows were filtered, halting the walk before the rest of the set.
+        let mut mock_server = mockito::Server::new_async().await;
+
+        let blank: Vec<String> = (0..2)
+            .map(|_| {
+                r#"{"url":"","ip":"1.2.3.4","domain":"example.com","port":80,"title":""}"#
+                    .to_string()
+            })
+            .collect();
+        let _p1 = mock_server
+            .mock("POST", "/v2/search")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"page":1}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{ "code": 60000, "total": 3, "data": [{}] }}"#,
+                blank.join(",")
+            ))
+            .create_async()
+            .await;
+        let _p2 = mock_server
+            .mock("POST", "/v2/search")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"page":2}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{ "code": 60000, "total": 3, "data": [
+                    {"url":"https://example.com/kept","ip":"1.2.3.4","domain":"example.com","port":443,"title":"t"}
+                ] }"#,
+            )
+            .create_async()
+            .await;
+
+        let mut provider = ZoomEyeProvider::new("test_api_key".to_string());
+        provider.with_base_url(mock_server.url());
+
+        let urls = provider.fetch_urls("example.com").await.unwrap();
+        assert_eq!(urls, vec!["https://example.com/kept".to_string()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Four defects in the API/discovery providers, each with a mockito-backed regression test that fails on `main` and passes here.

`cargo fmt --all` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --bin urx` green (647 passed).

---

## 1. robots.txt discovery reports an unreachable host as a clean, empty success

**Symptom.** With the target host unreachable, `--stats` prints `Robots.txt  0 urls  0 errors` — a failed scan wearing a ✓, indistinguishable from a host that simply publishes no robots.txt.

**Repro** (a closed local port stands in for any unreachable host):

```
PORT=$(python3 -c "import socket;s=socket.socket();s.bind(('127.0.0.1',0));print(s.getsockname()[1]);s.close()")
./target/debug/urx "127.0.0.1:$PORT" --providers robots,sitemap --stats --no-progress --no-cache --timeout 5
```

Before:
```
  provider                urls   partial   errors     elapsed
  Robots.txt                 0         0        0        12ms
  Sitemap                    0         0        0        16ms
```
After:
```
  provider                urls   partial   errors     elapsed
  Robots.txt                 0         0        1        26ms
  Sitemap                    0         0        1        25ms
```

**Root cause.** `src/providers/robots.rs:114-157` (pre-fix). Every failure path — `send()` erroring on HTTPS *and* on the HTTP fallback, a body dying mid-read, a non-2xx status — funnelled into the same `return Ok(urls)` with `urls` empty. The runner counts `Ok` as a success (`src/runner/mod.rs:400`) and only `Err` as an error (`src/runner/mod.rs:496`), so nothing was ever counted.

**Fix.** A `RobotsFetch` enum classifies each request as `Body` / `Absent` (the host answered, no robots.txt) / `Failed` (we never got an answer). `Absent` from either scheme still returns `Ok(vec![])`; only "neither scheme ever got a response" becomes an `Err`. This keeps the sanity check green — a host that 404s its robots.txt is still a successful zero-URL scan — while a genuine connect/DNS/TLS failure is now counted.

Tests: `test_unreachable_host_is_an_error_not_an_empty_success`, `test_missing_robots_txt_is_a_success_with_zero_urls`, `test_https_404_with_unreachable_http_fallback_is_still_a_success`.

## 2. Sitemap discovery does the same

**Symptom / repro.** Same command as above; `Sitemap  0 urls  0 errors` against a host nothing can connect to.

**Root cause.** `src/providers/sitemap.rs:118-127` (pre-fix): `parse_sitemap` returned `Ok(Vec::new())` for a `send()` error, a non-200, and a body read failure alike, and `fetch_urls` had no way to tell the six speculative candidate locations "all 404" apart from "none connected".

**Fix.** A `Walk` struct (which also now carries the existing `visited` cycle-breaker) records `answered` — set when any probe produced an HTTP response of any status — and the last transport `failure`. After the six candidates, `!walk.answered` returns an `Err`. A 404 at every location still returns `Ok(vec![])`.

Tests: `test_unreachable_host_is_an_error_not_an_empty_success`, `test_host_with_no_sitemap_is_a_success_with_zero_urls`.

## 3. Relative `Sitemap:` directives in robots.txt are emitted as non-URLs

**Symptom.** A robots.txt containing `Sitemap: /sitemap.xml` made the provider emit the literal string `/sitemap.xml`. It isn't a URL, so host validation dropped it — the sitemap it pointed at was silently lost. `Sitemap: javascript:alert(1)` was emitted too.

**Repro.** Serve `User-agent: *\nSitemap: /sitemap.xml\n` at `/robots.txt`; before the fix the provider returns `["/sitemap.xml", …]` (see the test's pre-fix output: `["/sitemap.xml", "https://cdn.example.com/absolute.xml", "javascript:alert(1)", "sitemaps/extra.xml"]`).

**Root cause.** `src/providers/robots.rs:206-208` (pre-fix): `urls.push(value.to_string())` with no resolution or scheme check. RFC 9309 does require an absolute URL here, but relative values are common in the wild and a crawler resolves them.

**Fix.** `resolve_sitemap_value` joins the value against the robots.txt actually fetched (`{protocol}://{domain}/robots.txt`) and keeps only http/https results. Absolute values — including spec-legal cross-host submission — pass through unchanged.

Test: `test_relative_sitemap_directives_are_resolved`.

## 4. `<loc>` whitespace is not trimmed in the `<urlset>` branch

**Symptom.** A pretty-printed sitemap (`<loc>\n      https://example.com/pretty\n    </loc>`) yielded `"\n      https://example.com/pretty\n    "`. Every URL from such a sitemap failed host validation and was silently dropped.

**Repro.** The regression test's pre-fix output: `left: ["\n      https://example.com/pretty\n    ", "   "]`.

**Root cause.** `src/providers/sitemap.rs:186-190` (pre-fix): `urls.push(url.to_string())` on `loc_node.text()`, which in XML carries the surrounding indentation. The sibling `<sitemapindex>` branch already called `.trim()` on its `<loc>` — this was the inconsistent half.

**Fix.** Trim, and skip a `<loc>` that is only whitespace.

Test: `test_pretty_printed_loc_values_are_trimmed`.

## 5. ZoomEye stops paginating after a fraction of the result set

**Symptom.** For a 25-result set served 10 rows per page, urx returned 10 of 25.

**Repro.** `test_pagination_counts_rows_returned_not_the_requested_page_size` — mock returns `total: 25` with 10/10/5 rows across three pages. Pre-fix: `walk stopped early: 10`.

**Root cause.** `src/providers/zoomeye.rs:274-275` (pre-fix): `let fetched_so_far = (page as u64) * (pagesize as u64);` — progress against `total` was measured from the page size urx *asks* for (100), not what the server returned. A server that clamps the page size below the request (ZoomEye clamps by plan/quota) made urx believe it had seen 100 results after a 10-row page. A second, related bug on the adjacent line: `page_was_empty` was computed from `page_urls` *after* rows without a `url` were filtered out, so a page of such rows read as "no more results" and halted the walk.

**Fix.** Accumulate `rows_received` from `data.len()` before filtering, and compare that against `total`; judge emptiness on rows the server sent.

Tests: `test_pagination_counts_rows_returned_not_the_requested_page_size`, `test_pagination_continues_past_a_page_whose_rows_all_lack_a_url`.

---

## Verification notes

This box's sandbox answers blocked hosts with HTTP 404 rather than refusing the connection, so a plain `urx example.com --providers robots,sitemap` exercises the *success* path (404 → zero URLs, zero errors) and cannot demonstrate bug 1/2 at the CLI. The repro above points at a bound-then-closed local port to get a real connection refusal; the unit tests do the same (bind `127.0.0.1:0`, drop the listener). No test touches a live third-party API.

## Out-of-scope findings

Not fixed — outside my file ownership:

- **`src/app/` — usage error exits 0.** `urx` with no domains prints "No domains provided…" and exits `0`. A CLI should exit non-zero on a usage error. (Orchestrator already noted this; flagging that it is not in `src/providers/`.)
- **`src/runner/mod.rs:395-401` — `--max-time` abort accounting.** When the deadline aborts an in-flight fetch, the provider is reported `0ms elapsed / partial 0 / errors 0`. `fetch_elapsed` is only recorded on the `Ok`/`Err` arms, so an aborted future contributes nothing; real wall time was the full `--max-time`. Owned by a6-runner-net.
- **`src/network/client.rs:106-120` — `read_body_capped` truncates silently.** When a body exceeds `max` it stops mid-stream and returns `Ok` with the partial text. Callers cannot tell a complete small body from a truncated huge one, so a capped sitemap/robots.txt parses as if it were the whole document. Returning a "truncated" signal would let the providers mark those results partial.
- **`src/providers/vt.rs` and `src/providers/urlscan.rs` — `include_subdomains` is stored but never read**, so `--subs` has no effect on either provider. Left alone because fixing it means changing the query sent to a third-party API I can't verify against from here; worth a look by someone who can.
