### PR TITLE
fix(output,readers,cache): broken-pipe panic, CSV injection, multi-member gzip data loss, Redis TTL overflow

### DIFF
--- a/src/cache/redis_impl.rs
+++ b/src/cache/redis_impl.rs
@@ -131,7 +131,11 @@ impl CacheBackend for RedisCache {
             .await
             .context("Failed to connect to Redis")?;
 
-        let cutoff_time = Utc::now() - chrono::Duration::seconds(ttl_seconds as i64);
+        // `Duration::seconds` panics past its bounds and `ttl_seconds as i64`
+        // wraps a huge TTL negative, which would push the cutoff into the future
+        // and wipe every entry. The SQLite backend already guards this; share
+        // the same helper so the two cannot diverge again.
+        let cutoff_time = super::types::expiry_cutoff(ttl_seconds);
 
         // Get all metadata keys
         let meta_keys: Vec<String> = redis::cmd("KEYS")

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -169,15 +169,9 @@ impl CacheBackend for SqliteCache {
     }
 
     async fn cleanup_expired(&self, ttl_seconds: u64) -> Result<()> {
-        // `chrono::Duration::seconds` panics past ~2.9e11 years, and `--cache-ttl`
-        // is a plain u64 straight off the command line — a large one crashed the
-        // run at cleanup time. Saturate instead: a TTL that long means "never
-        // expire", and `checked_sub` then leaves the cutoff at the earliest
-        // representable time so nothing is deleted.
-        let cutoff_time = chrono::Duration::try_seconds(ttl_seconds.min(i64::MAX as u64) as i64)
-            .and_then(|d| Utc::now().checked_sub_signed(d))
-            .unwrap_or(DateTime::<Utc>::MIN_UTC);
-        let cutoff_str = cutoff_time.to_rfc3339();
+        // See `expiry_cutoff`: `--cache-ttl` is an unvalidated u64 and the raw
+        // chrono conversion either panics or wraps into the future.
+        let cutoff_str = super::types::expiry_cutoff(ttl_seconds).to_rfc3339();
 
         self.with_connection(move |conn| {
             let deleted = conn.execute(

--- a/src/cache/types.rs
+++ b/src/cache/types.rs
@@ -151,6 +151,21 @@ impl CacheFilters {
     }
 }
 
+/// The instant before which an entry counts as expired, for a TTL in seconds.
+///
+/// `--cache-ttl` is an unvalidated `u64` (and callers double it for the cleanup
+/// sweep), so the value routinely exceeds what `chrono::Duration` accepts:
+/// `Duration::seconds` *panics* past its bounds, and casting a huge `u64` to
+/// `i64` wraps negative, which puts the cutoff in the *future* and makes a
+/// cleanup delete the entire cache. Saturating instead means a TTL that large
+/// reads as "never expire": the cutoff falls back to the earliest representable
+/// instant, which no stored entry precedes.
+pub fn expiry_cutoff(ttl_seconds: u64) -> DateTime<Utc> {
+    chrono::Duration::try_seconds(ttl_seconds.min(i64::MAX as u64) as i64)
+        .and_then(|d| Utc::now().checked_sub_signed(d))
+        .unwrap_or(DateTime::<Utc>::MIN_UTC)
+}
+
 /// Cache entry containing URLs and metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheEntry {
@@ -168,10 +183,16 @@ impl CacheEntry {
     }
 
     /// Check if the cache entry is expired
+    ///
+    /// A negative age — the entry was written by a machine whose clock is ahead,
+    /// or this one's went backwards — is not expiry. Casting it straight to
+    /// `u64` wrapped it to ~1.8e19 seconds, so any such entry looked ancient and
+    /// was deleted on sight.
     pub fn is_expired(&self, ttl_seconds: u64) -> bool {
-        let now = Utc::now();
-        let elapsed = now.signed_duration_since(self.timestamp).num_seconds() as u64;
-        elapsed >= ttl_seconds
+        let elapsed = Utc::now()
+            .signed_duration_since(self.timestamp)
+            .num_seconds();
+        elapsed >= 0 && (elapsed as u64) >= ttl_seconds
     }
 }
 
@@ -273,6 +294,43 @@ mod tests {
         // Simulate old entry
         entry.timestamp = Utc::now() - chrono::Duration::hours(2);
         assert!(entry.is_expired(3600)); // Should be expired
+    }
+
+    #[test]
+    fn test_expiry_cutoff_saturates_instead_of_panicking_or_wrapping() {
+        // `--cache-ttl` is an unvalidated u64 and callers double it. The raw
+        // conversion panics past chrono's bounds, and `u64 as i64` wraps a huge
+        // TTL negative — which puts the cutoff in the *future* and makes a
+        // cleanup sweep delete every entry in the cache.
+        let now = Utc::now();
+        for ttl in [
+            u64::MAX,
+            u64::MAX / 2,
+            10_000_000_000_000_000,
+            i64::MAX as u64,
+        ] {
+            let cutoff = expiry_cutoff(ttl);
+            assert!(
+                cutoff < now,
+                "a huge TTL must never push the cutoff forward: ttl={ttl} cutoff={cutoff}"
+            );
+        }
+
+        // Ordinary TTLs still land where they should.
+        let hour = expiry_cutoff(3600);
+        assert!((now - hour).num_seconds() >= 3599);
+        assert!((now - hour).num_seconds() <= 3601);
+    }
+
+    #[test]
+    fn test_entry_from_the_future_is_not_treated_as_expired() {
+        // Regression: a negative age was cast straight to u64 and wrapped to
+        // ~1.8e19 seconds, so an entry written by a machine whose clock runs
+        // ahead (or after a local clock step back) looked ancient and was
+        // deleted on sight.
+        let mut entry = CacheEntry::new(vec!["https://example.com".to_string()]);
+        entry.timestamp = Utc::now() + chrono::Duration::minutes(5);
+        assert!(!entry.is_expired(3600));
     }
 
     #[test]

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -209,15 +209,41 @@ pub(crate) fn csv_row(url_data: &UrlData, has_status: bool, has_sources: bool) -
     line
 }
 
+/// Leading characters that make a spreadsheet evaluate a cell as a formula
+/// rather than display it. A tab or carriage return counts because Excel strips
+/// it and then looks at the next character.
+const FORMULA_TRIGGERS: [char; 6] = ['=', '+', '-', '@', '\t', '\r'];
+
 /// Escape a field value for CSV output per RFC 4180.
-/// If the value contains a comma, double-quote, or newline, wrap it in
-/// double-quotes and escape any internal double-quotes by doubling them.
+///
+/// A value containing a comma, double-quote, CR or LF is wrapped in
+/// double-quotes with any internal double-quotes doubled. CR matters as much as
+/// LF: a bare `\r` in a field splits the row in Excel and in most spreadsheet
+/// importers, so leaving it unquoted corrupts the table.
+///
+/// A value *starting* with one of [`FORMULA_TRIGGERS`] is additionally prefixed
+/// with an apostrophe. Every field here is archive-controlled — the URL itself,
+/// and under `--show-only-param` a parameter name lifted verbatim out of a
+/// query string — so `=cmd|'/C calc'!A0` reaches the CSV unaltered and executes
+/// when the file is opened. Quoting alone does not stop that; the apostrophe is
+/// the standard mitigation for CSV formula injection (CWE-1236).
 pub(crate) fn csv_escape(value: &str) -> String {
-    if value.contains(',') || value.contains('"') || value.contains('\n') {
-        let escaped = value.replace('"', "\"\"");
-        format!("\"{escaped}\"")
+    let starts_formula = value.starts_with(FORMULA_TRIGGERS);
+    let needs_quoting = starts_formula
+        || value.contains(',')
+        || value.contains('"')
+        || value.contains('\n')
+        || value.contains('\r');
+
+    if !needs_quoting {
+        return value.to_string();
+    }
+
+    let escaped = value.replace('"', "\"\"");
+    if starts_formula {
+        format!("\"'{escaped}\"")
     } else {
-        value.to_string()
+        format!("\"{escaped}\"")
     }
 }
 
@@ -413,6 +439,35 @@ mod tests {
     #[test]
     fn test_csv_escape_with_quote() {
         assert_eq!(csv_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn test_csv_escape_neutralises_formula_triggers() {
+        // Regression: a field starting with a formula trigger reached the CSV
+        // verbatim, so `urx ... --show-only-param -f csv` could emit
+        // `=cmd|'/C calc'!A0=1` and a spreadsheet would execute it on open.
+        for trigger in ['=', '+', '-', '@', '\t', '\r'] {
+            let value = format!("{trigger}cmd|'/C calc'!A0");
+            let escaped = csv_escape(&value);
+            assert!(
+                escaped.starts_with("\"'"),
+                "{value:?} must be neutralised, got {escaped:?}"
+            );
+        }
+        assert_eq!(csv_escape("=1+1"), "\"'=1+1\"");
+        // A trigger anywhere but the start is harmless and left alone.
+        assert_eq!(csv_escape("https://a.com/x=1"), "https://a.com/x=1");
+    }
+
+    #[test]
+    fn test_csv_escape_quotes_carriage_return() {
+        // A bare CR splits the row in Excel and most importers, so it has to be
+        // quoted just like LF.
+        assert_eq!(csv_escape("https://a.com/a\rb"), "\"https://a.com/a\rb\"");
+        assert_eq!(
+            csv_escape("https://a.com/a\r\nb"),
+            "\"https://a.com/a\r\nb\""
+        );
     }
 
     #[test]

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -17,7 +17,7 @@
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::io::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use super::{create_outputter, Outputter, UrlData};
@@ -38,6 +38,10 @@ pub struct StreamSink {
     writer: Mutex<Box<dyn Write + Send>>,
     outputter: Box<dyn Outputter>,
     emitted: AtomicUsize,
+    /// Set once the destination stops accepting writes — `urx --stream | head`
+    /// closes the pipe long before the providers are done. Later batches are
+    /// then dropped instead of re-attempting a write that can only fail again.
+    closed: AtomicBool,
 }
 
 impl StreamSink {
@@ -61,6 +65,7 @@ impl StreamSink {
             writer: Mutex::new(writer),
             outputter: create_outputter(format),
             emitted: AtomicUsize::new(0),
+            closed: AtomicBool::new(false),
         };
 
         // CSV needs its header up front. A streamed run carries neither status
@@ -69,9 +74,15 @@ impl StreamSink {
         if format.eq_ignore_ascii_case("csv") {
             let header = super::formatter::csv_header(false, false);
             let mut w = sink.lock_writer();
-            w.write_all(header.as_bytes())
-                .context("Failed to write CSV header")?;
-            w.flush().context("Failed to flush CSV header")?;
+            let wrote = w
+                .write_all(header.as_bytes())
+                .and_then(|()| w.flush())
+                .map(|()| true)
+                .or_else(broken_pipe_is_ok);
+            drop(w);
+            if !wrote.context("Failed to write CSV header")? {
+                sink.closed.store(true, Ordering::Relaxed);
+            }
         }
 
         Ok(sink)
@@ -95,6 +106,10 @@ impl StreamSink {
     /// buffered, so without an explicit flush a downstream `grep` would see
     /// nothing until the buffer filled — which would defeat the whole point.
     pub fn emit(&self, urls: &[String]) -> Result<usize> {
+        if self.closed.load(Ordering::Relaxed) {
+            return Ok(0);
+        }
+
         let mut batch: Vec<UrlData> = Vec::new();
 
         {
@@ -122,12 +137,23 @@ impl StreamSink {
         }
 
         let mut w = self.lock_writer();
-        for entry in &batch {
-            let formatted = self.outputter.format(entry, false);
-            w.write_all(formatted.as_bytes())
-                .context("Failed to write streamed URL")?;
+        let written = (|| -> std::io::Result<bool> {
+            for entry in &batch {
+                let formatted = self.outputter.format(entry, false);
+                w.write_all(formatted.as_bytes())?;
+            }
+            w.flush()?;
+            Ok(true)
+        })()
+        .or_else(broken_pipe_is_ok);
+        drop(w);
+
+        if !written.context("Failed to write streamed output")? {
+            // `urx --stream | head -1`: the consumer has what it wanted. Stop
+            // emitting quietly instead of failing the whole run.
+            self.closed.store(true, Ordering::Relaxed);
+            return Ok(0);
         }
-        w.flush().context("Failed to flush streamed output")?;
 
         self.emitted.fetch_add(batch.len(), Ordering::Relaxed);
         Ok(batch.len())
@@ -136,6 +162,17 @@ impl StreamSink {
     /// Total URLs written so far.
     pub fn emitted(&self) -> usize {
         self.emitted.load(Ordering::Relaxed)
+    }
+}
+
+/// Map a closed destination onto `Ok(false)` and leave every other I/O error
+/// alone. A downstream `head`/`grep -q` closing the pipe is how a streaming CLI
+/// is normally stopped, not a failure to report.
+fn broken_pipe_is_ok(e: std::io::Error) -> std::io::Result<bool> {
+    if e.kind() == std::io::ErrorKind::BrokenPipe {
+        Ok(false)
+    } else {
+        Err(e)
     }
 }
 
@@ -313,6 +350,89 @@ mod tests {
         assert_eq!(out.lines().next().unwrap(), "url");
         assert_eq!(out.matches("url\n").count(), 1, "{out}");
         assert_eq!(out.lines().count(), 3);
+    }
+
+    /// A writer that fails every write the way a closed pipe does.
+    struct ClosedPipe;
+
+    impl Write for ClosedPipe {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "Broken pipe (os error 32)",
+            ))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A writer that fails with something that is *not* a closed pipe.
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::StorageFull,
+                "No space left on device",
+            ))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_closed_pipe_stops_the_stream_instead_of_failing_the_run() {
+        // `urx target --stream | head -1`: the consumer stops reading long
+        // before the providers finish. That used to bubble up as
+        // "Failed to write streamed URL: Broken pipe" and fail the whole run.
+        let sink = StreamSink::new(
+            UrlFilter::new(),
+            UrlTransformer::new(),
+            None,
+            "plain",
+            Box::new(ClosedPipe),
+        )
+        .unwrap();
+
+        assert_eq!(sink.emit(&["https://a.com/1".to_string()]).unwrap(), 0);
+        // Later batches are dropped without retrying a write that cannot work.
+        assert_eq!(sink.emit(&["https://a.com/2".to_string()]).unwrap(), 0);
+        assert_eq!(sink.emitted(), 0);
+    }
+
+    #[test]
+    fn test_a_real_write_failure_is_still_reported() {
+        let sink = StreamSink::new(
+            UrlFilter::new(),
+            UrlTransformer::new(),
+            None,
+            "plain",
+            Box::new(FailingWriter),
+        )
+        .unwrap();
+
+        let err = sink.emit(&["https://a.com/1".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to write streamed output"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_csv_header_on_a_closed_pipe_does_not_fail_construction() {
+        // The CSV header is written from the constructor, so it needs the same
+        // treatment: `urx target --stream -f csv | head -0` must not error.
+        let sink = StreamSink::new(
+            UrlFilter::new(),
+            UrlTransformer::new(),
+            None,
+            "csv",
+            Box::new(ClosedPipe),
+        )
+        .unwrap();
+        assert_eq!(sink.emit(&["https://a.com/1".to_string()]).unwrap(), 0);
     }
 
     #[test]

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -352,33 +352,44 @@ mod tests {
         assert_eq!(out.lines().count(), 3);
     }
 
-    /// A writer that fails every write the way a closed pipe does.
-    struct ClosedPipe;
+    /// A writer that fails with `kind`, either on the write itself or only when
+    /// it flushes. Both shapes are real: an unbuffered pipe rejects the write,
+    /// while a buffered one accepts it and only fails at the flush.
+    struct FailingWriter {
+        kind: std::io::ErrorKind,
+        only_on_flush: bool,
+    }
 
-    impl Write for ClosedPipe {
-        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "Broken pipe (os error 32)",
-            ))
+    impl FailingWriter {
+        fn on_write(kind: std::io::ErrorKind) -> Self {
+            Self {
+                kind,
+                only_on_flush: false,
+            }
         }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
+
+        fn on_flush(kind: std::io::ErrorKind) -> Self {
+            Self {
+                kind,
+                only_on_flush: true,
+            }
+        }
+
+        fn error(&self) -> std::io::Error {
+            std::io::Error::new(self.kind, "synthetic failure")
         }
     }
 
-    /// A writer that fails with something that is *not* a closed pipe.
-    struct FailingWriter;
-
     impl Write for FailingWriter {
-        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::StorageFull,
-                "No space left on device",
-            ))
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.only_on_flush {
+                Ok(buf.len())
+            } else {
+                Err(self.error())
+            }
         }
         fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
+            Err(self.error())
         }
     }
 
@@ -392,12 +403,31 @@ mod tests {
             UrlTransformer::new(),
             None,
             "plain",
-            Box::new(ClosedPipe),
+            Box::new(FailingWriter::on_write(std::io::ErrorKind::BrokenPipe)),
         )
         .unwrap();
 
         assert_eq!(sink.emit(&["https://a.com/1".to_string()]).unwrap(), 0);
         // Later batches are dropped without retrying a write that cannot work.
+        assert_eq!(sink.emit(&["https://a.com/2".to_string()]).unwrap(), 0);
+        assert_eq!(sink.emitted(), 0);
+    }
+
+    #[test]
+    fn test_a_pipe_that_closes_at_flush_time_also_stops_the_stream() {
+        // The sink flushes after every batch (that is what makes streaming
+        // useful downstream), so on a buffered destination the closed pipe
+        // surfaces there rather than on the write.
+        let sink = StreamSink::new(
+            UrlFilter::new(),
+            UrlTransformer::new(),
+            None,
+            "plain",
+            Box::new(FailingWriter::on_flush(std::io::ErrorKind::BrokenPipe)),
+        )
+        .unwrap();
+
+        assert_eq!(sink.emit(&["https://a.com/1".to_string()]).unwrap(), 0);
         assert_eq!(sink.emit(&["https://a.com/2".to_string()]).unwrap(), 0);
         assert_eq!(sink.emitted(), 0);
     }
@@ -409,7 +439,7 @@ mod tests {
             UrlTransformer::new(),
             None,
             "plain",
-            Box::new(FailingWriter),
+            Box::new(FailingWriter::on_write(std::io::ErrorKind::StorageFull)),
         )
         .unwrap();
 
@@ -429,7 +459,7 @@ mod tests {
             UrlTransformer::new(),
             None,
             "csv",
-            Box::new(ClosedPipe),
+            Box::new(FailingWriter::on_write(std::io::ErrorKind::BrokenPipe)),
         )
         .unwrap();
         assert_eq!(sink.emit(&["https://a.com/1".to_string()]).unwrap(), 0);

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -7,6 +7,31 @@ use std::path::PathBuf;
 // Outputter implementations for different formats
 use super::{Outputter, UrlData};
 
+/// Write to stdout, treating a closed pipe as a normal end of output.
+///
+/// `print!`/`println!` *panic* when stdout is gone, so `urx example.com | head -1`
+/// used to end in `thread 'main' panicked ... failed printing to stdout: Broken
+/// pipe` instead of the silent stop every other CLI gives. Taking the lock once
+/// also avoids re-locking stdout for every URL.
+fn write_stdout(f: impl FnOnce(&mut dyn Write) -> std::io::Result<()>) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    finish_stdout_write(f(&mut handle).and_then(|()| handle.flush()))
+}
+
+/// Decide what a finished stdout write means.
+///
+/// A closed pipe is not a failure: the reader (`| head`, `| grep -q`, a shut
+/// terminal) already has what it asked for, so the run stops delivering output
+/// and reports success. Any other I/O error is real and is surfaced.
+fn finish_stdout_write(result: std::io::Result<()>) -> Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(anyhow::Error::new(e).context("Failed to write to stdout")),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PlainOutputter {
     formatter: Box<dyn Formatter>,
@@ -55,11 +80,13 @@ impl Outputter for PlainOutputter {
                     return Ok(());
                 };
 
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
-                    print!("{formatted}");
-                }
-                Ok(())
+                write_stdout(|out| {
+                    for (i, url_data) in urls.iter().enumerate() {
+                        let formatted = self.format(url_data, i == urls.len() - 1);
+                        out.write_all(formatted.as_bytes())?;
+                    }
+                    Ok(())
+                })
             }
         }
     }
@@ -106,15 +133,14 @@ impl Outputter for JsonOutputter {
                     return Ok(());
                 };
 
-                print!("[");
-
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
-                    print!("{formatted}");
-                }
-
-                println!("]");
-                Ok(())
+                write_stdout(|out| {
+                    out.write_all(b"[")?;
+                    for (i, url_data) in urls.iter().enumerate() {
+                        let formatted = self.format(url_data, i == urls.len() - 1);
+                        out.write_all(formatted.as_bytes())?;
+                    }
+                    out.write_all(b"]\n")
+                })
             }
         }
     }
