### PR TITLE
fix(cli/config): CLI precedence, non-zero exit on no targets, silent config typos, --files validation bypass

### DIFF
--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -144,6 +144,7 @@ pub fn auto_enable_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::CliProvided;
     use crate::config::{self, Config};
     use crate::test_support::{env_mutex, EnvGuard};
     use clap::Parser;
@@ -307,13 +308,14 @@ mod tests {
         config.provider.vt_api_key = Some("config-vt".to_string());
         config.provider.urlscan_api_key = Some("config-urlscan".to_string());
         config.provider.zoomeye_api_key = Some("config-zoomeye".to_string());
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         let provider_keys = config::ProviderKeysConfig {
             vt_api_key: Some("provider-vt".to_string()),
             urlscan_api_key: Some("provider-urlscan".to_string()),
             zoomeye_api_key: Some("provider-zoomeye".to_string()),
             github_api_key: None,
+            unknown: Default::default(),
         };
         provider_keys.apply_to_args(
             &mut args,

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -35,6 +35,18 @@ const CDX_PROVIDERS: [&str; 3] = ["wayback", "cc", "arquivo"];
 /// a multi-value positive filter (see [`providers::ArchiveFilters`]).
 const PYWB_PROVIDERS: [&str; 2] = ["cc", "arquivo"];
 
+/// Trim the ids named by a provider-selecting flag.
+///
+/// clap splits `--providers` on commas but keeps the surrounding spaces, so the
+/// entirely natural `--providers "wayback, cc"` used to fail with
+/// `Unknown provider id(s) in --providers:  cc. Allowed values: ..., cc, ...`
+/// — an error that names the value it is simultaneously rejecting. An entry
+/// that is empty *after* trimming is left in place so it is still reported,
+/// rather than turning `--providers ""` into a silently different selection.
+fn trimmed_ids(raw: &[String]) -> Vec<String> {
+    raw.iter().map(|id| id.trim().to_string()).collect()
+}
+
 /// Which providers this run would use, given the flags and available API keys.
 ///
 /// Pure and side-effect free — [`crate::app::caching::create_cache_key`] relies
@@ -52,7 +64,7 @@ pub fn effective_provider_ids(args: &Args) -> Vec<String> {
             .map(|p| p.id.to_string())
             .collect()
     } else {
-        args.providers.clone()
+        trimmed_ids(&args.providers)
     };
 
     if !args.all_providers {
@@ -64,7 +76,8 @@ pub fn effective_provider_ids(args: &Args) -> Vec<String> {
         }
     }
 
-    let excluded: HashSet<&str> = args.exclude_providers.iter().map(String::as_str).collect();
+    let excluded_ids = trimmed_ids(&args.exclude_providers);
+    let excluded: HashSet<&str> = excluded_ids.iter().map(String::as_str).collect();
     providers_list.retain(|p| !excluded.contains(p.as_str()));
 
     for (id, requested) in [
@@ -164,11 +177,11 @@ fn warn_about_inert_archive_filters(
 /// Validate every provider-selecting flag before any network client is built,
 /// so a typo fails immediately instead of after minutes of fetching.
 fn validate_selection_flags(args: &Args) -> Result<()> {
-    validate_provider_ids(&args.providers, "--providers")?;
+    validate_provider_ids(&trimmed_ids(&args.providers), "--providers")?;
     // A misspelled preset used to be dropped in silence, producing an
     // unfiltered run that looked like the filter had matched everything.
     validate_presets(&args.preset)?;
-    validate_provider_ids(&args.exclude_providers, "--exclude-providers")?;
+    validate_provider_ids(&trimmed_ids(&args.exclude_providers), "--exclude-providers")?;
     validate_rate_limit_override_ids(args)
 }
 
@@ -303,13 +316,13 @@ pub fn initialize_providers(
     }
 
     if providers.is_empty() {
-        if !args.silent {
-            eprintln!(
-                "Error: No valid providers specified. Please use --providers with valid provider names ({})",
-                valid_provider_ids().join(", ")
-            );
-        }
-        return Err(anyhow::anyhow!("No valid providers specified"));
+        // Returned, not printed-and-returned: `main` reports the error too, so
+        // the old eprintln made every no-provider run emit the message twice —
+        // and the copy `--silent` suppressed was the one carrying the guidance.
+        return Err(anyhow::anyhow!(
+            "No valid providers specified. Please use --providers with valid provider names ({})",
+            valid_provider_ids().join(", ")
+        ));
     }
 
     Ok((providers, names))
@@ -561,6 +574,65 @@ mod tests {
         assert!(
             !ids.iter().any(|p| p == "vt"),
             "--exclude-providers must beat key-driven auto-enable; got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn test_provider_flags_tolerate_whitespace_around_commas() {
+        // Regression: clap splits on ',' but keeps the spaces, so
+        // `--providers "wayback, cc"` failed with
+        // "Unknown provider id(s) in --providers:  cc. Allowed values: ..., cc, ..."
+        // — an error naming the very value it rejected.
+        let _env_lock = env_mutex().lock().unwrap();
+        let _guard = EnvGuard::unset(&KEYED_ENV);
+
+        let args = Args::parse_from([
+            "urx",
+            "--providers",
+            " wayback , cc ",
+            "--exclude-providers",
+            " cc ",
+            "--exclude-robots",
+            "--exclude-sitemap",
+            "example.com",
+        ]);
+
+        assert_eq!(effective_provider_ids(&args), vec!["wayback"]);
+        let (providers, names) = initialize_providers(&args, &NetworkSettings::default())
+            .expect("whitespace around ids must not be an error");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(names, vec!["Wayback Machine"]);
+    }
+
+    #[test]
+    fn test_empty_provider_id_is_still_rejected() {
+        // Trimming must not quietly reinterpret an explicitly empty selection.
+        let mut args = build_test_args();
+        args.providers = vec![String::new()];
+        assert!(
+            selection_error(&args).contains("Unknown provider id(s) in --providers"),
+            "an empty id must still be reported"
+        );
+    }
+
+    #[test]
+    fn test_no_provider_error_carries_the_guidance_exactly_once() {
+        // The message used to be printed by this function *and* reported again
+        // by `main`, so a failing run showed it twice — and `--silent`
+        // suppressed the copy that carried the list of valid ids, leaving only
+        // the bare "No valid providers specified".
+        let _env_lock = env_mutex().lock().unwrap();
+        let _guard = EnvGuard::unset(&KEYED_ENV);
+
+        let mut args = build_test_args();
+        args.silent = true;
+        args.providers = vec![];
+
+        let err = selection_error(&args);
+        assert!(err.contains("No valid providers specified"), "{err}");
+        assert!(
+            err.contains("wayback"),
+            "the allowed ids must travel with the error: {err}"
         );
     }
 

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -174,9 +174,14 @@ fn warn_about_inert_archive_filters(
     );
 }
 
-/// Validate every provider-selecting flag before any network client is built,
-/// so a typo fails immediately instead of after minutes of fetching.
-fn validate_selection_flags(args: &Args) -> Result<()> {
+/// Validate every selection flag before any network client is built, so a typo
+/// fails immediately instead of after minutes of fetching.
+///
+/// Public because `--files` runs never reach [`initialize_providers`], and
+/// `--preset` is applied on that path too: `main` calls this up front so the
+/// checks cover every input mode. Running it twice on the provider path is
+/// harmless — it only reads `args`.
+pub fn validate_selection_flags(args: &Args) -> Result<()> {
     validate_provider_ids(&trimmed_ids(&args.providers), "--providers")?;
     // A misspelled preset used to be dropped in silence, producing an
     // unfiltered run that looked like the filter had matched everything.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug, Clone)]
@@ -399,6 +400,51 @@ pub struct Args {
     pub no_cache: bool,
 }
 
+/// The set of options the user actually named on the command line.
+///
+/// The config layers need this. A parsed [`Args`] cannot tell `--retries 2`
+/// from an unset `--retries`, so the old "does this field still equal its
+/// default?" test treated an explicitly supplied value as absent and let the
+/// config file overwrite it — the exact inverse of the documented
+/// `CLI > config` precedence.
+#[derive(Debug, Default, Clone)]
+pub struct CliProvided {
+    ids: HashSet<String>,
+}
+
+impl CliProvided {
+    /// True when `id` was supplied on the command line. `id` is the clap
+    /// argument id, which for this parser is the [`Args`] field name
+    /// (`format`, `providers`, `cache_ttl`, ...) regardless of the flag's
+    /// spelling.
+    pub fn has(&self, id: &str) -> bool {
+        self.ids.contains(id)
+    }
+}
+
+/// Parse the process arguments, recording which options were given explicitly.
+pub fn parse_args() -> (Args, CliProvided) {
+    parse_args_from(std::env::args_os())
+}
+
+/// [`parse_args`] over an explicit argv. Parse failures are rendered and the
+/// process exits exactly as [`Parser::parse_from`] would.
+pub fn parse_args_from<I, T>(argv: I) -> (Args, CliProvided)
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let matches = Args::command().get_matches_from(argv);
+    // Collected before `from_arg_matches`, which is free to consume `matches`.
+    let ids = matches
+        .ids()
+        .map(|id| id.as_str().to_string())
+        .filter(|id| matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine))
+        .collect();
+    let args = Args::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    (args, CliProvided { ids })
+}
+
 pub fn read_domains_from_stdin() -> anyhow::Result<Vec<String>> {
     use anyhow::Context;
     use std::io::{self, BufRead};
@@ -437,9 +483,22 @@ pub fn read_domains_from_file(path: &std::path::Path) -> anyhow::Result<Vec<Stri
     Ok(domains)
 }
 
+/// Drop a leading UTF-8 byte-order mark.
+///
+/// `str::trim` does not remove U+FEFF (it is not `White_Space`), so a domain
+/// list saved by Notepad, Excel, or PowerShell's `>` redirect used to turn its
+/// first entry into the host `"\u{feff}example.com"`. Every provider then
+/// queried that literally and returned nothing, with no diagnostic — the run
+/// simply looked like the archives had never seen the domain.
+fn strip_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 /// Trim whitespace and drop blank / comment lines from a single text line.
 fn parse_domain_line(line: &str) -> Option<String> {
-    let trimmed = line.trim();
+    // The BOM has to go before the comment test too, or `\u{feff}# note` on
+    // the first line reads as a domain instead of a comment.
+    let trimmed = strip_bom(line.trim()).trim();
     if trimmed.is_empty() || trimmed.starts_with('#') {
         None
     } else {
@@ -454,7 +513,10 @@ fn parse_domain_line(line: &str) -> Option<String> {
 /// fragment and lowercase the host. Returns `None` when nothing host-like
 /// remains. `www.` is intentionally preserved (it can be a distinct host).
 pub fn normalize_domain(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
+    // Also applied here, not just in `parse_domain_line`: a positional target
+    // can be pasted with a BOM too, and `--files`-mode host validation
+    // re-reads the raw target list.
+    let trimmed = strip_bom(raw.trim()).trim();
     if trimmed.is_empty() {
         return None;
     }
@@ -956,6 +1018,79 @@ mod tests {
             args.provider_config.as_deref().map(|p| p.to_str().unwrap()),
             Some("/tmp/keys.toml")
         );
+    }
+
+    #[test]
+    fn test_utf8_bom_is_stripped_from_domain_lines() {
+        // Regression: `str::trim` leaves U+FEFF in place (it is not
+        // `White_Space`), so the first entry of a BOM-prefixed domain list
+        // became the host "\u{feff}example.com". That host is interpolated
+        // straight into the CDX query string (`?url={domain}/*`), where reqwest
+        // percent-encodes it to %EF%BB%BF and every archive returns nothing —
+        // and strict host validation then rejects any URL that did come back.
+        // Both failures are silent: the run just looks like an empty archive.
+        assert_eq!(
+            parse_domain_line("\u{feff}example.com"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            normalize_domain("\u{feff}example.com").as_deref(),
+            Some("example.com")
+        );
+        assert_eq!(
+            normalize_domain("\u{feff}https://example.com/path").as_deref(),
+            Some("example.com")
+        );
+        // A BOM in front of a comment marker must not turn the comment into a
+        // target either.
+        assert_eq!(parse_domain_line("\u{feff}# a note"), None);
+        // A BOM-only line is blank.
+        assert_eq!(parse_domain_line("\u{feff}"), None);
+        assert_eq!(normalize_domain("\u{feff}"), None);
+    }
+
+    #[test]
+    fn test_read_domains_from_file_handles_bom_and_crlf() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        // Exactly what Notepad / Excel / PowerShell `>` produce.
+        file.write_all("\u{feff}example.com\r\n# note\r\nanother.test\r\n".as_bytes())
+            .unwrap();
+        let domains = read_domains_from_file(file.path()).unwrap();
+        assert_eq!(domains, vec!["example.com", "another.test"]);
+    }
+
+    #[test]
+    fn test_parse_args_records_only_command_line_options() {
+        // The whole point of `CliProvided`: a flag whose value equals the clap
+        // default is still an explicit choice, and the config layers must be
+        // able to see that.
+        let (args, provided) = parse_args_from(["urx", "example.com", "--format", "plain"]);
+        assert_eq!(args.format, "plain");
+        assert!(provided.has("format"), "--format was typed");
+        assert!(!provided.has("retries"), "--retries was not");
+        assert!(!provided.has("providers"));
+
+        let (_, provided) = parse_args_from(["urx", "example.com"]);
+        assert!(
+            !provided.has("format"),
+            "an untouched default must not look supplied"
+        );
+
+        // Defaults that happen to match what the user typed still count.
+        let (_, provided) = parse_args_from([
+            "urx",
+            "example.com",
+            "--retries",
+            "2",
+            "--providers",
+            "wayback,cc,otx",
+            "--cache-ttl",
+            "86400",
+        ]);
+        for id in ["retries", "providers", "cache_ttl"] {
+            assert!(provided.has(id), "{id} was supplied on the command line");
+        }
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,15 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::cli::Args;
+use crate::cli::{Args, CliProvided};
+
+/// Keys a config section did not recognise.
+///
+/// Captured rather than dropped so a typo can be reported. serde ignores
+/// unknown fields by default, which made a misspelled key — or worse, a
+/// misspelled *section* like `[filters]` — completely inert: every setting
+/// underneath it silently never applied.
+pub type UnknownKeys = std::collections::BTreeMap<String, toml::Value>;
 
 /// Represents the application configuration loaded from a file
 #[derive(Debug, Deserialize, Default)]
@@ -26,6 +34,10 @@ pub struct Config {
 
     #[serde(default)]
     pub cache: CacheConfig,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -34,6 +46,10 @@ pub struct OutputConfig {
     pub format: Option<String>,
     pub merge_endpoint: Option<bool>,
     pub stream: Option<bool>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -55,6 +71,10 @@ pub struct ProviderConfig {
     pub include_sitemap: Option<bool>,
     pub exclude_robots: Option<bool>,
     pub exclude_sitemap: Option<bool>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 /// Provider-config file: a small TOML that holds only API keys so the main
@@ -66,6 +86,37 @@ pub struct ProviderKeysConfig {
     pub urlscan_api_key: Option<String>,
     pub zoomeye_api_key: Option<String>,
     pub github_api_key: Option<String>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
+}
+
+/// Render one unrecognised entry for the warning: a whole unknown table is
+/// shown in section form (`[filters]`) so it's obvious the entire block is
+/// inert, anything else as a plain key path.
+fn describe_unknown(section: Option<&str>, key: &str, value: &toml::Value) -> String {
+    match section {
+        Some(section) => format!("{section}.{key}"),
+        None if value.is_table() => format!("[{key}]"),
+        None => key.to_string(),
+    }
+}
+
+/// Warn once about every config key urx did not recognise.
+///
+/// Silence here is expensive: a config whose section is spelled `[filters]`
+/// instead of `[filter]` parses cleanly and then does nothing at all, which
+/// reads as "the filter matched everything".
+fn warn_about_unknown_keys(unknown: &[String], source: &str, silent: bool) {
+    if unknown.is_empty() || silent {
+        return;
+    }
+    eprintln!(
+        "Warning: ignoring unrecognised {} in {source}: {}. Check for a typo — settings under an unknown key have no effect.",
+        if unknown.len() == 1 { "key" } else { "keys" },
+        unknown.join(", ")
+    );
 }
 
 /// Split a comma-separated key list into individual keys, trimming each and
@@ -79,6 +130,14 @@ fn split_csv(s: &str) -> Vec<String> {
 }
 
 impl ProviderKeysConfig {
+    /// Every key in the provider-config file urx does not recognise, sorted.
+    pub fn unknown_keys(&self) -> Vec<String> {
+        self.unknown
+            .iter()
+            .map(|(k, v)| describe_unknown(None, k, v))
+            .collect()
+    }
+
     /// Parse a provider-config TOML file from `path`. Returns the parsed
     /// struct or an error.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -154,6 +213,12 @@ impl ProviderKeysConfig {
         cli_supplied_zoomeye: bool,
         cli_supplied_github: bool,
     ) {
+        warn_about_unknown_keys(
+            &self.unknown_keys(),
+            "the provider-config file",
+            args.silent,
+        );
+
         if !cli_supplied_vt {
             if let Some(keys) = &self.vt_api_key {
                 args.vt_api_key = split_csv(keys);
@@ -189,6 +254,10 @@ pub struct FilterConfig {
     pub show_only_param: Option<bool>,
     pub min_length: Option<usize>,
     pub max_length: Option<usize>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -202,6 +271,10 @@ pub struct NetworkConfig {
     pub retries: Option<u32>,
     pub parallel: Option<u32>,
     pub rate_limit: Option<f32>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -210,6 +283,10 @@ pub struct TestingConfig {
     pub include_status: Option<Vec<String>>,
     pub exclude_status: Option<Vec<String>>,
     pub extract_links: Option<bool>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -220,6 +297,10 @@ pub struct CacheConfig {
     pub redis_url: Option<String>,
     pub cache_ttl: Option<u64>,
     pub no_cache: Option<bool>,
+
+    /// Anything in this section urx does not know about. See [`UnknownKeys`].
+    #[serde(flatten)]
+    pub unknown: UnknownKeys,
 }
 
 fn normalize_output_format(format: &str) -> Option<String> {
@@ -321,18 +402,50 @@ impl Config {
         Ok(Config::default())
     }
 
-    /// Apply configuration values to Args, respecting priority
-    /// Command line arguments take precedence over config file values
-    pub fn apply_to_args(self, args: &mut Args) {
-        self.apply_output_config(args);
-        self.apply_provider_config(args);
-        self.apply_filter_config(args);
-        self.apply_network_config(args);
-        self.apply_testing_config(args);
-        self.apply_cache_config(args);
+    /// Every key in the file urx does not recognise, as `section.key` — or
+    /// `[section]` for a whole unknown table. Sorted, so the warning is stable.
+    pub fn unknown_keys(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .unknown
+            .iter()
+            .map(|(k, v)| describe_unknown(None, k, v))
+            .collect();
+        for (section, unknown) in [
+            ("output", &self.output.unknown),
+            ("provider", &self.provider.unknown),
+            ("filter", &self.filter.unknown),
+            ("network", &self.network.unknown),
+            ("testing", &self.testing.unknown),
+            ("cache", &self.cache.unknown),
+        ] {
+            out.extend(
+                unknown
+                    .iter()
+                    .map(|(k, v)| describe_unknown(Some(section), k, v)),
+            );
+        }
+        out.sort();
+        out
     }
 
-    fn apply_output_config(&self, args: &mut Args) {
+    /// Apply configuration values to Args, respecting priority.
+    ///
+    /// `provided` names the options the user typed on the command line. Those
+    /// always win: a flag whose value happens to equal the clap default (say
+    /// an explicit `--format plain`) is still an explicit choice, and used to
+    /// be silently replaced by the config file's value.
+    pub fn apply_to_args(self, args: &mut Args, provided: &CliProvided) {
+        warn_about_unknown_keys(&self.unknown_keys(), "the config file", args.silent);
+
+        self.apply_output_config(args, provided);
+        self.apply_provider_config(args, provided);
+        self.apply_filter_config(args);
+        self.apply_network_config(args, provided);
+        self.apply_testing_config(args);
+        self.apply_cache_config(args, provided);
+    }
+
+    fn apply_output_config(&self, args: &mut Args, provided: &CliProvided) {
         // Output options
         if args.output.is_none() {
             if let Some(output) = &self.output.output {
@@ -340,7 +453,7 @@ impl Config {
             }
         }
 
-        if args.format == "plain" {
+        if !provided.has("format") {
             if let Some(format) = &self.output.format {
                 if let Some(format) = normalize_output_format(format) {
                     args.format = format;
@@ -361,9 +474,9 @@ impl Config {
         }
     }
 
-    fn apply_provider_config(&self, args: &mut Args) {
+    fn apply_provider_config(&self, args: &mut Args, provided: &CliProvided) {
         // Provider options
-        if args.providers == vec!["wayback", "cc", "otx"] {
+        if !provided.has("providers") {
             if let Some(providers) = &self.provider.providers {
                 args.providers = providers.clone();
             }
@@ -373,11 +486,9 @@ impl Config {
             args.subs = true;
         }
 
-        // Treat the default singleton list as "not user-supplied" so the file
-        // value wins. Config file still accepts a single string; we split it
-        // on commas so users can configure multi-index there too.
-        let cc_default = vec!["latest".to_string()];
-        if args.cc_index == cc_default {
+        // Config file still accepts a single string; we split it on commas so
+        // users can configure multi-index there too.
+        if !provided.has("cc_index") {
             if let Some(cc_index) = &self.provider.cc_index {
                 let split: Vec<String> = cc_index
                     .split(',')
@@ -529,9 +640,9 @@ impl Config {
         }
     }
 
-    fn apply_network_config(&self, args: &mut Args) {
+    fn apply_network_config(&self, args: &mut Args, provided: &CliProvided) {
         // Network options
-        if args.network_scope == "all" {
+        if !provided.has("network_scope") {
             if let Some(network_scope) = &self.network.network_scope {
                 if let Some(network_scope) = normalize_network_scope(network_scope) {
                     args.network_scope = network_scope;
@@ -559,7 +670,7 @@ impl Config {
             args.random_agent = true;
         }
 
-        if args.timeout == 120 {
+        if !provided.has("timeout") {
             if let Some(timeout) = self.network.timeout {
                 if timeout > 0 {
                     args.timeout = timeout;
@@ -571,13 +682,13 @@ impl Config {
             }
         }
 
-        if args.retries == 2 {
+        if !provided.has("retries") {
             if let Some(retries) = self.network.retries {
                 args.retries = retries;
             }
         }
 
-        if args.parallel.unwrap_or(5) == 5 && self.network.parallel.is_some() {
+        if !provided.has("parallel") {
             if let Some(parallel) = self.network.parallel {
                 if parallel > 0 {
                     args.parallel = Some(parallel);
@@ -615,13 +726,13 @@ impl Config {
         }
     }
 
-    fn apply_cache_config(&self, args: &mut Args) {
+    fn apply_cache_config(&self, args: &mut Args, provided: &CliProvided) {
         // Cache options
         if !args.incremental && self.cache.incremental.unwrap_or(false) {
             args.incremental = true;
         }
 
-        if args.cache_type == "sqlite" {
+        if !provided.has("cache_type") {
             if let Some(cache_type) = &self.cache.cache_type {
                 // Mirrors how [output].format and [network].network_scope are
                 // handled: name the bad value at the point it was read, rather
@@ -650,7 +761,7 @@ impl Config {
             args.redis_url = self.cache.redis_url.clone();
         }
 
-        if args.cache_ttl == 86400 {
+        if !provided.has("cache_ttl") {
             if let Some(cache_ttl) = self.cache.cache_ttl {
                 args.cache_ttl = cache_ttl;
             }
@@ -780,7 +891,7 @@ mod tests {
         assert_eq!(args.providers, vec!["wayback", "cc", "otx"]);
 
         // Apply config to args
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         // Verify args were updated correctly
         assert_eq!(args.output, Some(PathBuf::from("output.txt")));
@@ -795,7 +906,7 @@ mod tests {
         config.network.parallel = Some(0);
 
         let mut args = Args::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.timeout, 120);
         assert_eq!(args.parallel, Some(5));
@@ -808,7 +919,7 @@ mod tests {
         config.network.network_scope = Some("providers only".to_string());
 
         let mut args = Args::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.format, "plain");
         assert_eq!(args.network_scope, "all");
@@ -821,7 +932,7 @@ mod tests {
         config.network.network_scope = Some("TESTERS,PROVIDERS".to_string());
 
         let mut args = Args::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.format, "json");
         assert_eq!(args.network_scope, "providers,testers");
@@ -882,7 +993,7 @@ mod tests {
         config.provider.github_api_key = Some("gh1,gh2".to_string());
 
         let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.vt_api_key, vec!["k1", "k2", "k3"]);
         assert_eq!(args.urlscan_api_key, vec!["us1", "us2"]);
@@ -917,7 +1028,7 @@ mod tests {
         let mut config = Config::default();
         config.provider.github_api_key = Some("from-main".to_string());
         let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
         assert_eq!(args.github_api_key, vec!["from-main"]);
 
         let keys = ProviderKeysConfig {
@@ -925,6 +1036,7 @@ mod tests {
             urlscan_api_key: None,
             zoomeye_api_key: None,
             github_api_key: Some("from-provider-config".to_string()),
+            unknown: Default::default(),
         };
         keys.apply_to_args(&mut args, false, false, false, false);
         assert_eq!(args.github_api_key, vec!["from-provider-config"]);
@@ -942,14 +1054,14 @@ mod tests {
         let mut config = Config::default();
         config.cache.cache_type = Some("postgres".to_string());
         let mut args = <Args as clap::Parser>::parse_from(["urx", "--silent", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
         assert_eq!(args.cache_type, "sqlite", "invalid value must be ignored");
 
         // A valid value still applies, case-insensitively.
         let mut config = Config::default();
         config.cache.cache_type = Some("Redis".to_string());
         let mut args = <Args as clap::Parser>::parse_from(["urx", "--silent", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
         assert_eq!(args.cache_type, "redis");
     }
 
@@ -967,6 +1079,7 @@ mod tests {
             urlscan_api_key: Some("us-from-file".to_string()),
             zoomeye_api_key: None,
             github_api_key: None,
+            unknown: Default::default(),
         };
         let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
         // Pretend the user supplied vt via CLI: provider-config should NOT
@@ -990,6 +1103,7 @@ mod tests {
             urlscan_api_key: None,
             zoomeye_api_key: None,
             github_api_key: None,
+            unknown: Default::default(),
         };
         let mut args = <Args as clap::Parser>::parse_from(["urx", "example.com"]);
         cfg.apply_to_args(&mut args, false, false, false, false);
@@ -1011,7 +1125,7 @@ mod tests {
         let config = Config::from_file(file.path()).unwrap();
 
         let mut args = Args::parse_from(["urx", "example.com"]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.from.as_deref(), Some("2020"));
         assert_eq!(args.to.as_deref(), Some("2021"));
@@ -1019,6 +1133,218 @@ mod tests {
         assert_eq!(args.archive_exclude_status, vec!["404", "500"]);
         assert_eq!(args.archive_mime, vec!["application/json"]);
         assert_eq!(args.archive_exclude_mime, vec!["text/html"]);
+    }
+
+    #[test]
+    fn test_explicit_cli_flag_wins_even_when_it_equals_the_default() {
+        // Regression: precedence used to be decided by "does this field still
+        // equal its clap default?", which cannot see the difference between
+        // `--format plain` and no `--format` at all. Every option whose default
+        // a user might legitimately type back was therefore silently
+        // overridden by the config file — `urx --format plain` printed JSON.
+        let content = r#"
+            [output]
+            format = "json"
+
+            [provider]
+            providers = ["arquivo"]
+            cc_index = "CC-MAIN-2020-05"
+
+            [network]
+            network_scope = "testers"
+            timeout = 30
+            retries = 9
+            parallel = 2
+
+            [cache]
+            cache_type = "redis"
+            cache_ttl = 60
+        "#;
+        let file = create_temp_config_file(content);
+
+        let argv = [
+            "urx",
+            "--format",
+            "plain",
+            "--providers",
+            "wayback,cc,otx",
+            "--cc-index",
+            "latest",
+            "--network-scope",
+            "all",
+            "--timeout",
+            "120",
+            "--retries",
+            "2",
+            "--parallel",
+            "5",
+            "--cache-type",
+            "sqlite",
+            "--cache-ttl",
+            "86400",
+            "example.com",
+        ];
+        let (mut args, provided) = crate::cli::parse_args_from(argv);
+        Config::from_file(file.path())
+            .unwrap()
+            .apply_to_args(&mut args, &provided);
+
+        assert_eq!(args.format, "plain");
+        assert_eq!(args.providers, vec!["wayback", "cc", "otx"]);
+        assert_eq!(args.cc_index, vec!["latest"]);
+        assert_eq!(args.network_scope, "all");
+        assert_eq!(args.timeout, 120);
+        assert_eq!(args.retries, 2);
+        assert_eq!(args.parallel, Some(5));
+        assert_eq!(args.cache_type, "sqlite");
+        assert_eq!(args.cache_ttl, 86400);
+    }
+
+    #[test]
+    fn test_config_still_applies_when_the_flag_was_not_supplied() {
+        // The other half of the contract: without the flag, the file wins.
+        let content = r#"
+            [output]
+            format = "json"
+
+            [provider]
+            providers = ["arquivo"]
+            cc_index = "CC-MAIN-2020-05"
+
+            [network]
+            network_scope = "testers"
+            timeout = 30
+            retries = 9
+            parallel = 2
+
+            [cache]
+            cache_type = "redis"
+            cache_ttl = 60
+        "#;
+        let file = create_temp_config_file(content);
+
+        let (mut args, provided) = crate::cli::parse_args_from(["urx", "example.com"]);
+        Config::from_file(file.path())
+            .unwrap()
+            .apply_to_args(&mut args, &provided);
+
+        assert_eq!(args.format, "json");
+        assert_eq!(args.providers, vec!["arquivo"]);
+        assert_eq!(args.cc_index, vec!["CC-MAIN-2020-05"]);
+        assert_eq!(args.network_scope, "testers");
+        assert_eq!(args.timeout, 30);
+        assert_eq!(args.retries, 9);
+        assert_eq!(args.parallel, Some(2));
+        assert_eq!(args.cache_type, "redis");
+        assert_eq!(args.cache_ttl, 60);
+    }
+
+    #[test]
+    fn test_unknown_config_keys_and_sections_are_reported() {
+        // Regression: serde drops unknown fields in silence, so a misspelled
+        // key — or a whole misspelled section like `[filters]` — parsed
+        // cleanly and then did absolutely nothing. Users read the resulting
+        // unfiltered output as "the filter matched everything".
+        let content = r#"
+            stray = 1
+
+            [output]
+            fromat = "json"
+
+            [filters]
+            extensions = ["js"]
+
+            [provider]
+            provdiers = ["wayback"]
+
+            [network]
+            rate_limit = 5
+        "#;
+        let config = Config::from_file(create_temp_config_file(content).path()).unwrap();
+
+        assert_eq!(
+            config.unknown_keys(),
+            vec![
+                "[filters]".to_string(),
+                "output.fromat".to_string(),
+                "provider.provdiers".to_string(),
+                "stray".to_string(),
+            ]
+        );
+        // ...and capturing them must not disturb ordinary parsing, including
+        // the integer-to-float widening TOML does for `rate_limit`.
+        assert_eq!(config.network.rate_limit, Some(5.0));
+    }
+
+    #[test]
+    fn test_known_config_keys_are_not_reported_as_unknown() {
+        let content = r#"
+            [output]
+            output = "out.txt"
+            format = "json"
+            merge_endpoint = true
+            stream = false
+
+            [provider]
+            providers = ["wayback"]
+            subs = true
+            cc_index = "latest"
+            from = "2020"
+            to = "2021"
+            vt_api_key = "k"
+            include_robots = false
+
+            [filter]
+            preset = ["no-images"]
+            extensions = ["js"]
+            min_length = 5
+            max_length = 500
+
+            [network]
+            network_scope = "all"
+            proxy = "http://p:1"
+            insecure = true
+            timeout = 10
+            retries = 1
+            parallel = 2
+            rate_limit = 1.5
+
+            [testing]
+            check_status = true
+            include_status = ["200"]
+
+            [cache]
+            incremental = true
+            cache_type = "sqlite"
+            cache_path = "/tmp/x.db"
+            cache_ttl = 10
+            no_cache = false
+        "#;
+        let config = Config::from_file(create_temp_config_file(content).path()).unwrap();
+        assert!(
+            config.unknown_keys().is_empty(),
+            "{:?}",
+            config.unknown_keys()
+        );
+    }
+
+    #[test]
+    fn test_unknown_provider_config_keys_are_reported() {
+        let content = r#"
+            vt_api_key = "abc"
+            vt_apikey = "typo"
+
+            [provider]
+            zoomeye_api_key = "z"
+        "#;
+        let cfg = ProviderKeysConfig::from_file(create_temp_config_file(content).path()).unwrap();
+        assert_eq!(cfg.vt_api_key.as_deref(), Some("abc"));
+        let mut unknown = cfg.unknown_keys();
+        unknown.sort();
+        assert_eq!(
+            unknown,
+            vec!["[provider]".to_string(), "vt_apikey".to_string()]
+        );
     }
 
     #[test]
@@ -1039,7 +1365,7 @@ mod tests {
             "404",
             "example.com",
         ]);
-        config.apply_to_args(&mut args);
+        config.apply_to_args(&mut args, &CliProvided::default());
 
         assert_eq!(args.from.as_deref(), Some("2015"));
         assert_eq!(args.archive_status, vec!["404"]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use clap::Parser;
 use std::sync::Arc;
 
 mod app;
@@ -29,7 +28,7 @@ use app::pipeline::{
 };
 use app::report::{configure_colors, print_provider_stats, render_header, write_per_domain_output};
 use app::selection::initialize_providers;
-use cli::Args;
+use cli::{Args, CliProvided};
 use config::Config;
 use network::NetworkSettings;
 use output::create_outputter;
@@ -40,12 +39,12 @@ use utils::verbose_print;
 
 /// Load the config layers over `args`, honouring the documented precedence:
 /// `CLI/env` > provider-config file > main config file.
-fn apply_config_layers(args: &mut Args) -> Result<()> {
+fn apply_config_layers(args: &mut Args, provided: &CliProvided) -> Result<()> {
     // Must run before either config layer: afterwards there is no way to tell a
     // key the user supplied from one a config file filled in.
     let direct = seed_api_keys_from_env(args);
 
-    Config::load(args)?.apply_to_args(args);
+    Config::load(args)?.apply_to_args(args, provided);
 
     // The provider-config file is separate from the main config and overrides
     // it, but still loses to anything supplied on the CLI or in the environment.
@@ -71,7 +70,7 @@ async fn collect_urls(
     progress_manager: &ProgressManager,
     stream_sink: Option<&Arc<output::StreamSink>>,
     header: &mut Option<indicatif::ProgressBar>,
-) -> Result<Option<ProviderRunResult>> {
+) -> Result<ProviderRunResult> {
     // File input skips provider processing entirely. Every URL is attributed to
     // "file" so downstream `--show-sources` stays consistent.
     if let Some(urls) = read_urls_from_files(args)? {
@@ -80,20 +79,21 @@ async fn collect_urls(
         for url in urls {
             url_map.entry(url).or_default().insert("file".to_string());
         }
-        return Ok(Some(ProviderRunResult {
+        return Ok(ProviderRunResult {
             urls: url_map,
             stats: Vec::new(),
-        }));
+        });
     }
 
     let domains = collect_domains(args)?;
     if domains.is_empty() {
-        if !args.silent {
-            eprintln!(
-                "No domains provided. Pass DOMAINS positionally, use --domain-list FILE, or pipe them through stdin."
-            );
-        }
-        return Ok(None);
+        // A usage error, not a successful empty run: reported through the
+        // `Result` so the process exits non-zero. Printing it and returning
+        // `Ok` made `urx | wc -l` in a script look like a target that simply
+        // has no archived URLs.
+        return Err(anyhow::anyhow!(
+            "No domains provided. Pass DOMAINS positionally, use --domain-list FILE, or pipe them through stdin."
+        ));
     }
 
     let (providers, provider_names) = initialize_providers(args, network_settings)?;
@@ -105,31 +105,27 @@ async fn collect_urls(
     // Streaming writes as it goes and bypasses the cache entirely (the cache
     // both reads whole domains and writes whole result sets).
     if let Some(sink) = stream_sink {
-        return Ok(Some(
-            process_domains(
-                domains,
-                args,
-                progress_manager,
-                &providers,
-                &provider_names,
-                Some(Arc::clone(sink)),
-            )
-            .await,
-        ));
-    }
-
-    let cache_manager = create_cache_manager(args).await?;
-    Ok(Some(
-        process_domains_with_cache(
+        return Ok(process_domains(
             domains,
             args,
             progress_manager,
             &providers,
             &provider_names,
-            cache_manager.as_ref(),
+            Some(Arc::clone(sink)),
         )
-        .await?,
-    ))
+        .await);
+    }
+
+    let cache_manager = create_cache_manager(args).await?;
+    process_domains_with_cache(
+        domains,
+        args,
+        progress_manager,
+        &providers,
+        &provider_names,
+        cache_manager.as_ref(),
+    )
+    .await
 }
 
 /// Re-request the surviving URLs when `--check-status` or `--extract-links`
@@ -204,7 +200,7 @@ fn write_output(args: &Args, final_urls: &[output::UrlData]) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut args = Args::parse();
+    let (mut args, provided) = cli::parse_args();
 
     // Short-circuit: list providers and exit without doing any I/O.
     if args.list_providers {
@@ -212,7 +208,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    apply_config_layers(&mut args)?;
+    apply_config_layers(&mut args, &provided)?;
 
     // Honor --no-color / NO_COLOR before any styled output is produced.
     configure_colors(&args);
@@ -225,17 +221,14 @@ async fn main() -> Result<()> {
     let stream_sink = build_stream_sink(&args)?;
 
     let mut header = None;
-    let Some(run_result) = collect_urls(
+    let run_result = collect_urls(
         &args,
         &network_settings,
         &progress_manager,
         stream_sink.as_ref(),
         &mut header,
     )
-    .await?
-    else {
-        return Ok(());
-    };
+    .await?;
 
     if let Some(sink) = &stream_sink {
         // Everything has already been written by the sink; printing the
@@ -278,4 +271,45 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::io::Write;
+
+    /// A run with nothing to scan must fail, not report success.
+    ///
+    /// `--domain-list` is used rather than an empty argv because
+    /// [`collect_domains`] falls back to reading stdin when no target was named
+    /// at all, which would block the test. A file holding only unusable entries
+    /// exercises the same "zero effective targets" path without it — and is
+    /// itself a case that used to exit 0 while scanning nothing.
+    #[tokio::test]
+    async fn no_effective_targets_is_a_usage_error() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        // Neither line yields a host: one is scheme-only, one is a bare slash.
+        writeln!(file, "https://\n/").unwrap();
+
+        let args = Args::parse_from([
+            "urx",
+            "--silent",
+            "--no-progress",
+            "--domain-list",
+            file.path().to_str().unwrap(),
+        ]);
+
+        let err = collect_urls(
+            &args,
+            &NetworkSettings::default(),
+            &ProgressManager::new(true),
+            None,
+            &mut None,
+        )
+        .await
+        .expect_err("a run with no resolvable target must not succeed");
+
+        assert!(err.to_string().contains("No domains provided"), "{err}");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,13 @@ use app::pipeline::{
     build_testers, collect_domains, read_urls_from_files, should_check_status,
 };
 use app::report::{configure_colors, print_provider_stats, render_header, write_per_domain_output};
-use app::selection::initialize_providers;
+use app::selection::{initialize_providers, validate_selection_flags};
 use cli::{Args, CliProvided};
 use config::Config;
 use network::NetworkSettings;
 use output::create_outputter;
 use progress::ProgressManager;
-use runner::{process_domains, ProviderRunResult};
+use runner::{process_domains, ProviderRunResult, ProviderStats};
 use tester_manager::process_urls_with_testers;
 use utils::verbose_print;
 
@@ -71,9 +71,20 @@ async fn collect_urls(
     stream_sink: Option<&Arc<output::StreamSink>>,
     header: &mut Option<indicatif::ProgressBar>,
 ) -> Result<ProviderRunResult> {
+    // Ahead of the `--files` short-circuit below, which never reaches
+    // `initialize_providers`. `--preset` is applied to file input just like
+    // provider output, so a misspelled preset used to be dropped in silence
+    // there and emit an unfiltered run that looked like the filter had matched
+    // everything — the exact failure this validation exists to prevent.
+    validate_selection_flags(args)?;
+
     // File input skips provider processing entirely. Every URL is attributed to
     // "file" so downstream `--show-sources` stays consistent.
+    let read_started = std::time::Instant::now();
     if let Some(urls) = read_urls_from_files(args)? {
+        let elapsed = read_started.elapsed();
+        // Counted before deduplication, matching what a provider row reports.
+        let url_count = urls.len();
         let mut url_map: std::collections::HashMap<String, std::collections::HashSet<String>> =
             std::collections::HashMap::new();
         for url in urls {
@@ -81,7 +92,19 @@ async fn collect_urls(
         }
         return Ok(ProviderRunResult {
             urls: url_map,
-            stats: Vec::new(),
+            // `--stats` must not fall silent just because the URLs came from a
+            // file rather than a provider: an explicit flag printing nothing at
+            // all reads as "the run collected nothing". Labelled "file", the
+            // same source name `--show-sources` gives these URLs. `error_count`
+            // is honestly 0 — `read_urls_from_files` propagates the first
+            // failure, so reaching here means every file was read.
+            stats: vec![ProviderStats {
+                name: "file".to_string(),
+                url_count,
+                error_count: 0,
+                partial_count: 0,
+                elapsed,
+            }],
         });
     }
 
@@ -311,5 +334,99 @@ mod tests {
         .expect_err("a run with no resolvable target must not succeed");
 
         assert!(err.to_string().contains("No domains provided"), "{err}");
+    }
+
+    /// Build an `Args` for a `--files` run over a temp file of `urls`.
+    fn files_args(file: &tempfile::NamedTempFile, extra: &[&str]) -> Args {
+        let mut argv = vec![
+            "urx",
+            "--no-progress",
+            "--files",
+            file.path().to_str().unwrap(),
+        ];
+        argv.extend_from_slice(extra);
+        Args::parse_from(argv)
+    }
+
+    fn temp_urls() -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "https://example.com/a.js\nhttps://example.com/b.php\nhttps://example.com/c.png"
+        )
+        .unwrap();
+        file
+    }
+
+    async fn run_files(args: &Args) -> Result<ProviderRunResult> {
+        collect_urls(
+            args,
+            &NetworkSettings::default(),
+            &ProgressManager::new(true),
+            None,
+            &mut None,
+        )
+        .await
+    }
+
+    /// Regression: `--files` short-circuits before `initialize_providers`, so
+    /// none of the selection flags were validated on that path. A misspelled
+    /// `--preset` was the damaging case — presets *are* applied to file input,
+    /// so `--preset only-jss` silently emitted every URL, which reads as a
+    /// filter that matched everything.
+    #[tokio::test]
+    async fn selection_flags_are_validated_for_file_input_too() {
+        let file = temp_urls();
+
+        for (extra, expected) in [
+            (
+                vec!["--preset", "only-jss"],
+                "Unknown preset(s) in --preset",
+            ),
+            (
+                vec!["--providers", "bogus"],
+                "Unknown provider id(s) in --providers",
+            ),
+            (
+                vec!["--exclude-providers", "bogus"],
+                "Unknown provider id(s) in --exclude-providers",
+            ),
+            (
+                vec!["--rate-limit-by", "wayback=fast"],
+                "Malformed entry in --rate-limit-by",
+            ),
+        ] {
+            let args = files_args(&file, &extra);
+            let err = run_files(&args)
+                .await
+                .expect_err("a bad selection flag must fail even with --files");
+            assert!(err.to_string().contains(expected), "{extra:?}: {err}");
+        }
+
+        // ...and a valid invocation still runs.
+        assert!(run_files(&files_args(&file, &["--preset", "only-js"]))
+            .await
+            .is_ok());
+    }
+
+    /// Regression: file input reported `stats: Vec::new()`, and
+    /// `print_provider_stats` returns early on an empty slice — so an explicit
+    /// `--stats` printed absolutely nothing, which reads as "the run collected
+    /// nothing" rather than "these URLs did not come from a provider".
+    #[tokio::test]
+    async fn file_input_reports_a_stats_row() {
+        let file = temp_urls();
+        let result = run_files(&files_args(&file, &["--stats"])).await.unwrap();
+
+        assert_eq!(result.stats.len(), 1, "{:?}", result.stats);
+        let row = &result.stats[0];
+        assert_eq!(row.name, "file");
+        // Counted before deduplication, exactly as a provider row is.
+        assert_eq!(row.url_count, 3);
+        assert_eq!(row.error_count, 0);
+        assert_eq!(row.partial_count, 0);
+        // Every URL is still attributed to the "file" source.
+        assert_eq!(result.urls.len(), 3);
+        assert!(result.urls.values().all(|sources| sources.contains("file")));
     }
 }


### PR DESCRIPTION
Eight defects in the CLI surface, config loading, and provider selection. Every fix has a regression test; `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` and `cargo test --bin urx` (678 passed) are all green. Rebased on `main` (includes #356 and #357).

Files touched: `src/cli/mod.rs`, `src/config/mod.rs`, `src/app/selection.rs`, `src/app/keys.rs`, `src/main.rs`. Nothing outside the CLI/config area.

---

### 1. `urx` with no targets exits 0

**Symptom** — a run that resolved zero domains printed a hint and exited **0**. In a script that is indistinguishable from a domain the archives have never seen.

**Repro**
```console
$ urx --no-progress </dev/null
No domains provided. Pass DOMAINS positionally, use --domain-list FILE, or pipe them through stdin.
$ echo $?
0
```
Same for a `--domain-list` whose entries all fail to normalize (e.g. a file of bare `https://` / `/` lines): urx exits 0 having scanned nothing.

**Root cause** — `src/main.rs:89-97` (pre-fix): the empty-domain branch `eprintln!`s and returns `Ok(None)`; `main` maps that to `Ok(())`.

**Fix** — the condition travels back as an `anyhow` error, so the process exits non-zero like every other usage mistake (`--preset bogus`, unknown provider id, unreadable `--domain-list` — all already exit 1). `collect_urls` loses its now-always-`Some` `Option` wrapper.

```console
$ urx --no-progress </dev/null
Error: No domains provided. Pass DOMAINS positionally, use --domain-list FILE, or pipe them through stdin.
$ echo $?
1
```
> Exit 1 rather than 2, deliberately: it matches what urx already returns for every other validation failure. Say the word if you'd prefer a distinct `EX_USAGE`-style 2 for usage errors specifically.

**Test** — `main.rs::tests::no_effective_targets_is_a_usage_error`

---

### 2. An explicit CLI flag is overridden by the config file whenever its value equals the default

**Symptom** — `urx --format plain` prints **JSON** if the config file says `format = "json"`. This is the documented `CLI > config` precedence inverted.

**Repro**
```console
$ cat cfg.toml
[output]
format = "json"

$ urx --files urls.txt --config cfg.toml --format plain --no-progress
[{"url":"https://example.com/a.js"},{"url":"https://example.org/b.php"}
]
```

**Root cause** — `src/config/mod.rs`: precedence was decided by comparing the parsed field to its clap default — `args.format == "plain"` (:343), `args.providers == vec!["wayback","cc","otx"]` (:366), `args.cc_index == cc_default` (:380), `args.network_scope == "all"` (:534), `args.timeout == 120` (:562), `args.retries == 2` (:574), `args.parallel.unwrap_or(5) == 5` (:580), `args.cache_type == "sqlite"` (:624), `args.cache_ttl == 86400` (:653). That test cannot distinguish `--format plain` from no `--format` at all, so any flag whose value happens to equal the default is treated as absent.

**Fix** — `cli::parse_args` parses through `ArgMatches` and records which argument ids clap saw with `ValueSource::CommandLine` (new `CliProvided`). All nine sites now ask `!provided.has("<id>")`. `Config::apply_to_args` takes `&CliProvided`.

```console
$ urx --files urls.txt --config cfg.toml --format plain --no-progress
https://example.com/a.js
https://example.org/b.php
$ urx --files urls.txt --config cfg.toml --no-progress          # config still wins when unset
[{"url":"https://example.com/a.js"},...]
```

**Tests** — `config::tests::test_explicit_cli_flag_wins_even_when_it_equals_the_default` (all nine options), `..._config_still_applies_when_the_flag_was_not_supplied` (the other half of the contract), `cli::tests::test_parse_args_records_only_command_line_options`.

---

### 3. Misspelled config keys — and whole misspelled sections — are silently ignored

**Symptom** — serde drops unknown fields by default, so `[filters]` (plural) instead of `[filter]` parses cleanly and then does **nothing**. The user reads the unfiltered output as "the filter matched everything".

**Repro** (pre-fix: completely silent, exit 0)
```console
$ cat cfg.toml
stray = 1
[output]
fromat = "json"
[filters]
extensions = ["js"]
[provider]
provdiers = ["wayback"]

$ urx --files urls.txt --config cfg.toml --no-progress
https://example.com/a.js
https://example.org/b.php
```

**Root cause** — `src/config/mod.rs:10-69,180-223`: `#[derive(Deserialize)]` with no unknown-field handling on `Config` and all six section structs, and on `ProviderKeysConfig`.

**Fix** — each struct captures leftovers via `#[serde(flatten)] unknown: UnknownKeys`; `Config::unknown_keys()` / `ProviderKeysConfig::unknown_keys()` flatten those into sorted paths and `apply_to_args` warns once. A warning rather than a hard error, matching how urx already reports a bad `[output].format` or `[cache].cache_type`. `--silent` suppresses it.

```console
$ urx --files urls.txt --config cfg.toml --no-progress
Warning: ignoring unrecognised keys in the config file: [filters], output.fromat, provider.provdiers, stray. Check for a typo — settings under an unknown key have no effect.
```

**Tests** — `test_unknown_config_keys_and_sections_are_reported`, `test_known_config_keys_are_not_reported_as_unknown` (guards against false positives across every documented key, and asserts `rate_limit = 5` still widens int→f32 under `flatten`), `test_unknown_provider_config_keys_are_reported`.

> **This immediately found a bug in the repo's own `example/config.toml`** — see Out-of-scope findings.

---

### 4. A UTF-8 BOM in a `--domain-list` silently corrupts the first target

**Symptom** — a domain list saved by Notepad/Excel/PowerShell `>` starts with U+FEFF. `str::trim` does **not** remove it (U+FEFF is not `White_Space`), so the first entry becomes the host `"\u{feff}example.com"`. That host is interpolated straight into the CDX query string (`src/providers/wayback.rs:148` — `?url={domain}/*`), where reqwest percent-encodes it to `%EF%BB%BF` and every archive returns nothing; strict host validation then rejects anything that did come back. Both failures are silent — the run just looks like an empty archive.

**Repro**
```console
$ printf '\xef\xbb\xbfexample.com\n' > domains.txt
$ urx --domain-list domains.txt --providers wayback --no-progress
# 0 URLs, 0 errors — the target queried was "\u{feff}example.com", not "example.com"
```
Related: a BOM in front of `#` on the first line stopped a comment being recognised as one, turning it into a target.

**Root cause** — `src/cli/mod.rs:441-448` (`parse_domain_line`) and `:456-482` (`normalize_domain`) both rely on `trim()` alone.

**Fix** — a `strip_bom` helper applied in both, so file, stdin, and positional inputs agree. CRLF was already handled by `trim()`; there's now a test pinning that too.

**Tests** — `test_utf8_bom_is_stripped_from_domain_lines`, `test_read_domains_from_file_handles_bom_and_crlf`.

---

### 5. `--providers "wayback, cc"` fails with an error that names the value it rejected

**Symptom**
```console
$ urx example.com --providers "wayback, cc"
Error: Unknown provider id(s) in --providers:  cc. Allowed values: arquivo, cc, github, otx, robots, sitemap, urlscan, vt, wayback, zoomeye
```
The rejected id (` cc`, with a leading space) is listed among the allowed values. clap splits on `,` but keeps the surrounding whitespace.

**Root cause** — `src/app/selection.rs:55,67,167,171`: `args.providers` / `args.exclude_providers` are consumed verbatim.

**Fix** — a `trimmed_ids` helper at all four read sites (these are the only ones in the tree). An entry that is **empty after trimming** is deliberately left in place so `--providers ""` is still reported rather than silently becoming a different selection.

**Tests** — `test_provider_flags_tolerate_whitespace_around_commas`, `test_empty_provider_id_is_still_rejected`.

---

### 6. "No valid providers specified" printed twice, and `--silent` hid the useful copy

**Symptom**
```console
$ urx example.com --providers wayback --exclude-providers wayback --exclude-robots --exclude-sitemap
Error: No valid providers specified. Please use --providers with valid provider names (arquivo, cc, ...)
Error: No valid providers specified
```
`initialize_providers` `eprintln!`s the guidance and *also* returns a bare error that `main` reports. Under `--silent` only the bare, guidance-free line survived.

**Root cause** — `src/app/selection.rs:305-313`.

**Fix** — the valid-id list travels inside the error; the `eprintln!` is gone. One line, and `--silent` no longer strips the part worth reading.

**Test** — `test_no_provider_error_carries_the_guidance_exactly_once`.

---

### 7. `--files` skips every selection-flag check, so a misspelled `--preset` silently returns everything

**Symptom** — `--files` short-circuits in `collect_urls` before `initialize_providers`, which is the only caller of `validate_selection_flags`. Presets *are* applied to file input, so a typo produces a full, unfiltered result set and exit 0 — the precise failure the existing comment on `validate_selection_flags` says it was added to prevent.

**Repro**
```console
$ cat urls.txt
https://example.com/a.js
https://example.com/b.php
https://example.com/c.png

$ urx --files urls.txt --preset only-js --no-progress      # correct
https://example.com/a.js

$ urx --files urls.txt --preset only-jss --no-progress     # one typo
https://example.com/a.js
https://example.com/b.php
https://example.com/c.png
$ echo $?
0
```
`--providers bogus`, `--exclude-providers bogus` and `--rate-limit-by wayback=fast` were ignored on this path just as quietly, all exiting 0. Without `--files` every one of them is a hard error.

**Root cause** — `src/main.rs:76` returns before `src/app/selection.rs:180` (`initialize_providers` → `validate_selection_flags`) is ever reached.

**Fix** — `validate_selection_flags` is now `pub` and called at the top of `collect_urls`, above the `--files` branch, so the checks cover every input mode. `initialize_providers` keeps its own call (it only re-reads `args`, and its existing tests assert it rejects bad ids on its own).

```console
$ urx --files urls.txt --preset only-jss --no-progress
Error: Unknown preset(s) in --preset: only-jss. Allowed values: no-resources, ...
$ echo $?
1
```

**Test** — `main.rs::tests::selection_flags_are_validated_for_file_input_too` (all four flags, plus a valid preset still running).

---

### 8. `--stats` prints nothing at all for `--files` input

**Symptom** — an explicitly requested flag producing total silence, indistinguishable from a run that collected nothing.

**Repro**
```console
$ urx --files urls.txt --stats --no-progress
https://example.com/a.js
https://example.com/b.php
https://example.com/c.png
$ echo $?
0
```
No stats block, no explanation.

**Root cause** — `src/main.rs` builds the file-input `ProviderRunResult` with `stats: Vec::new()`, and `print_provider_stats` (`src/app/report.rs:60`) returns early on an empty slice.

**Fix (main.rs half)** — the files path now emits a real row rather than an empty vec. It is labelled `file`, the same source name `--show-sources` already attributes these URLs to, and carries the URL count (pre-deduplication, exactly as a provider row does) and the wall time spent reading. `error_count` is honestly `0`: `read_urls_from_files` propagates the first failure with `?`, so reaching that point means every file was read.

```console
$ urx --files urls.txt --stats --no-progress
https://example.com/a.js
https://example.com/b.php
https://example.com/c.png

Provider stats:
  provider                urls   partial   errors     elapsed
  ------------------  --------  --------  -------  ----------
  file                       3         0        0         0ms
```
`--silent` still suppresses it, as before.

> **The `report.rs` half is not mine.** The sibling case — stats also vanishing on a **cache hit** — is in `src/app/report.rs` and belongs to **a6-runner-net**. The two fixes compose: mine makes the slice non-empty for file input, theirs handles an empty slice arriving for other reasons.

**Test** — `main.rs::tests::file_input_reports_a_stats_row`.

---

## Verification

```
cargo fmt --all                                  # clean
cargo clippy --all-targets -- -D warnings        # clean
cargo test --bin urx                             # 678 passed; 0 failed; 2 ignored
```
Each fix was also reproduced against the release binary before and after. The BOM claim about which host is actually requested was confirmed by pointing urx at a logging HTTP proxy (`--proxy`) and reading the request line.

---

## Out-of-scope findings

Not touched — outside my file ownership. Listed for routing.

1. **`example/config.toml` documents four keys urx never reads.** The new warning surfaces it immediately:
   ```console
   $ urx example.com --config example/config.toml
   Warning: ignoring unrecognised keys in the config file: domains, filter.strict, provider.no_progress, provider.silent, provider.verbose. ...
   ```
   - `domains = ["example.com", "example.org"]` — there is no top-level `domains` config key; users following the example get no targets (and, with fix #1, now a non-zero exit).
   - `verbose` / `silent` / `no_progress` are written *after* the `[provider]` header, so TOML nests them under `[provider]` — and `ProviderConfig` has no such fields. They have never done anything.
   - `[filter] strict = true` — `FilterConfig` has no `strict` field; host validation cannot be configured from a file at all.

   Either add the fields or fix the example. As it stands the shipped example emits a warning, which is correct but not a good first impression.

2. **`--files` mode skips host validation entirely** (`src/app/pipeline.rs:195`, `:383`). The comment says file input "has no queried domain to validate against", but `--domain-list`/positional domains can be supplied *alongside* `--files`, and `build_host_validator` reads exactly those. Today `urx --files urls.txt --domain-list one-domain.txt` emits URLs for every other host in the file with no filtering and no diagnostic.

3. **`--min-length 100 --max-length 10`** is accepted and silently yields an empty result set (`src/filters/url_filter.rs`). An unsatisfiable range is a usage error worth rejecting up front.

4. **`urx` with no arguments on a TTY blocks forever** reading stdin (`src/app/pipeline.rs:70`). The stdin fallback is right for pipelines but should be skipped when stdin is a terminal, otherwise a bare `urx` looks hung.

5. **A port or userinfo on a bare target survives `normalize_domain`, but not on a URL-shaped one.** `example.com:8080` → `example.com:8080`, while `https://example.com:8080/x` → `example.com`. Same for `user@example.com`. This is in a file I own, but the "right" answer depends on what providers should receive for a port-bearing target, so I left it rather than guess.