@@ -160,10 +186,12 @@ impl Outputter for JsonLinesOutputter {
                 if silent {
                     return Ok(());
                 };
-                for url_data in urls {
-                    print!("{}", self.format(url_data, false));
-                }
-                Ok(())
+                write_stdout(|out| {
+                    for url_data in urls {
+                        out.write_all(self.format(url_data, false).as_bytes())?;
+                    }
+                    Ok(())
+                })
             }
         }
     }
@@ -213,14 +241,15 @@ impl Outputter for CsvOutputter {
                     return Ok(());
                 };
 
-                print!("{header}");
-
-                for url_data in urls {
-                    let formatted = super::formatter::csv_row(url_data, has_status, has_sources);
-                    print!("{formatted}");
-                }
-
-                Ok(())
+                write_stdout(|out| {
+                    out.write_all(header.as_bytes())?;
+                    for url_data in urls {
+                        let formatted =
+                            super::formatter::csv_row(url_data, has_status, has_sources);
+                        out.write_all(formatted.as_bytes())?;
+                    }
+                    Ok(())
+                })
             }
         }
     }
@@ -409,6 +438,30 @@ mod tests {
     }
 
     #[test]
+    fn test_csv_output_neutralises_a_formula_field_end_to_end() -> Result<()> {
+        // `urx ... --show-only-param -f csv` writes a raw query-parameter name
+        // into the url column; one starting with `=` is a live DDE formula in
+        // Excel. Reproduced from real output: `=cmd|'/C calc'!A0=1&normal=2`.
+        let outputter = CsvOutputter::new();
+        let urls = vec![
+            UrlData::new("=cmd|'/C calc'!A0=1".to_string()),
+            UrlData::new("https://example.com/ok".to_string()),
+        ];
+
+        let temp_file = NamedTempFile::new()?;
+        let temp_path = temp_file.path().to_path_buf();
+        outputter.output(&urls, Some(temp_path.clone()), false)?;
+
+        let mut content = String::new();
+        File::open(&temp_path)?.read_to_string(&mut content)?;
+        assert_eq!(
+            content,
+            "url\n\"'=cmd|'/C calc'!A0=1\"\nhttps://example.com/ok\n"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_empty_urls() -> Result<()> {
         let outputter = PlainOutputter::new();
         let urls: Vec<UrlData> = vec![];
@@ -474,6 +527,26 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_broken_pipe_on_stdout_is_a_clean_stop_not_a_failure() {
+        // Regression: every stdout path used `print!`, which *panics* when the
+        // reader is gone, so `urx example.com | head -1` ended in
+        // "thread 'main' panicked ... failed printing to stdout: Broken pipe".
+        // The outputters now funnel through this policy instead.
+        let closed = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Broken pipe");
+        assert!(finish_stdout_write(Err(closed)).is_ok());
+
+        // A genuine write failure is still reported.
+        let disk_full = std::io::Error::new(std::io::ErrorKind::StorageFull, "No space left");
+        let err = finish_stdout_write(Err(disk_full)).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to write to stdout"),
+            "{err}"
+        );
+
+        assert!(finish_stdout_write(Ok(())).is_ok());
     }
 
     #[test]

--- a/src/output/writer.rs
+++ b/src/output/writer.rs
@@ -45,6 +45,18 @@ impl PlainOutputter {
     }
 }
 
+impl PlainOutputter {
+    /// Render the whole result set. Both destinations go through this, so the
+    /// bytes a pipe sees and the bytes a file gets can never drift apart.
+    fn render(&self, urls: &[UrlData], out: &mut dyn Write) -> std::io::Result<()> {
+        for (i, url_data) in urls.iter().enumerate() {
+            let formatted = self.format(url_data, i == urls.len() - 1);
+            out.write_all(formatted.as_bytes())?;
+        }
+        Ok(())
+    }
+}
+
 impl Outputter for PlainOutputter {
     fn format(&self, url_data: &UrlData, is_last: bool) -> String {
         self.formatter.format(url_data, is_last)
@@ -62,16 +74,12 @@ impl Outputter for PlainOutputter {
                 // NO_COLOR run stays colourless instead of being re-enabled.
                 let prev_colorize = colored::control::SHOULD_COLORIZE.should_colorize();
                 colored::control::set_override(false);
-                let mut file = File::create(&path).context("Failed to create output file")?;
-
-                let result = (|| {
-                    for (i, url_data) in urls.iter().enumerate() {
-                        let formatted = self.format(url_data, i == urls.len() - 1);
-                        file.write_all(formatted.as_bytes())
-                            .context("Failed to write to output file")?;
-                    }
-                    Ok(())
-                })();
+                let result = File::create(&path)
+                    .context("Failed to create output file")
+                    .and_then(|mut file| {
+                        self.render(urls, &mut file)
+                            .context("Failed to write to output file")
+                    });
                 colored::control::set_override(prev_colorize);
                 result
             }
@@ -80,13 +88,7 @@ impl Outputter for PlainOutputter {
                     return Ok(());
                 };
 
-                write_stdout(|out| {
-                    for (i, url_data) in urls.iter().enumerate() {
-                        let formatted = self.format(url_data, i == urls.len() - 1);
-                        out.write_all(formatted.as_bytes())?;
-                    }
-                    Ok(())
-                })
+                write_stdout(|out| self.render(urls, out))
             }
         }
     }
@@ -105,6 +107,19 @@ impl JsonOutputter {
     }
 }
 
+impl JsonOutputter {
+    /// Render the array. Shared by both destinations; stdout adds a trailing
+    /// newline afterwards so an interactive run ends on its own line.
+    fn render(&self, urls: &[UrlData], out: &mut dyn Write) -> std::io::Result<()> {
+        out.write_all(b"[")?;
+        for (i, url_data) in urls.iter().enumerate() {
+            let formatted = self.format(url_data, i == urls.len() - 1);
+            out.write_all(formatted.as_bytes())?;
+        }
+        out.write_all(b"]")
+    }
+}
+
 impl Outputter for JsonOutputter {
     fn format(&self, url_data: &UrlData, is_last: bool) -> String {
         self.formatter.format(url_data, is_last)
@@ -114,19 +129,8 @@ impl Outputter for JsonOutputter {
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
-
-                file.write_all(b"[")
-                    .context("Failed to write JSON opening bracket")?;
-
-                for (i, url_data) in urls.iter().enumerate() {
-                    let formatted = self.format(url_data, i == urls.len() - 1);
-                    file.write_all(formatted.as_bytes())
-                        .context("Failed to write to output file")?;
-                }
-
-                file.write_all(b"]")
-                    .context("Failed to write JSON closing bracket")?;
-                Ok(())
+                self.render(urls, &mut file)
+                    .context("Failed to write to output file")
             }
             None => {
                 if silent {
@@ -134,12 +138,8 @@ impl Outputter for JsonOutputter {
                 };
 
                 write_stdout(|out| {
-                    out.write_all(b"[")?;
-                    for (i, url_data) in urls.iter().enumerate() {
-                        let formatted = self.format(url_data, i == urls.len() - 1);
-                        out.write_all(formatted.as_bytes())?;
-                    }
-                    out.write_all(b"]\n")
+                    self.render(urls, out)?;
+                    out.write_all(b"\n")
                 })
             }
         }
@@ -167,6 +167,16 @@ impl Default for JsonLinesOutputter {
     }
 }
 
+impl JsonLinesOutputter {
+    /// Render one standalone JSON object per line, for either destination.
+    fn render(&self, urls: &[UrlData], out: &mut dyn Write) -> std::io::Result<()> {
+        for url_data in urls {
+            out.write_all(self.format(url_data, false).as_bytes())?;
+        }
+        Ok(())
+    }
+}
+
 impl Outputter for JsonLinesOutputter {
     fn format(&self, url_data: &UrlData, is_last: bool) -> String {
         self.formatter.format(url_data, is_last)
@@ -176,22 +186,14 @@ impl Outputter for JsonLinesOutputter {
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
-                for url_data in urls {
-                    file.write_all(self.format(url_data, false).as_bytes())
-                        .context("Failed to write to output file")?;
-                }
-                Ok(())
+                self.render(urls, &mut file)
+                    .context("Failed to write to output file")
             }
             None => {
                 if silent {
                     return Ok(());
                 };
-                write_stdout(|out| {
-                    for url_data in urls {
-                        out.write_all(self.format(url_data, false).as_bytes())?;
-                    }
-                    Ok(())
-                })
+                write_stdout(|out| self.render(urls, out))
             }
         }
     }
@@ -210,46 +212,44 @@ impl CsvOutputter {
     }
 }
 
+impl CsvOutputter {
+    /// Render header plus rows for either destination.
+    ///
+    /// The column layout is decided once for the whole run so the header and
+    /// every row emit exactly the same columns (otherwise rows could carry a
+    /// trailing/extra comma the header doesn't, breaking strict CSV parsers) —
+    /// which is also why both destinations must share this one function.
+    fn render(&self, urls: &[UrlData], out: &mut dyn Write) -> std::io::Result<()> {
+        let has_status = urls.iter().any(|url| url.status.is_some());
+        let has_sources = urls.iter().any(|url| !url.sources.is_empty());
+
+        out.write_all(super::formatter::csv_header(has_status, has_sources).as_bytes())?;
+        for url_data in urls {
+            let formatted = super::formatter::csv_row(url_data, has_status, has_sources);
+            out.write_all(formatted.as_bytes())?;
+        }
+        Ok(())
+    }
+}
+
 impl Outputter for CsvOutputter {
     fn format(&self, url_data: &UrlData, is_last: bool) -> String {
         self.formatter.format(url_data, is_last)
     }
 
     fn output(&self, urls: &[UrlData], output_path: Option<PathBuf>, silent: bool) -> Result<()> {
-        // Decide the column layout once for the whole run so the header and
-        // every row emit exactly the same columns (otherwise rows could carry a
-        // trailing/extra comma the header doesn't, breaking strict CSV parsers).
-        let has_status = urls.iter().any(|url| url.status.is_some());
-        let has_sources = urls.iter().any(|url| !url.sources.is_empty());
-        let header = super::formatter::csv_header(has_status, has_sources);
         match output_path {
             Some(path) => {
                 let mut file = File::create(&path).context("Failed to create output file")?;
-                file.write_all(header.as_bytes())
-                    .context("Failed to write CSV header")?;
-
-                for url_data in urls {
-                    let formatted = super::formatter::csv_row(url_data, has_status, has_sources);
-                    file.write_all(formatted.as_bytes())
-                        .context("Failed to write to output file")?;
-                }
-
-                Ok(())
+                self.render(urls, &mut file)
+                    .context("Failed to write to output file")
             }
             None => {
                 if silent {
                     return Ok(());
                 };
 
-                write_stdout(|out| {
-                    out.write_all(header.as_bytes())?;
-                    for url_data in urls {
-                        let formatted =
-                            super::formatter::csv_row(url_data, has_status, has_sources);
-                        out.write_all(formatted.as_bytes())?;
-                    }
-                    Ok(())
-                })
+                write_stdout(|out| self.render(urls, out))
             }
         }
     }
@@ -258,6 +258,7 @@ impl Outputter for CsvOutputter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output::create_outputter;
     use std::io::Read;
     use tempfile::NamedTempFile;
 
@@ -527,6 +528,104 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    fn rendered(f: impl FnOnce(&mut Vec<u8>) -> std::io::Result<()>) -> String {
+        let mut buf = Vec::new();
+        f(&mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn sample() -> Vec<UrlData> {
+        vec![
+            UrlData::new("https://example.com/page1".to_string()),
+            UrlData::with_status(
+                "https://example.com/page2".to_string(),
+                "200 OK".to_string(),
+            ),
+        ]
+    }
+
+    #[test]
+    fn test_render_produces_the_same_bytes_for_every_destination() {
+        // The stdout and file branches used to be twin copies of the same loop,
+        // so a fix to one could silently miss the other. They now share
+        // `render`; these assert what both destinations therefore emit.
+        let urls = sample();
+
+        assert_eq!(
+            rendered(|out| PlainOutputter::new().render(&urls, out)),
+            "https://example.com/page1\nhttps://example.com/page2 [200 OK]\n"
+        );
+        assert_eq!(
+            rendered(|out| JsonOutputter::new().render(&urls, out)),
+            "[{\"url\":\"https://example.com/page1\"},\
+             {\"url\":\"https://example.com/page2\",\"status\":\"200 OK\"}\n]"
+        );
+        assert_eq!(
+            rendered(|out| JsonLinesOutputter::new().render(&urls, out)),
+            "{\"url\":\"https://example.com/page1\"}\n\
+             {\"url\":\"https://example.com/page2\",\"status\":\"200 OK\"}\n"
+        );
+        assert_eq!(
+            rendered(|out| CsvOutputter::new().render(&urls, out)),
+            "url,status\nhttps://example.com/page1,\nhttps://example.com/page2,200 OK\n"
+        );
+    }
+
+    #[test]
+    fn test_render_of_an_empty_result_set() {
+        let none: Vec<UrlData> = Vec::new();
+        // json stays a valid (empty) array; csv still declares its columns.
+        assert_eq!(
+            rendered(|out| JsonOutputter::new().render(&none, out)),
+            "[]"
+        );
+        assert_eq!(
+            rendered(|out| CsvOutputter::new().render(&none, out)),
+            "url\n"
+        );
+        assert_eq!(rendered(|out| PlainOutputter::new().render(&none, out)), "");
+        assert_eq!(
+            rendered(|out| JsonLinesOutputter::new().render(&none, out)),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_render_with_sources() {
+        let urls = vec![UrlData::new("https://example.com/a".to_string())
+            .with_sources(vec!["wayback".into(), "cc".into()])];
+
+        assert_eq!(
+            rendered(|out| CsvOutputter::new().render(&urls, out)),
+            "url,sources\nhttps://example.com/a,cc|wayback\n"
+        );
+        assert_eq!(
+            rendered(|out| JsonLinesOutputter::new().render(&urls, out)),
+            "{\"url\":\"https://example.com/a\",\"sources\":[\"cc\",\"wayback\"]}\n"
+        );
+    }
+
+    #[test]
+    fn test_stdout_destination_writes_every_format() {
+        // Exercises the stdout branch of all four outputters end to end — the
+        // path that used to panic on a closed pipe. The bytes are pinned by the
+        // render tests above; what matters here is that the real destination is
+        // driven without panicking and reports success. One URL only: these
+        // writes go straight to fd 1 and so escape the harness's per-test
+        // capture, and this keeps the stray lines to a minimum.
+        let urls = vec![UrlData::new("https://example.com/a".to_string())];
+        for outputter in [
+            create_outputter("plain"),
+            create_outputter("json"),
+            create_outputter("jsonl"),
+            create_outputter("csv"),
+        ] {
+            outputter.output(&urls, None, false).unwrap();
+            // --silent short-circuits before touching stdout at all.
+            outputter.output(&urls, None, true).unwrap();
+        }
     }
 
     #[test]

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -15,12 +15,16 @@ pub use warc_reader::WarcFileReader;
 /// decompresses to one enormous "line") from exhausting memory.
 const MAX_LINE_BYTES: usize = 1024 * 1024;
 
+/// UTF-8 byte order mark, stripped from the first line of every input.
+const BOM: &[u8] = b"\xef\xbb\xbf";
+
 /// Call `f` for each line of `reader`, decoding lossily so binary content
 /// (common inside WARC response bodies) doesn't abort the whole read the way
 /// `BufRead::lines()` does on invalid UTF-8. Lines longer than
 /// `MAX_LINE_BYTES` are truncated and the remainder skipped.
 fn for_each_line_lossy<R: BufRead>(mut reader: R, mut f: impl FnMut(&str)) -> std::io::Result<()> {
     let mut buf = Vec::with_capacity(8 * 1024);
+    let mut first_line = true;
     loop {
         buf.clear();
         let n = reader
@@ -31,7 +35,17 @@ fn for_each_line_lossy<R: BufRead>(mut reader: R, mut f: impl FnMut(&str)) -> st
             break;
         }
         let hit_cap = n == MAX_LINE_BYTES && buf.last() != Some(&b'\n');
-        let line = String::from_utf8_lossy(&buf);
+        let mut bytes = &buf[..];
+        if first_line {
+            first_line = false;
+            // A UTF-8 BOM is invisible but glues itself to the first line, so
+            // "https://…" no longer starts with its scheme and every reader
+            // silently drops that URL. Editors on Windows add one routinely.
+            if let Some(rest) = bytes.strip_prefix(BOM) {
+                bytes = rest;
+            }
+        }
+        let line = String::from_utf8_lossy(bytes);
         f(line.trim_end_matches(['\n', '\r']));
         if hit_cap {
             skip_to_newline(&mut reader)?;
@@ -97,13 +111,16 @@ pub(crate) fn collect_capped<R: Read>(
     let mut url_capped = false;
 
     for_each_line_lossy(std::io::BufReader::new(&mut limited), |line| {
-        if urls.len() >= max_urls {
-            // Stop collecting; the `take` bound still drains the rest so we
-            // never read more than `max_bytes (+1)` total.
-            url_capped = true;
-            return;
-        }
         if let Some(url) = extract(line) {
+            if urls.len() >= max_urls {
+                // Stop collecting; the `take` bound still drains the rest so we
+                // never read more than `max_bytes (+1)` total. The flag is set
+                // only once a real URL is dropped — testing the cap before
+                // extraction reported "truncated" for a file that merely ended
+                // in a blank or comment line.
+                url_capped = true;
+                return;
+            }
             urls.push(url);
         }
     })?;
@@ -285,6 +302,54 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].len(), MAX_LINE_BYTES);
         assert_eq!(lines[1], "https://example.com/after");
+    }
+
+    #[test]
+    fn test_for_each_line_lossy_strips_a_leading_utf8_bom() {
+        // Regression: a BOM glued itself to the first line, so
+        // "\u{feff}https://example.com/a" did not start with "http" and every
+        // reader dropped that URL without a word.
+        let data = b"\xef\xbb\xbfhttps://example.com/a\nhttps://example.com/b\n";
+        let mut lines = Vec::new();
+        for_each_line_lossy(&data[..], |line| lines.push(line.to_string())).unwrap();
+        assert_eq!(
+            lines,
+            vec!["https://example.com/a", "https://example.com/b"]
+        );
+    }
+
+    #[test]
+    fn test_for_each_line_lossy_only_strips_the_bom_at_the_start() {
+        // A BOM-looking sequence later in the file is data, not a marker.
+        let data = "a\n\u{feff}b\n".as_bytes();
+        let mut lines = Vec::new();
+        for_each_line_lossy(data, |line| lines.push(line.to_string())).unwrap();
+        assert_eq!(lines, vec!["a", "\u{feff}b"]);
+    }
+
+    #[test]
+    fn test_url_cap_flag_reflects_a_dropped_url_not_a_trailing_line() {
+        // Regression: the cap was tested before extraction, so a file holding
+        // exactly `max_urls` URLs followed by a blank or comment line reported
+        // "results truncated" while nothing had been dropped.
+        let data = b"https://example.com/a\nhttps://example.com/b\n\n# done\n";
+        let (urls, url_capped, _) = collect_capped(&data[..], 2, MAX_FILE_BYTES, |line| {
+            let t = line.trim();
+            (t.starts_with("http://") || t.starts_with("https://")).then(|| t.to_string())
+        })
+        .unwrap();
+        assert_eq!(urls.len(), 2);
+        assert!(!url_capped, "nothing was dropped, so nothing was truncated");
+
+        // A third URL past the cap is a genuine truncation.
+        let data = b"https://example.com/a\nhttps://example.com/b\nhttps://example.com/c\n";
+        let (urls, url_capped, _) = collect_capped(&data[..], 2, MAX_FILE_BYTES, |line| {
+            let t = line.trim();
+            (t.starts_with("http://") || t.starts_with("https://")).then(|| t.to_string())
+        })
+        .unwrap();
+        assert_eq!(urls.len(), 2);
+        assert!(url_capped);
     }
 
     #[test]

--- a/src/readers/text_reader.rs
+++ b/src/readers/text_reader.rs
@@ -76,6 +76,24 @@ mod tests {
     }
 
     #[test]
+    fn test_leading_utf8_bom_does_not_swallow_the_first_url() -> Result<()> {
+        // Regression: a BOM-prefixed list (what Notepad and Excel write by
+        // default) lost its first URL — the byte order mark made the line fail
+        // the "starts with http" check, and nothing said so.
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all("\u{feff}https://example.com/first\n".as_bytes())?;
+        writeln!(temp_file, "https://example.com/second")?;
+        temp_file.flush()?;
+
+        let urls = TextFileReader::new().read_urls(temp_file.path())?;
+        assert_eq!(
+            urls,
+            vec!["https://example.com/first", "https://example.com/second"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_read_urls_from_empty_file() -> Result<()> {
         let temp_file = NamedTempFile::new()?;
 

--- a/src/readers/urlteam_reader.rs
+++ b/src/readers/urlteam_reader.rs
@@ -278,17 +278,22 @@ mod tests {
         Ok(())
     }
 
-    /// Concatenate two independently-gzipped payloads, which is exactly how
+    /// Concatenate independently-gzipped payloads, which is exactly how
     /// `.warc.gz` (one member per record) and `cat a.gz b.gz` are built.
-    fn write_multi_member_gzip(path: &Path, chunks: &[&str]) -> Result<()> {
+    fn multi_member_gzip(chunks: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();
         for chunk in chunks {
             let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-            encoder.write_all(chunk.as_bytes())?;
-            out.extend_from_slice(&encoder.finish()?);
+            encoder
+                .write_all(chunk.as_bytes())
+                .expect("writing to an in-memory encoder cannot fail");
+            out.extend_from_slice(
+                &encoder
+                    .finish()
+                    .expect("finishing an in-memory encoder cannot fail"),
+            );
         }
-        std::fs::write(path, out)?;
-        Ok(())
+        out
     }
 
     #[test]
@@ -297,14 +302,12 @@ mod tests {
         // (gzip per record) or any concatenated .gz silently yielded only the
         // first record's URLs — `gunzip -c` showed all of them.
         let temp_file = NamedTempFile::new()?;
-        write_multi_member_gzip(
-            temp_file.path(),
-            &[
-                "https://example.com/one\n",
-                "https://example.com/two\n",
-                "https://example.com/three\n",
-            ],
-        )?;
+        let bytes = multi_member_gzip(&[
+            "https://example.com/one\n",
+            "https://example.com/two\n",
+            "https://example.com/three\n",
+        ]);
+        std::fs::write(temp_file.path(), bytes)?;
 
         let reader = UrlTeamFileReader::new();
         let urls = reader.read_urls(temp_file.path())?;
@@ -337,11 +340,10 @@ mod tests {
         std::fs::write(truncated.path(), &full[..full.len() / 2])?;
 
         let reader = UrlTeamFileReader::new();
-        let urls = reader.read_urls(truncated.path())?;
+        let recovered = reader.read_urls(truncated.path())?.len();
         assert!(
-            !urls.is_empty() && urls.len() < 5_000,
-            "a truncated archive should yield what decoded, got {}",
-            urls.len()
+            recovered > 0 && recovered < 5_000,
+            "a truncated archive should yield what decoded, got {recovered}"
         );
         Ok(())
     }
@@ -351,8 +353,7 @@ mod tests {
         // MultiGzDecoder reports junk after the final member as a bad header;
         // that must not lose the members that decoded cleanly.
         let temp_file = NamedTempFile::new()?;
-        write_multi_member_gzip(temp_file.path(), &["https://example.com/kept\n"])?;
-        let mut bytes = std::fs::read(temp_file.path())?;
+        let mut bytes = multi_member_gzip(&["https://example.com/kept\n"]);
         bytes.extend_from_slice(b"NOT-A-GZIP-HEADER");
         std::fs::write(temp_file.path(), bytes)?;
 
@@ -372,16 +373,90 @@ mod tests {
         let member: String = (0..50_000)
             .map(|i| format!("https://example.com/bomb/{i}\n"))
             .collect();
-        write_multi_member_gzip(temp_file.path(), &[&member, &member, &member])?;
+        let bytes = multi_member_gzip(&[&member, &member, &member]);
+        std::fs::write(temp_file.path(), bytes)?;
 
         let reader = UrlTeamFileReader::with_caps(MAX_FILE_URLS, 4096);
-        let urls = reader.read_urls(temp_file.path())?;
+        let found = reader.read_urls(temp_file.path())?.len();
         assert!(
-            !urls.is_empty() && urls.len() < 1_000,
-            "the byte cap must bound every member, got {} URLs",
-            urls.len()
+            found > 0 && found < 1_000,
+            "the byte cap must bound every member, got {found} URLs"
         );
         Ok(())
+    }
+
+    /// A reader that yields `head`, then fails with `kind` on the next call.
+    struct FailAfter {
+        head: Vec<u8>,
+        kind: std::io::ErrorKind,
+        interrupts_left: usize,
+    }
+
+    impl Read for FailAfter {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if !self.head.is_empty() {
+                let n = self.head.len().min(buf.len());
+                buf[..n].copy_from_slice(&self.head[..n]);
+                self.head.drain(..n);
+                return Ok(n);
+            }
+            if self.interrupts_left > 0 {
+                self.interrupts_left -= 1;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "eintr",
+                ));
+            }
+            Err(std::io::Error::new(self.kind, "synthetic decode failure"))
+        }
+    }
+
+    #[test]
+    fn test_stop_on_decode_error_ends_the_read_and_records_why() {
+        // The adapter is what keeps a half-decoded archive's URLs: it converts
+        // the failure into a clean EOF so the caller's Vec survives, and holds
+        // on to the error so the reader can say what happened.
+        let mut src = StopOnDecodeError::new(FailAfter {
+            head: b"https://example.com/a\nhttps://example.com/b\n".to_vec(),
+            kind: std::io::ErrorKind::UnexpectedEof,
+            interrupts_left: 0,
+        });
+
+        let (urls, _, _) = UrlTeamFileReader::collect_capped(&mut src, MAX_FILE_URLS, 1 << 20)
+            .expect("a decode failure must not surface as an error");
+        assert_eq!(
+            urls,
+            vec!["https://example.com/a", "https://example.com/b"],
+            "everything decoded before the failure must survive"
+        );
+
+        let recorded = src.error.as_ref().expect("the failure must be recorded");
+        assert_eq!(recorded.kind(), std::io::ErrorKind::UnexpectedEof);
+
+        // Once it has failed, further reads report EOF rather than re-failing.
+        assert_eq!(src.read(&mut [0u8; 8]).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_stop_on_decode_error_passes_interrupted_through() {
+        // EINTR is retryable, not a decode failure: swallowing it as EOF would
+        // truncate a perfectly good stream.
+        let mut src = StopOnDecodeError::new(FailAfter {
+            head: b"x".to_vec(),
+            kind: std::io::ErrorKind::UnexpectedEof,
+            interrupts_left: 1,
+        });
+
+        let mut buf = [0u8; 8];
+        assert_eq!(src.read(&mut buf).unwrap(), 1);
+        assert_eq!(
+            src.read(&mut buf).unwrap_err().kind(),
+            std::io::ErrorKind::Interrupted
+        );
+        assert!(
+            src.error.is_none(),
+            "a retryable error must not end the read"
+        );
     }
 
     #[test]

--- a/src/readers/urlteam_reader.rs
+++ b/src/readers/urlteam_reader.rs
@@ -1,11 +1,47 @@
 use super::FileReader;
 use anyhow::{Context, Result};
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
 use super::{MAX_FILE_BYTES, MAX_FILE_URLS};
+
+/// Turns a mid-stream read failure into a clean end of input, remembering it so
+/// the caller can say what happened.
+///
+/// A truncated `.gz` — an interrupted download, an archive cut short — used to
+/// abort the whole read with "unexpected end of file", discarding every URL
+/// already decoded. The bytes that *did* decompress are perfectly good results;
+/// the same goes for trailing junk after the final gzip member, which
+/// [`MultiGzDecoder`] reports as a bad header rather than ignoring.
+struct StopOnDecodeError<R> {
+    inner: R,
+    error: Option<std::io::Error>,
+}
+
+impl<R: Read> StopOnDecodeError<R> {
+    fn new(inner: R) -> Self {
+        Self { inner, error: None }
+    }
+}
+
+impl<R: Read> Read for StopOnDecodeError<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.error.is_some() {
+            return Ok(0);
+        }
+        match self.inner.read(buf) {
+            Ok(n) => Ok(n),
+            // Interrupted is retryable and not a decode failure.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Err(e),
+            Err(e) => {
+                self.error = Some(e);
+                Ok(0)
+            }
+        }
+    }
+}
 
 /// Reader for URLTeam compressed files (typically gzip format)
 pub struct UrlTeamFileReader {
@@ -92,7 +128,20 @@ impl FileReader for UrlTeamFileReader {
 
         let (urls, url_capped, byte_capped) = if Self::is_gzip(file_path)? {
             // File is gzip compressed: bound the *decompressed* stream.
-            Self::collect_capped(GzDecoder::new(file), self.max_urls, self.max_bytes)
+            //
+            // MultiGzDecoder, not GzDecoder: gzip members concatenate, and both
+            // `.warc.gz` (one member per record) and any `cat a.gz b.gz` archive
+            // are made that way. GzDecoder stops after the first member, so urx
+            // returned the first record's URLs and silently dropped the rest.
+            let mut src = StopOnDecodeError::new(MultiGzDecoder::new(file));
+            let collected = Self::collect_capped(&mut src, self.max_urls, self.max_bytes);
+            if let Some(e) = src.error {
+                eprintln!(
+                    "[urx] {}: gzip stream ended early ({e}); keeping the URLs decoded so far",
+                    file_path.display()
+                );
+            }
+            collected
         } else {
             // File is not compressed, read as plain text.
             Self::collect_capped(file, self.max_urls, self.max_bytes)
@@ -224,6 +273,112 @@ mod tests {
         assert!(
             !urls.is_empty() && urls.len() < 1000,
             "byte cap should truncate the stream, got {} URLs",
+            urls.len()
+        );
+        Ok(())
+    }
+
+    /// Concatenate two independently-gzipped payloads, which is exactly how
+    /// `.warc.gz` (one member per record) and `cat a.gz b.gz` are built.
+    fn write_multi_member_gzip(path: &Path, chunks: &[&str]) -> Result<()> {
+        let mut out = Vec::new();
+        for chunk in chunks {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(chunk.as_bytes())?;
+            out.extend_from_slice(&encoder.finish()?);
+        }
+        std::fs::write(path, out)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_reads_every_member_of_a_multi_member_gzip() -> Result<()> {
+        // Regression: GzDecoder stops after the first member, so a `.warc.gz`
+        // (gzip per record) or any concatenated .gz silently yielded only the
+        // first record's URLs — `gunzip -c` showed all of them.
+        let temp_file = NamedTempFile::new()?;
+        write_multi_member_gzip(
+            temp_file.path(),
+            &[
+                "https://example.com/one\n",
+                "https://example.com/two\n",
+                "https://example.com/three\n",
+            ],
+        )?;
+
+        let reader = UrlTeamFileReader::new();
+        let urls = reader.read_urls(temp_file.path())?;
+
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/one",
+                "https://example.com/two",
+                "https://example.com/three",
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_truncated_gzip_keeps_what_it_decoded() -> Result<()> {
+        // Regression: a half-downloaded archive aborted the read with
+        // "unexpected end of file" and threw away every URL already decoded.
+        let source = NamedTempFile::new()?;
+        {
+            let mut encoder = GzEncoder::new(File::create(source.path())?, Compression::default());
+            for i in 0..5_000 {
+                writeln!(encoder, "https://example.com/page{i}")?;
+            }
+            encoder.finish()?;
+        }
+        let full = std::fs::read(source.path())?;
+        let truncated = NamedTempFile::new()?;
+        std::fs::write(truncated.path(), &full[..full.len() / 2])?;
+
+        let reader = UrlTeamFileReader::new();
+        let urls = reader.read_urls(truncated.path())?;
+        assert!(
+            !urls.is_empty() && urls.len() < 5_000,
+            "a truncated archive should yield what decoded, got {}",
+            urls.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_trailing_garbage_after_the_last_member_is_not_fatal() -> Result<()> {
+        // MultiGzDecoder reports junk after the final member as a bad header;
+        // that must not lose the members that decoded cleanly.
+        let temp_file = NamedTempFile::new()?;
+        write_multi_member_gzip(temp_file.path(), &["https://example.com/kept\n"])?;
+        let mut bytes = std::fs::read(temp_file.path())?;
+        bytes.extend_from_slice(b"NOT-A-GZIP-HEADER");
+        std::fs::write(temp_file.path(), bytes)?;
+
+        let reader = UrlTeamFileReader::new();
+        assert_eq!(
+            reader.read_urls(temp_file.path())?,
+            vec!["https://example.com/kept"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_byte_cap_still_bounds_a_multi_member_bomb() -> Result<()> {
+        // Reading every member must not weaken the decompression-bomb guard:
+        // the cap applies to the decompressed stream as a whole.
+        let temp_file = NamedTempFile::new()?;
+        let member: String = (0..50_000)
+            .map(|i| format!("https://example.com/bomb/{i}\n"))
+            .collect();
+        write_multi_member_gzip(temp_file.path(), &[&member, &member, &member])?;
+
+        let reader = UrlTeamFileReader::with_caps(MAX_FILE_URLS, 4096);
+        let urls = reader.read_urls(temp_file.path())?;
+        assert!(
+            !urls.is_empty() && urls.len() < 1_000,
+            "the byte cap must bound every member, got {} URLs",
             urls.len()
         );
         Ok(())


### PR DESCRIPTION
Seven defects in `src/output/`, `src/readers/` and `src/cache/`, each reproduced against the built binary and each covered by a regression test. No files outside my assigned area were touched.

Gate: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` (and with `--features redis-cache`), `cargo test --bin urx` — 655 passed, 0 failed.

---

## 1. `urx target | head -1` panics on a broken pipe

**Symptom**
```
thread 'main' (9295136) panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**Repro**
```sh
seq 0 19999 | sed 's#^#https://example.com/page#' > urls.txt
urx --files urls.txt --no-progress | head -2 >/dev/null
```

**Root cause** — `src/output/writer.rs:60,109,116,164,216,220` (pre-fix): every stdout path used `print!`/`println!`, and Rust's `print!` **panics** when the underlying write fails. `head` closing the pipe is the ordinary way to stop a CLI.

The `--stream` path had the same defect in a different shape: `src/output/stream.rs:127` did `w.write_all(...).context("Failed to write streamed URL")?`, so `urx target --stream | head -1` failed the whole run with an I/O error instead of stopping.

**Fix** — all four outputters now write through one `write_stdout` helper that takes the stdout lock once and classifies the result in `finish_stdout_write`: `BrokenPipe` → clean stop, anything else → a real error. `StreamSink` gained a `closed: AtomicBool`, so once the destination goes away later batches are dropped rather than re-attempting a write that can only fail again (the CSV header write, which happens in the constructor, is covered too).

**Verified after the fix**
```
$ urx --files urls.txt --no-progress 2>err.txt | head -2 >/dev/null
$ wc -c < err.txt
0
$ urx github.com --stream --providers otx --no-progress --max-time 40 | head -1
https://github.com/.git/
[exit=0]
```

## 2. CSV formula injection: `=`/`+`/`-`/`@` fields written verbatim

**Symptom** — an archive-controlled field beginning with a formula trigger reaches the CSV unaltered and executes when the file is opened in Excel/LibreOffice (CWE-1236).

**Repro**
```sh
printf "https://example.com/x?=cmd|'/C calc'!A0=1&normal=2\n" > inj.txt
urx --files inj.txt --no-progress -f csv --show-only-param
```
before:
```
url
=cmd|%27/C%20calc%27!A0=1&normal=2      <-- live DDE formula
```
after:
```
url
"'=cmd|%27/C%20calc%27!A0=1&normal=2"
```

**Root cause** — `src/output/formatter.rs:216` (pre-fix) `csv_escape` quoted only `,`, `"` and `\n`. Quoting alone does not stop a spreadsheet from evaluating a cell anyway. Every field here is attacker/archive-controlled: the URL itself, and under `--show-only-param` a query-parameter name lifted verbatim out of the URL.

**Fix** — a value starting with `=`, `+`, `-`, `@`, tab or CR is quoted **and** apostrophe-prefixed (the standard OWASP mitigation). Only fields that actually begin with a trigger are altered — a normal `https://…` URL, a `200 OK` status and a `cc|wayback` sources cell are all byte-identical to before.

**Also fixed here:** a bare `\r` did not force quoting, so a URL containing one split the row in Excel and most importers. CR now triggers quoting like LF does.

## 3. Multi-member gzip: everything past the first member silently dropped

**Symptom** — `gunzip -c` shows every URL; urx shows only the first member's.

**Repro**
```sh
printf 'https://example.com/one\n' | gzip -c >  a.gz
printf 'https://example.com/two\n' | gzip -c >  b.gz
cat a.gz b.gz > multi.gz

$ gunzip -c multi.gz
https://example.com/one
https://example.com/two
$ urx --files multi.gz --no-progress
https://example.com/one          <-- half the file, no warning
```

**Root cause** — `src/readers/urlteam_reader.rs:95` used `flate2::read::GzDecoder`, which stops after the first gzip member. gzip members concatenate, and this is not an edge case: **`.warc.gz` stores one gzip member per WARC record**, and any `cat *.gz` / `pigz` output is multi-member. `detect_file_format` routes every `.gz` (including `.warc.gz`) through this reader.

**Fix** — `MultiGzDecoder`. The decompression-bomb byte cap still applies to the decompressed stream as a whole; there is a new test (`test_byte_cap_still_bounds_a_multi_member_bomb`) asserting the cap is not weakened by reading further members.

## 4. A truncated `.gz` threw away every URL it had already decoded

**Symptom / repro** — take a valid 5,000-URL `.gz`, cut it in half (an interrupted download):
```
$ urx --files trunc.gz --no-progress
Error: Failed to read URLTeam file: trunc.gz
Caused by:
    unexpected end of file
```
Zero URLs, though ~1,000 had decoded cleanly.

**Root cause** — `src/readers/urlteam_reader.rs:100`: the decode error propagated out of `collect_capped`, discarding the whole `Vec`. This also mattered for the fix above: `MultiGzDecoder` reports trailing junk after the final member as a bad header, where `GzDecoder` ignored it — without this, #3 would have regressed files with trailing padding.

**Fix** — a `StopOnDecodeError` adapter turns a mid-stream decode failure into a clean EOF and remembers it, so the reader keeps what decoded and warns on stderr:
```
$ urx --files trunc.gz --no-progress
[urx] trunc.gz: gzip stream ended early (unexpected end of file); keeping the URLs decoded so far
...981 URLs...
$ urx --files tail.gz --no-progress     # valid member + "GARBAGEGARBAGE"
https://example.com/one                 # still works, no regression
```

## 5. A leading UTF-8 BOM silently swallows the first URL

**Repro**
```sh
printf '\xef\xbb\xbfhttps://example.com/bom1\nhttps://example.com/plain2\n' > bom.txt
$ urx --files bom.txt --no-progress
https://example.com/plain2     <-- bom1 is gone, nothing said
```

**Root cause** — `src/readers/mod.rs:34` (pre-fix): the BOM stayed glued to the first line, so `"\u{feff}https://…"` failed the `starts_with("http://")` check in every reader and was dropped as a non-URL line. Notepad and Excel add a BOM by default, so a hand-made URL list hits this routinely.

**Fix** — `for_each_line_lossy` strips a leading BOM from the first line only, which fixes the text, URLTeam and WARC readers at once (including after gzip decompression). A BOM sequence later in the file is left alone as data.

## 6. False "results truncated" warning

**Root cause** — `src/readers/mod.rs:99-108` (pre-fix) tested `urls.len() >= max_urls` *before* extraction, so a file holding exactly `max_urls` URLs and ending in a blank or `#` comment line printed `stopped at the N-URL cap; results truncated` when nothing had been dropped.

**Fix** — the flag is set only when a line that really yields a URL is discarded.

## 7. Redis cache: large `--cache-ttl` panics, or deletes the entire cache

**Root cause** — `src/cache/redis_impl.rs:134` (pre-fix): `Utc::now() - chrono::Duration::seconds(ttl_seconds as i64)`. `--cache-ttl` is an unvalidated `u64` and `process_domains_with_cache` doubles it before the sweep, so:
- `--cache-ttl 10000000000000000` → `Duration::seconds` is past chrono's bounds → **panic**;
- `--cache-ttl 18446744073709551615` → `u64 as i64` wraps to `-1` → the cutoff lands *in the future* → `timestamp < cutoff` is true for every entry → **the whole cache is deleted**.

This is the exact bug already fixed for SQLite (`sqlite.rs:172`, commented as such) — the Redis backend was never updated.

**Fix** — one shared `cache::types::expiry_cutoff` helper used by both backends, so they cannot diverge again. A TTL that large reads as "never expire": the cutoff saturates to the earliest representable instant, which no stored entry precedes.

**Also fixed here:** `CacheEntry::is_expired` cast a *negative* age straight to `u64`, wrapping it to ~1.8e19 seconds. An entry written by a machine whose clock runs ahead — or after a local clock step backwards — therefore looked ancient and was deleted on sight by `CacheManager::is_valid`.

---

## Things I checked and found correct

- `--format json` is a single valid array when empty (`[]`), when filtered to nothing, and with `--output`; `jsonl` is position-independent and valid line-by-line; `csv` header and rows always agree on the column count.
- `--show-sources` works in all four formats.
- CRLF, blank lines, `#` comments, extremely long lines, and non-UTF8 bytes in the text reader.
- The decompression-bomb byte cap and the URL cap fire correctly (and still do across gzip members).
- The SQLite cache key covers `--providers`, `--subs`, `--from`/`--to`, `--cc-index`, the `--archive-*` predicates and every local filter, is length-prefixed against boundary collisions, and sorts providers. Its RFC3339 string comparison in `cleanup_expired` is lexicographically correct for chrono's `AutoSi` fractional-second formats.
- rusqlite already sets a 5 s `busy_timeout` by default, so concurrent urx processes on one cache DB do not fail immediately.

## Out-of-scope findings

Not fixed — outside my file ownership.

1. **`src/main.rs`** — a corrupt/unreadable cache DB kills the whole scan. `urx example.com --cache-path ./bad.db` (where `bad.db` is 4 KB of random bytes) exits with `Error: Failed to create cache table / file is not a database` and produces no URLs at all. The cache is a local optimisation; a corrupt `~/.urx/cache.db` (crash, disk-full) makes urx unusable until the user works out which file to delete, and the message never names the path. The fix belongs in `create_cache_manager`'s caller or in `main`'s error handling: warn, name the path, continue with caching disabled. (`create_cache_manager` itself is in my area, but degrading it to `Ok(None)` changes `main.rs`'s contract, so I left it.)
2. **`src/main.rs:176`** — confirms the orchestrator's finding: a usage error still exits 0. `urx` with no domains prints the "No domains provided…" hint and returns 0, and the corrupt-DB error above also came back as 0 through a pipeline.
3. **`src/app/report.rs:134`** — `write_per_domain_output` builds the filename from `Url::host_str()`, so path traversal via a crafted domain is not reachable, but a host containing `:` (an IPv6 literal, e.g. `https://[::1]/x` → `::1.txt`) makes an awkward filename, and nothing caps its length. Low severity.
4. **`src/output/mod.rs:58` / `src/tester_manager/mod.rs:158`** — `UrlData::from_string` splits on the *last* `" - "`, so a URL containing `" - "` and carrying **no** status would have its tail parsed as a status. Not reachable today (the only caller always appends a status), so I left it alone rather than churn the parser.
