### PR TITLE
fix(runner,net,testers): honest --max-time accounting, working 30x status checks, stdout hygiene

### DIFF
--- a/src/app/report.rs
+++ b/src/app/report.rs
@@ -60,26 +60,35 @@ pub fn print_provider_stats(stats: &[ProviderStats]) {
     if stats.is_empty() {
         return;
     }
-    eprintln!();
-    eprintln!("Provider stats:");
-    eprintln!(
-        "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}",
+    eprintln!("{}", render_provider_stats(stats));
+}
+
+/// The per-provider summary table, as text.
+fn render_provider_stats(stats: &[ProviderStats]) -> String {
+    let mut out = String::from("\nProvider stats:\n");
+    out.push_str(&format!(
+        "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}\n",
         "provider", "urls", "partial", "errors", "elapsed"
-    );
-    eprintln!(
-        "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}",
+    ));
+    out.push_str(&format!(
+        "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}\n",
         "------------------", "--------", "--------", "-------", "----------"
-    );
+    ));
     for s in stats {
-        eprintln!(
-            "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}",
+        // A provider cut off by --max-time / Ctrl-C is called out: every count
+        // on its row is a floor, not a total, and without the marker a run that
+        // was stopped mid-fetch reads exactly like one that finished.
+        out.push_str(&format!(
+            "  {:<18}  {:>8}  {:>8}  {:>7}  {:>10}{}\n",
             s.name,
             s.url_count,
             s.partial_count,
             s.error_count,
-            format_elapsed(s.elapsed)
-        );
+            format_elapsed(s.elapsed),
+            if s.aborted { "  (aborted)" } else { "" }
+        ));
     }
+    out
 }
 
 /// Sub-second durations read better in milliseconds; anything longer in
@@ -170,6 +179,43 @@ mod tests {
         assert_eq!(format_elapsed(Duration::from_millis(999)), "999ms");
         assert_eq!(format_elapsed(Duration::from_millis(1000)), "1.00s");
         assert_eq!(format_elapsed(Duration::from_millis(1500)), "1.50s");
+    }
+
+    #[test]
+    fn test_stats_table_flags_a_provider_that_was_cut_off() {
+        // Regression: a provider aborted by --max-time was rendered exactly
+        // like one that finished — same columns, no marker — so a truncated run
+        // read as a complete one.
+        let rows = [
+            ProviderStats {
+                name: "Wayback Machine".to_string(),
+                url_count: 1_200,
+                partial_count: 1,
+                error_count: 0,
+                elapsed: Duration::from_secs(90),
+                aborted: true,
+            },
+            ProviderStats {
+                name: "OTX".to_string(),
+                url_count: 3,
+                partial_count: 0,
+                error_count: 0,
+                elapsed: Duration::from_millis(120),
+                aborted: false,
+            },
+        ];
+
+        let table = render_provider_stats(&rows);
+        let wayback = table
+            .lines()
+            .find(|l| l.contains("Wayback Machine"))
+            .unwrap();
+        assert!(wayback.contains("90.00s"), "{wayback}");
+        assert!(wayback.ends_with("(aborted)"), "{wayback}");
+
+        // A provider that ran to completion carries no marker.
+        let otx = table.lines().find(|l| l.contains("OTX")).unwrap();
+        assert!(!otx.contains("aborted"), "{otx}");
     }
 
     #[test]

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -36,11 +36,37 @@ impl Default for HttpClientConfig {
 impl HttpClientConfig {
     /// Build a `reqwest::Client` from this configuration.
     ///
+    /// Redirects are followed (reqwest's default), which is what a provider
+    /// walking an archive index wants.
+    ///
     /// # Errors
     ///
     /// Returns an error if the proxy URL is invalid or the client fails to build.
     pub fn build_client(&self) -> Result<Client> {
+        self.build(true)
+    }
+
+    /// Build a client that reports redirects instead of following them.
+    ///
+    /// For a status *check* the redirect is the answer: following it reports
+    /// the status of a different URL than the one printed (`/old - 200 OK` when
+    /// `/old` actually answers 301), and it makes the documented
+    /// `--include-status 30x` unmatchable, because a 3xx never reaches the
+    /// filter. Not following also spares a redirect chain (or loop) per URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the proxy URL is invalid or the client fails to build.
+    pub fn build_client_no_redirect(&self) -> Result<Client> {
+        self.build(false)
+    }
+
+    fn build(&self, follow_redirects: bool) -> Result<Client> {
         let mut builder = Client::builder().timeout(Duration::from_secs(self.timeout));
+
+        if !follow_redirects {
+            builder = builder.redirect(reqwest::redirect::Policy::none());
+        }
 
         if self.insecure {
             builder = builder.danger_accept_invalid_certs(true);
@@ -319,6 +345,47 @@ mod tests {
         };
         let client = config.build_client();
         assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_redirect_policy_differs_between_the_two_builders() {
+        // Providers need the redirect followed to reach the document; a status
+        // check needs the redirect itself, or `--include-status 30x` can never
+        // match and the reported status belongs to another URL.
+        let mut server = mockito::Server::new_async().await;
+        let _redirect = server
+            .mock("GET", "/redir")
+            .with_status(302)
+            .with_header("location", "/final")
+            .create_async()
+            .await;
+        let _final_page = server
+            .mock("GET", "/final")
+            .with_status(200)
+            .with_body("arrived")
+            .create_async()
+            .await;
+
+        let config = HttpClientConfig::default();
+        let url = format!("{}/redir", server.url());
+
+        let followed = config
+            .build_client()
+            .unwrap()
+            .get(&url)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(followed.status(), 200);
+
+        let reported = config
+            .build_client_no_redirect()
+            .unwrap()
+            .get(&url)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(reported.status(), 302);
     }
 
     #[tokio::test]

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -1,6 +1,8 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 
 /// Braille-dot spinner frames — the calm, ubiquitous "modern CLI" spinner.
 /// Cycled at ~80ms it reads as smooth, light motion that pairs with the thin
@@ -80,6 +82,37 @@ pub fn provider_partial_style() -> ProgressStyle {
     .expect("static provider partial template is valid")
 }
 
+/// A run-wide "wrap up now" flag, shared by every [`ProgressReporter`] handed
+/// to a provider.
+///
+/// `--max-time` (and Ctrl-C) end a run by cancelling the provider tasks. A
+/// cancelled future is *dropped*, and a paginating provider accumulates its
+/// results in a local buffer until it returns — so every URL it had already
+/// paged in dies with the future. That is why a 90-second `--max-time` run over
+/// a domain with hundreds of thousands of captures yields zero URLs, despite
+/// `--max-time` being documented as "urx proceeds with whatever URLs have been
+/// collected so far".
+///
+/// The fix is cooperative: the runner raises this flag at the deadline and
+/// gives in-flight fetches a short grace window to notice. A provider that
+/// walks a cursor checks it between requests and takes the path it already has
+/// for a mid-walk failure — [`ProgressReporter::mark_partial`] and `break`,
+/// returning what it collected — instead of being cancelled with it.
+#[derive(Clone, Debug, Default)]
+pub struct StopSignal(Arc<AtomicBool>);
+
+impl StopSignal {
+    /// Ask every fetch sharing this signal to stop at its next checkpoint.
+    pub fn request_stop(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether a stop has been requested.
+    pub fn is_stopped(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
 /// A small, cloneable handle that providers use to surface fine-grained
 /// progress (e.g. "page 3/12") on their own line without knowing anything
 /// about `indicatif`. Cloning is cheap and updates are no-ops on a hidden bar,
@@ -90,6 +123,8 @@ pub struct ProgressReporter {
     /// Stable leading context (e.g. "(1/3) example.com · ") prepended to every
     /// detail so the line keeps identifying which domain is being worked.
     prefix: String,
+    /// Raised by the runner when the run must end. See [`StopSignal`].
+    stop: StopSignal,
     /// Set by a provider when the results it is about to return are known to be
     /// incomplete (e.g. a paginating fetch lost a page after already collecting
     /// some). Shared across clones via `Arc`, so the runner that handed the
@@ -106,7 +141,27 @@ impl ProgressReporter {
             bar,
             prefix: prefix.into(),
             partial: Arc::new(AtomicBool::new(false)),
+            stop: StopSignal::default(),
         }
+    }
+
+    /// Attach the run-wide stop signal, so this reporter's provider can wrap up
+    /// gracefully when the run ends.
+    pub fn with_stop_signal(mut self, stop: StopSignal) -> Self {
+        self.stop = stop;
+        self
+    }
+
+    /// Whether the run has asked this fetch to stop.
+    ///
+    /// A provider walking a paginated cursor should check this between requests
+    /// and, when it is `true`, call [`mark_partial`] and return the URLs it has
+    /// already collected. Ignoring it is safe but costs those URLs: the runner
+    /// hard-cancels whatever is still in flight once the grace window closes.
+    ///
+    /// [`mark_partial`]: ProgressReporter::mark_partial
+    pub fn stop_requested(&self) -> bool {
+        self.stop.is_stopped()
     }
 
     /// Replace the trailing status detail, keeping the stable prefix.
@@ -130,16 +185,92 @@ impl ProgressReporter {
     }
 }
 
+/// Where an out-of-band operator line is written.
+#[derive(Clone)]
+enum NoteSink {
+    /// Above the live region, through `MultiProgress` (which draws to stderr)
+    /// so the region's line tracking stays correct.
+    Region(MultiProgress),
+    /// No live region to disturb — straight to stderr.
+    Stderr,
+    /// Test-only: collect the lines so a test can assert *that* a message went
+    /// through this channel rather than to stdout.
+    #[cfg(test)]
+    Capture(Arc<Mutex<Vec<String>>>),
+}
+
+/// A cloneable, `Send + Sync` handle for writing an operator-facing line from
+/// inside a spawned task.
+///
+/// Everything urx says *about* a run belongs on stderr: stdout carries the URL
+/// list a caller pipes onward. The runner's per-domain verbose lines used to go
+/// through `println!`, so `urx -v > urls.txt` interleaved "Domain completed: …"
+/// into the results — and, written straight to the terminal, they also bypassed
+/// `MultiProgress`, desyncing its line tracking so a later [`ProgressManager::clear`]
+/// left stale bars behind.
+#[derive(Clone)]
+pub struct Notifier {
+    sink: NoteSink,
+}
+
+impl Notifier {
+    /// Write one line above the live region (or to stderr when there is none).
+    pub fn note(&self, msg: impl AsRef<str>) {
+        match &self.sink {
+            NoteSink::Region(multi) => {
+                let _ = multi.println(msg.as_ref());
+            }
+            NoteSink::Stderr => eprintln!("{}", msg.as_ref()),
+            #[cfg(test)]
+            NoteSink::Capture(lines) => lines
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(msg.as_ref().to_string()),
+        }
+    }
+}
+
 pub struct ProgressManager {
     multi_progress: MultiProgress,
     no_progress: bool,
+    notes: NoteSink,
 }
 
 impl ProgressManager {
     pub fn new(no_progress: bool) -> Self {
+        let multi_progress = MultiProgress::new();
+        let notes = if no_progress {
+            NoteSink::Stderr
+        } else {
+            NoteSink::Region(multi_progress.clone())
+        };
         ProgressManager {
-            multi_progress: MultiProgress::new(),
+            multi_progress,
             no_progress,
+            notes,
+        }
+    }
+
+    /// A [`ProgressManager`] whose notes are collected instead of printed, plus
+    /// the buffer they land in.
+    #[cfg(test)]
+    pub fn capturing() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let manager = ProgressManager {
+            multi_progress: MultiProgress::new(),
+            no_progress: true,
+            notes: NoteSink::Capture(Arc::clone(&lines)),
+        };
+        (manager, lines)
+    }
+
+    /// A handle the spawned provider/tester tasks can carry, so their
+    /// operator-facing lines reach the same place [`note`] writes to.
+    ///
+    /// [`note`]: ProgressManager::note
+    pub fn notifier(&self) -> Notifier {
+        Notifier {
+            sink: self.notes.clone(),
         }
     }
 
@@ -314,11 +445,7 @@ impl ProgressManager {
     ///
     /// [`clear`]: ProgressManager::clear
     pub fn note(&self, msg: impl AsRef<str>) {
-        if self.no_progress {
-            eprintln!("{}", msg.as_ref());
-        } else {
-            let _ = self.multi_progress.println(msg.as_ref());
-        }
+        self.notifier().note(msg);
     }
 }
 
@@ -406,6 +533,44 @@ mod tests {
         // handle the runner kept (shared Arc).
         clone.mark_partial();
         assert!(reporter.is_partial());
+    }
+
+    #[test]
+    fn test_stop_signal_reaches_every_reporter_sharing_it() {
+        // The runner raises one signal at the deadline; every in-flight fetch's
+        // reporter must see it, or a paginating provider keeps walking its
+        // cursor until it is cancelled — losing everything it had collected.
+        let signal = StopSignal::default();
+        let a =
+            ProgressReporter::new(ProgressBar::hidden(), "a · ").with_stop_signal(signal.clone());
+        let b =
+            ProgressReporter::new(ProgressBar::hidden(), "b · ").with_stop_signal(signal.clone());
+
+        assert!(!a.stop_requested());
+        assert!(!b.stop_requested());
+
+        signal.request_stop();
+
+        assert!(a.stop_requested());
+        assert!(b.stop_requested());
+        // A clone a provider is holding sees it too.
+        assert!(a.clone().stop_requested());
+    }
+
+    #[test]
+    fn test_reporter_without_a_signal_is_never_asked_to_stop() {
+        let reporter = ProgressReporter::new(ProgressBar::hidden(), "x");
+        let other = StopSignal::default();
+        other.request_stop();
+        assert!(!reporter.stop_requested());
+    }
+
+    #[test]
+    fn test_notes_are_captured_rather_than_printed_in_tests() {
+        let (manager, lines) = ProgressManager::capturing();
+        manager.note("first");
+        manager.notifier().note("second");
+        assert_eq!(lines.lock().unwrap().as_slice(), ["first", "second"]);
     }
 
     #[test]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -2,7 +2,7 @@ use futures::future::join_all;
 use futures::stream::{self, StreamExt};
 use indicatif::ProgressBar;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::task;
 
@@ -11,10 +11,20 @@ use crate::network::{NetworkScope, NetworkSettings};
 use crate::output::StreamSink;
 use crate::progress::{
     provider_error_style, provider_partial_style, provider_running_style, provider_success_style,
-    ProgressManager, ProgressReporter,
+    Notifier, ProgressManager, ProgressReporter, StopSignal,
 };
 use crate::providers::Provider;
 use crate::utils::verbose_print;
+
+/// How long a fetch gets, after the run has asked it to stop, to come back
+/// with the URLs it has already collected before it is hard-cancelled.
+///
+/// Cancelling drops a paginating provider's whole in-memory result set, so this
+/// window is what makes `--max-time` keep its promise to "proceed with whatever
+/// URLs have been collected so far". Kept short: it is time spent past the
+/// deadline the user asked for, and a provider only has to notice the flag
+/// between two requests.
+const STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Format an integer with thousands separators (e.g. `12345` → `12,345`) so
 /// large URL counts stay legible in the progress summary.
@@ -78,6 +88,7 @@ struct DomainCompletionCtx {
     domain_completion: Arc<Mutex<HashMap<String, usize>>>,
     processed_domains: Arc<Mutex<usize>>,
     overall_bar: ProgressBar,
+    notifier: Notifier,
     verbose: bool,
     silent: bool,
 }
@@ -106,10 +117,10 @@ impl DomainCompletionCtx {
             ));
 
             if self.verbose && !self.silent {
-                println!(
+                self.notifier.note(format!(
                     "Domain completed: {} ({}/{})",
                     domain, *count, self.total_domains
-                );
+                ));
             }
         }
 
@@ -119,12 +130,18 @@ impl DomainCompletionCtx {
 
 /// Helper function to apply network settings to a provider
 pub fn apply_network_settings_to_provider(provider: &mut dyn Provider, settings: &NetworkSettings) {
+    // `--subs` is a *search scope* option, not a network setting: it decides
+    // which hosts the archive query asks for. `--network-scope testers` narrows
+    // where proxy/timeout/TLS/rate-limit apply, and used to take subdomain
+    // inclusion down with it — so `urx example.com --subs --network-scope
+    // testers` silently queried the apex only.
+    provider.with_subdomains(settings.include_subdomains);
+
     // Skip applying settings if network scope doesn't include providers
     if settings.scope == NetworkScope::Testers {
         return;
     }
 
-    provider.with_subdomains(settings.include_subdomains);
     provider.with_timeout(settings.timeout);
     provider.with_retries(settings.retries);
     provider.with_random_agent(settings.random_agent);
@@ -190,7 +207,9 @@ pub fn add_provider<T: Provider + 'static>(
             config_info.push(format!("  Rate limit: {rate} requests/second{label}"));
         }
 
-        println!("{}", config_info.join("\n"));
+        // stderr: stdout is the URL list. This runs before any progress bar is
+        // drawn (providers are built first), so a plain write is safe here.
+        eprintln!("{}", config_info.join("\n"));
     }
 
     let mut provider = provider_builder();
@@ -208,10 +227,18 @@ pub struct ProviderStats {
     pub url_count: usize,
     /// Number of domain fetches that failed.
     pub error_count: usize,
-    /// Number of domain fetches that returned incomplete (partial) results.
+    /// Number of domain fetches that returned incomplete (partial) results,
+    /// including the ones cut off by `--max-time` or Ctrl-C.
     pub partial_count: usize,
-    /// Total wall-clock time spent in fetch_urls across domains.
+    /// Total wall-clock time spent in fetch_urls across domains. For an
+    /// [`aborted`] provider this is at least the time the run actually spent
+    /// waiting on it, not the (zero) time its unfinished fetches recorded.
+    ///
+    /// [`aborted`]: ProviderStats::aborted
     pub elapsed: std::time::Duration,
+    /// The provider was still fetching when `--max-time` or Ctrl-C ended the
+    /// run, so every other number in this row is a floor, not a total.
+    pub aborted: bool,
 }
 
 /// Result of a provider run: URLs mapped to the providers that reported them,
@@ -298,12 +325,32 @@ pub async fn process_domains(
     // per domain) keeps --rate-limit honest across these concurrent fetches.
     let parallel = args.parallel.unwrap_or(5).max(1) as usize;
 
+    // Per-provider bookkeeping the *outer* task needs after an abort: how many
+    // domains each provider actually got through, and whether it ran to
+    // completion at all. Both live outside the spawned task because a task that
+    // `--max-time` cancels never comes back to report them.
+    let done_counters: Vec<Arc<AtomicUsize>> = (0..total_providers)
+        .map(|_| Arc::new(AtomicUsize::new(0)))
+        .collect();
+    let finished_flags: Vec<Arc<AtomicBool>> = (0..total_providers)
+        .map(|_| Arc::new(AtomicBool::new(false)))
+        .collect();
+    let run_start = std::time::Instant::now();
+    let notifier = progress_manager.notifier();
+    // Raised when --max-time or Ctrl-C ends the run, so a provider mid-cursor
+    // can return what it has instead of losing it to a cancelled future.
+    let stop_signal = StopSignal::default();
+
     for (provider_clone, provider_name, original_idx) in provider_data.into_iter() {
         let all_urls = Arc::clone(&all_urls);
         let stream = stream.clone();
         let stats = Arc::clone(&stats);
         let provider_bar = provider_bars[original_idx].clone();
         let domains = domains.clone();
+        let notifier = notifier.clone();
+        let stop_signal = stop_signal.clone();
+        let done = Arc::clone(&done_counters[original_idx]);
+        let finished = Arc::clone(&finished_flags[original_idx]);
 
         // Shared so each concurrent domain future can mark domain completion
         // against the run-wide progress without contending on a &mut.
@@ -313,6 +360,7 @@ pub async fn process_domains(
             domain_completion: Arc::clone(&domain_completion),
             processed_domains: Arc::clone(&processed_domains),
             overall_bar: overall_bar.clone(),
+            notifier: notifier.clone(),
             verbose,
             silent,
         });
@@ -331,13 +379,13 @@ pub async fn process_domains(
             let url_total = Arc::new(AtomicUsize::new(0));
             let err_total = Arc::new(AtomicUsize::new(0));
             let partial_total = Arc::new(AtomicUsize::new(0));
-            let done = Arc::new(AtomicUsize::new(0));
             let total = domains.len();
 
             // Handles retained for the summary after the stream consumes the
             // per-domain clones.
             let summary_bar = provider_bar.clone();
             let summary_name = provider_name.clone();
+            let summary_notifier = notifier.clone();
             let summary_urls = Arc::clone(&url_total);
             let summary_errs = Arc::clone(&err_total);
             let summary_partials = Arc::clone(&partial_total);
@@ -367,6 +415,8 @@ pub async fn process_domains(
                     let err_total = Arc::clone(&err_total);
                     let partial_total = Arc::clone(&partial_total);
                     let done = Arc::clone(&done);
+                    let notifier = notifier.clone();
+                    let stop_signal = stop_signal.clone();
 
                     async move {
                         let prefix = format!("{domain} · ");
@@ -376,9 +426,12 @@ pub async fn process_domains(
                         // Aggregate mode: it only carries the partial-result
                         // flag (a hidden bar) so concurrent domains don't fight
                         // over the single line; --silent suppresses it entirely.
-                        let reporter = if silent {
-                            None
-                        } else if rich {
+                        // A reporter is handed in even under --silent: besides
+                        // the (then hidden) line it carries the partial flag and
+                        // the run-wide stop signal, and a provider that cannot
+                        // see the stop signal loses everything it has paged in
+                        // when --max-time cancels it.
+                        let reporter = if rich && !silent {
                             provider_bar.set_style(provider_running_style());
                             provider_bar.set_prefix(format!("{provider_name:<16}"));
                             provider_bar.reset_elapsed();
@@ -386,10 +439,11 @@ pub async fn process_domains(
                             if !no_progress {
                                 provider_bar.tick();
                             }
-                            Some(ProgressReporter::new(provider_bar.clone(), prefix.clone()))
+                            ProgressReporter::new(provider_bar.clone(), prefix.clone())
                         } else {
-                            Some(ProgressReporter::new(ProgressBar::hidden(), prefix.clone()))
+                            ProgressReporter::new(ProgressBar::hidden(), prefix.clone())
                         };
+                        let reporter = Some(reporter.with_stop_signal(stop_signal.clone()));
 
                         // Fetch URLs for this domain using this provider.
                         let fetch_start = std::time::Instant::now();
@@ -405,9 +459,14 @@ pub async fn process_domains(
                                 // A *partial* result (e.g. a page failed
                                 // mid-pagination) is surfaced as a distinct,
                                 // warned state so a truncated crawl is never
-                                // mistaken for a clean success.
-                                let partial =
-                                    reporter.as_ref().is_some_and(|r| r.is_partial());
+                                // mistaken for a clean success. A result that
+                                // lands after the run asked everyone to stop
+                                // counts too: the provider may have cut its
+                                // cursor walk short to hand back what it had,
+                                // so it cannot be reported as complete.
+                                let partial = reporter
+                                    .as_ref()
+                                    .is_some_and(|r| r.is_partial() || r.stop_requested());
                                 if partial {
                                     partial_total.fetch_add(1, Ordering::Relaxed);
                                 }
@@ -419,7 +478,9 @@ pub async fn process_domains(
                                     Some(sink) => {
                                         if let Err(e) = sink.emit(&urls) {
                                             if !silent {
-                                                eprintln!("Error writing streamed output: {e}");
+                                                notifier.note(format!(
+                                                    "Error writing streamed output: {e}"
+                                                ));
                                             }
                                         }
                                     }
@@ -465,9 +526,9 @@ pub async fn process_domains(
                                     }
                                     provider_bar.tick();
                                     if partial && verbose && !silent {
-                                        eprintln!(
-                                            "Warning: partial results for {domain} from {provider_name}: a request failed mid-fetch; returning {url_count} URL(s) collected so far"
-                                        );
+                                        notifier.note(format!(
+                                            "Warning: partial results for {domain} from {provider_name}: the fetch stopped early; returning {url_count} URL(s) collected so far"
+                                        ));
                                     }
                                 } else {
                                     tick_aggregate(
@@ -483,9 +544,9 @@ pub async fn process_domains(
                                 completion_ctx.track(&domain);
 
                                 if verbose && !silent {
-                                    println!(
+                                    notifier.note(format!(
                                         "  - {provider_name}: Found {url_count} URLs for {domain}"
-                                    );
+                                    ));
                                 }
                             }
                             Err(e) => {
@@ -518,9 +579,9 @@ pub async fn process_domains(
                                 completion_ctx.track(&domain);
 
                                 if verbose && !silent {
-                                    eprintln!(
+                                    notifier.note(format!(
                                         "Error fetching URLs for {domain} from {provider_name}: {e}"
-                                    );
+                                    ));
                                 }
                             }
                         }
@@ -567,8 +628,14 @@ pub async fn process_domains(
             }
 
             if verbose && !silent {
-                println!("Provider {provider_name} has completed processing all domains");
+                summary_notifier.note(format!(
+                    "Provider {provider_name} has completed processing all domains"
+                ));
             }
+
+            // Last thing the task does: whoever is watching the deadline uses
+            // this to tell "ran to completion" from "cancelled mid-flight".
+            finished.store(true, Ordering::Relaxed);
         });
 
         provider_futures.push(provider_future);
@@ -580,7 +647,6 @@ pub async fn process_domains(
     // pushed into the shared map — an interrupted run still produces output and
     // a summary instead of dying with nothing.
     let abort_handles: Vec<_> = provider_futures.iter().map(|h| h.abort_handle()).collect();
-    let join_future = join_all(provider_futures);
     let deadline = (args.max_time > 0).then(|| std::time::Duration::from_secs(args.max_time));
 
     enum RunEnd {
@@ -589,8 +655,13 @@ pub async fn process_domains(
         Interrupted,
     }
 
+    // Pinned in the enclosing scope, not inside the `select!` block: after the
+    // deadline fires we still need the same join future to await the graceful
+    // wind-down below.
+    let join_future = join_all(provider_futures);
+    tokio::pin!(join_future);
+
     let run_end = {
-        tokio::pin!(join_future);
         // A deadline that simply never fires when --max-time isn't set.
         let timeout = async {
             match deadline {
@@ -613,41 +684,65 @@ pub async fn process_domains(
         }
     };
 
-    match &run_end {
-        RunEnd::Completed => {}
-        RunEnd::TimedOut => {
-            for h in &abort_handles {
-                h.abort();
-            }
-            if !args.silent {
-                progress_manager.note(format!(
-                    "[urx] --max-time {}s elapsed; aborting in-flight provider fetches and returning partial results",
+    if !matches!(run_end, RunEnd::Completed) {
+        // Say why the run is wrapping up before waiting on it, so the grace
+        // window below never looks like a hang.
+        if !args.silent {
+            match run_end {
+                RunEnd::TimedOut => progress_manager.note(format!(
+                    "[urx] --max-time {}s elapsed; stopping in-flight provider fetches and returning partial results",
                     deadline.map(|d| d.as_secs()).unwrap_or(0)
-                ));
+                )),
+                _ => progress_manager.note(
+                    "[urx] interrupted (Ctrl-C); returning URLs collected so far — press Ctrl-C again to force quit",
+                ),
             }
         }
-        RunEnd::Interrupted => {
-            for h in &abort_handles {
-                h.abort();
-            }
-            if !args.silent {
-                progress_manager.note(
-                    "[urx] interrupted (Ctrl-C); returning URLs collected so far — press Ctrl-C again to force quit",
-                );
-            }
-            // The rest of the pipeline (output, optional testing) can still take
-            // a while, so a second Ctrl-C force-quits.
+
+        // The rest of the pipeline (output, optional testing) can still take a
+        // while, so a second Ctrl-C force-quits. Armed before the grace window
+        // so it also covers the wait itself.
+        if matches!(run_end, RunEnd::Interrupted) {
             tokio::spawn(async {
                 if tokio::signal::ctrl_c().await.is_ok() {
                     std::process::exit(130);
                 }
             });
         }
-    }
 
-    // A timeout/interrupt leaves the provider(s) that were mid-fetch on a
-    // spinning "fetching…" line; freeze them so the final display is honest.
-    if !matches!(run_end, RunEnd::Completed) {
+        // Cancelling a provider task drops everything it has buffered but not
+        // yet returned, and a paginating provider buffers the whole crawl until
+        // its last page — so a hard abort here threw away exactly the results
+        // --max-time promises to keep. Raise the cooperative stop signal and
+        // give in-flight fetches a brief window to return what they already
+        // have; only what is still running when it closes gets cancelled.
+        stop_signal.request_stop();
+        let _ = tokio::time::timeout(STOP_GRACE, &mut join_future).await;
+        for h in &abort_handles {
+            h.abort();
+        }
+
+        // A provider cancelled mid-fetch never reached the stats update that
+        // runs after a fetch resolves, so its row stayed at 0 urls / 0 partial
+        // / 0 errors / 0ms — a run that spent 90 seconds on it read as an
+        // instant, clean pass. Charge it the wall time the run actually spent
+        // and flag it, counting each domain it never finished as partial.
+        let wall = run_start.elapsed();
+        {
+            let mut s = lock_ignore_poison(&stats);
+            for (idx, entry) in s.iter_mut().enumerate() {
+                if finished_flags[idx].load(Ordering::Relaxed) {
+                    continue;
+                }
+                entry.aborted = true;
+                entry.elapsed = entry.elapsed.max(wall);
+                let completed = done_counters[idx].load(Ordering::Relaxed);
+                entry.partial_count += total_domains.saturating_sub(completed);
+            }
+        }
+
+        // A timeout/interrupt leaves the provider(s) that were mid-fetch on a
+        // spinning "fetching…" line; freeze them so the final display is honest.
         let label = if matches!(run_end, RunEnd::TimedOut) {
             "timed out"
         } else {
@@ -695,6 +790,94 @@ mod tests {
     use crate::output;
     use crate::test_support::{build_test_args, MockProvider};
     use crate::utils::UrlTransformer;
+    use std::future::Future;
+    use std::pin::Pin;
+
+    /// A provider that paginates: it collects one URL every `step`, and honours
+    /// the run-wide stop signal the way a real cursor-walking provider is meant
+    /// to — flag the result partial and return what it already has, rather than
+    /// let a cancelled future take the whole buffer with it.
+    #[derive(Clone)]
+    struct PaginatingProvider {
+        step: std::time::Duration,
+        pages: usize,
+    }
+
+    impl Provider for PaginatingProvider {
+        fn clone_box(&self) -> Box<dyn Provider> {
+            Box::new(self.clone())
+        }
+
+        fn fetch_urls<'a>(
+            &'a self,
+            domain: &'a str,
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<String>>> + Send + 'a>> {
+            self.fetch_urls_with_progress(domain, None)
+        }
+
+        fn fetch_urls_with_progress<'a>(
+            &'a self,
+            domain: &'a str,
+            reporter: Option<ProgressReporter>,
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<String>>> + Send + 'a>> {
+            let step = self.step;
+            let pages = self.pages;
+            let domain = domain.to_string();
+            Box::pin(async move {
+                let mut urls = Vec::new();
+                for page in 0..pages {
+                    tokio::time::sleep(step).await;
+                    urls.push(format!("https://{domain}/page{page}"));
+                    if let Some(r) = &reporter {
+                        if r.stop_requested() {
+                            r.mark_partial();
+                            break;
+                        }
+                    }
+                }
+                Ok(urls)
+            })
+        }
+
+        fn with_subdomains(&mut self, _include: bool) {}
+        fn with_proxy(&mut self, _proxy: Option<String>) {}
+        fn with_proxy_auth(&mut self, _auth: Option<String>) {}
+        fn with_timeout(&mut self, _seconds: u64) {}
+        fn with_retries(&mut self, _count: u32) {}
+        fn with_random_agent(&mut self, _enabled: bool) {}
+        fn with_insecure(&mut self, _enabled: bool) {}
+        fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
+    }
+
+    /// A provider that records what `with_subdomains` was told.
+    #[derive(Clone, Default)]
+    struct SubdomainRecordingProvider {
+        include_subdomains: bool,
+    }
+
+    impl Provider for SubdomainRecordingProvider {
+        fn clone_box(&self) -> Box<dyn Provider> {
+            Box::new(self.clone())
+        }
+
+        fn fetch_urls<'a>(
+            &'a self,
+            _domain: &'a str,
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<String>>> + Send + 'a>> {
+            Box::pin(async move { Ok(vec![]) })
+        }
+
+        fn with_subdomains(&mut self, include: bool) {
+            self.include_subdomains = include;
+        }
+        fn with_proxy(&mut self, _proxy: Option<String>) {}
+        fn with_proxy_auth(&mut self, _auth: Option<String>) {}
+        fn with_timeout(&mut self, _seconds: u64) {}
+        fn with_retries(&mut self, _count: u32) {}
+        fn with_random_agent(&mut self, _enabled: bool) {}
+        fn with_insecure(&mut self, _enabled: bool) {}
+        fn with_rate_limit(&mut self, _rate_limit: Option<f32>) {}
+    }
 
     #[tokio::test]
     async fn test_process_domains() {
@@ -1012,6 +1195,151 @@ mod tests {
             result.urls.is_empty(),
             "expected no URLs, got {:?}",
             result.urls
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_time_charges_the_aborted_provider_real_elapsed_time() {
+        // Regression: a provider cancelled by --max-time never reached the
+        // stats update at the end of its fetch, so `--stats` reported it as
+        // "0 urls · 0 partial · 0 errors · 0ms" — a run that spent the whole
+        // deadline on it read as an instant, clean pass.
+        let slow = MockProvider::new(vec!["https://example.com/never".to_string()], false)
+            .with_delay_ms(30_000);
+
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(slow)];
+        let provider_names = vec!["SlowProvider".to_string()];
+
+        let mut args = build_test_args();
+        args.max_time = 1;
+
+        let result = process_domains(
+            vec!["example.com".to_string()],
+            &args,
+            &ProgressManager::new(true),
+            &providers,
+            &provider_names,
+            None,
+        )
+        .await;
+
+        let stats = &result.stats[0];
+        assert!(stats.aborted, "aborted provider must be flagged: {stats:?}");
+        assert!(
+            stats.elapsed >= std::time::Duration::from_millis(900),
+            "elapsed must be real wall time, got {:?}",
+            stats.elapsed
+        );
+        // The one domain it never finished is reported as an incomplete result
+        // rather than a silent zero.
+        assert_eq!(stats.partial_count, 1, "{stats:?}");
+    }
+
+    #[tokio::test]
+    async fn test_max_time_keeps_the_urls_a_provider_already_collected() {
+        // Regression: --max-time is documented as "in-flight provider fetches
+        // are aborted and urx proceeds with whatever URLs have been collected
+        // so far", but cancelling the task dropped the provider's in-memory
+        // buffer — a paginating provider accumulates the whole crawl until it
+        // returns, so a timed-out run yielded *nothing*. The runner now asks
+        // fetches to stop and gives them a moment to hand back what they have.
+        let provider = PaginatingProvider {
+            step: std::time::Duration::from_millis(100),
+            pages: 10_000,
+        };
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(provider)];
+        let provider_names = vec!["Paginating".to_string()];
+
+        let mut args = build_test_args();
+        args.max_time = 1;
+
+        let result = process_domains(
+            vec!["example.com".to_string()],
+            &args,
+            &ProgressManager::new(true),
+            &providers,
+            &provider_names,
+            None,
+        )
+        .await;
+
+        assert!(
+            !result.urls.is_empty(),
+            "URLs collected before the deadline must survive it"
+        );
+        let stats = &result.stats[0];
+        assert_eq!(stats.url_count, result.urls.len(), "{stats:?}");
+        // The provider wrapped up on its own, so it isn't flagged as cancelled —
+        // but the truncated result is still reported as partial, never clean.
+        assert!(!stats.aborted, "{stats:?}");
+        assert_eq!(stats.partial_count, 1, "{stats:?}");
+        assert!(
+            stats.elapsed >= std::time::Duration::from_millis(900),
+            "{stats:?}"
+        );
+    }
+
+    #[test]
+    fn test_subdomain_inclusion_is_not_a_network_setting() {
+        // Regression: --network-scope testers made
+        // apply_network_settings_to_provider bail before it applied --subs, so
+        // `urx example.com --subs --network-scope testers` silently queried the
+        // apex only. Subdomain inclusion decides *what* is searched, not how
+        // the request is made.
+        let settings = NetworkSettings::new().with_subdomains(true);
+
+        for scope in [
+            NetworkScope::All,
+            NetworkScope::Providers,
+            NetworkScope::Testers,
+        ] {
+            let mut settings = settings.clone();
+            settings.scope = scope.clone();
+            let mut provider = SubdomainRecordingProvider::default();
+            apply_network_settings_to_provider(&mut provider, &settings);
+            assert!(
+                provider.include_subdomains,
+                "--subs must survive --network-scope {scope:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verbose_progress_lines_never_touch_stdout() {
+        // Regression: the per-domain verbose lines went out through `println!`,
+        // so `urx -v > urls.txt` interleaved "Domain completed: …" into the URL
+        // list a caller was piping — and, drawn straight to the terminal, they
+        // also bypassed MultiProgress and desynced the live region. They must
+        // go through the progress note channel (stderr) instead.
+        let providers: Vec<Box<dyn Provider>> = vec![Box::new(MockProvider::new(
+            vec!["https://example.com/a".to_string()],
+            false,
+        ))];
+        let provider_names = vec!["Mock".to_string()];
+
+        let mut args = build_test_args();
+        args.verbose = true;
+        args.silent = false;
+
+        let (progress_manager, notes) = ProgressManager::capturing();
+        let _ = process_domains(
+            vec!["example.com".to_string()],
+            &args,
+            &progress_manager,
+            &providers,
+            &provider_names,
+            None,
+        )
+        .await;
+
+        let notes = notes.lock().unwrap().join("\n");
+        assert!(
+            notes.contains("Mock: Found 1 URLs for example.com"),
+            "per-provider verbose line should reach the note channel: {notes:?}"
+        );
+        assert!(
+            notes.contains("Domain completed: example.com"),
+            "domain completion line should reach the note channel: {notes:?}"
         );
     }
 

--- a/src/tester_manager/mod.rs
+++ b/src/tester_manager/mod.rs
@@ -117,12 +117,17 @@ pub async fn process_urls_with_testers(
         .map(|chunk| chunk.to_vec())
         .collect();
 
+    // Per-URL diagnostics belong on stderr, above the live region — stdout is
+    // the URL list a caller pipes onward.
+    let notifier = progress_manager.notifier();
+
     let chunk_results: Vec<Vec<output::UrlData>> =
         stream::iter(url_chunks.into_iter().map(|url_vec| {
             let testers_clone: Vec<_> = testers.iter().map(|t| t.clone_box()).collect();
             let test_bar = test_bar.clone();
             let completed = Arc::clone(&completed);
             let link_filter = link_filter.clone();
+            let notifier = notifier.clone();
 
             async move {
                 let mut result_urls = Vec::new();
@@ -145,7 +150,7 @@ pub async fn process_urls_with_testers(
                             }
                             Err(e) => {
                                 if verbose && !silent {
-                                    eprintln!("Error testing URL {url}: {e}");
+                                    notifier.note(format!("Error testing URL {url}: {e}"));
                                 }
                             }
                         }
@@ -229,7 +234,10 @@ pub async fn process_urls_with_testers(
     test_bar.finish_with_message(format!("Testing complete, found {} URLs", new_urls.len()));
 
     if args.verbose && !args.silent {
-        println!("Testing complete, final URL count: {}", new_urls.len());
+        progress_manager.note(format!(
+            "Testing complete, final URL count: {}",
+            new_urls.len()
+        ));
     }
 
     new_urls

--- a/src/testers/link_extractor.rs
+++ b/src/testers/link_extractor.rs
@@ -171,7 +171,7 @@ impl Tester for LinkExtractor {
             // Perform the request with retries
             let mut last_error = None;
 
-            for _ in 0..=self.retries {
+            for attempt in 0..=self.retries {
                 match client.get(url).send().await {
                     Ok(response) => {
                         // Get the base URL for resolving relative URLs
@@ -208,7 +208,12 @@ impl Tester for LinkExtractor {
                     }
                     Err(e) => {
                         last_error = Some(e);
-                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        // Back off only when another attempt follows; a sleep
+                        // after the final one is pure latency, paid once per
+                        // unreachable URL (and even with `--retries 0`).
+                        if attempt < self.retries {
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        }
                         continue;
                     }
                 }
@@ -554,6 +559,25 @@ mod tests {
         assert!(!is_html_like(&with("application/octet-stream")));
         // Absent header: assume markup rather than drop the page.
         assert!(is_html_like(&HeaderMap::new()));
+    }
+
+    #[tokio::test]
+    async fn test_no_retries_means_no_backoff_wait() {
+        // Regression: the 500ms back-off was slept after the *final* attempt as
+        // well, so an unreachable page cost half a second even with
+        // `--retries 0` — once per URL, across a whole --extract-links run.
+        let mut extractor = LinkExtractor::new();
+        extractor.with_retries(0);
+
+        let start = std::time::Instant::now();
+        let result = extractor.test_url("http://127.0.0.1:0/nope").await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        assert!(
+            elapsed < std::time::Duration::from_millis(400),
+            "a single failed attempt must not sleep, took {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/testers/status_checker.rs
+++ b/src/testers/status_checker.rs
@@ -69,9 +69,13 @@ impl StatusChecker {
     /// Return the shared HTTP client, building it on the first call and reusing
     /// it thereafter. If a build fails the cell stays empty, so a later call
     /// retries rather than caching the error.
+    ///
+    /// The client does *not* follow redirects: the status urx reports has to
+    /// belong to the URL it prints, and `--include-status 30x` can only match a
+    /// 3xx that is actually surfaced.
     async fn client(&self) -> Result<&Client> {
         self.client
-            .get_or_try_init(|| async { self.client_config().build_client() })
+            .get_or_try_init(|| async { self.client_config().build_client_no_redirect() })
             .await
     }
 
@@ -157,7 +161,7 @@ impl Tester for StatusChecker {
             // Perform the request with retries
             let mut last_error = None;
 
-            for _ in 0..=self.retries {
+            for attempt in 0..=self.retries {
                 match client.get(url).send().await {
                     Ok(response) => {
                         let status = response.status();
@@ -177,7 +181,13 @@ impl Tester for StatusChecker {
                     }
                     Err(e) => {
                         last_error = Some(e);
-                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        // Back off only when another attempt follows. Sleeping
+                        // after the *last* one bought nothing and cost 500ms per
+                        // unreachable URL — with `--retries 0`, which means "no
+                        // retries", every failure still waited half a second.
+                        if attempt < self.retries {
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        }
                         continue;
                     }
                 }
@@ -324,6 +334,88 @@ mod tests {
         checker.with_exclude_status(Some(vec!["2xx".to_string()]));
         assert!(checker.should_include_status(200));
         assert!(!checker.should_include_status(201));
+    }
+
+    #[tokio::test]
+    async fn test_redirects_are_reported_not_followed() {
+        // Regression: the client followed redirects, so `/redir` was reported
+        // as "200 OK" — the status of a *different* URL than the one printed.
+        let mut server = mockito::Server::new_async().await;
+        let redirect = server
+            .mock("GET", "/redir")
+            .with_status(301)
+            .with_header("location", "/final")
+            .expect(1)
+            .create_async()
+            .await;
+        // Never requested: following the redirect is exactly what must not
+        // happen.
+        let final_page = server
+            .mock("GET", "/final")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let checker = StatusChecker::new();
+        let out = checker
+            .test_url(&format!("{}/redir", server.url()))
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!(out[0].contains("301"), "{out:?}");
+        redirect.assert();
+        final_page.assert();
+    }
+
+    #[tokio::test]
+    async fn test_include_status_30x_matches_a_redirect() {
+        // The documented `--include-status 200,30x` could never match anything:
+        // a followed redirect resolves to its target's status, so no 3xx ever
+        // reached the filter.
+        let mut server = mockito::Server::new_async().await;
+        let _r = server
+            .mock("GET", "/redir")
+            .with_status(302)
+            .with_header("location", "/final")
+            .create_async()
+            .await;
+        let _f = server
+            .mock("GET", "/final")
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let mut checker = StatusChecker::new();
+        checker.with_include_status(Some(vec!["30x".to_string()]));
+        let out = checker
+            .test_url(&format!("{}/redir", server.url()))
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1, "--is 30x should keep a redirect: {out:?}");
+        assert!(out[0].contains("302"), "{out:?}");
+    }
+
+    #[tokio::test]
+    async fn test_no_retries_means_no_backoff_wait() {
+        // Regression: the 500ms back-off was slept after the *final* attempt
+        // too, so even `--retries 0` ("no retries") cost half a second for
+        // every unreachable URL.
+        let mut checker = StatusChecker::new();
+        checker.with_retries(0);
+
+        let start = std::time::Instant::now();
+        // Port 0 is never listening, so this fails immediately.
+        let result = checker.test_url("http://127.0.0.1:0/nope").await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        assert!(
+            elapsed < std::time::Duration::from_millis(400),
+            "a single failed attempt must not sleep, took {elapsed:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Six defects in the runner / network / tester / progress layer, each with a regression test. Verified live against `web.archive.org` where the bug is observable end-to-end, and with `mockito` everywhere a test touches HTTP.

`cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --bin urx` (651 passed) are all green.

---

## 1. `--max-time` threw away the URLs it promises to keep (data loss)

**Symptom.** `--max-time` is documented as "in-flight provider fetches are aborted and urx proceeds with whatever URLs have been collected so far". It proceeded with *nothing*.

**Repro.**
```
urx example.com --providers wayback --stats --no-progress --no-cache --max-time 15
# -> 0 URLs on stdout, while an unbounded run of the same query returns 860,295
```

**Root cause.** `src/runner/mod.rs` ended the run by cancelling the provider tasks (`abort_handle().abort()`). A cancelled future is *dropped*, and every paginating provider accumulates its results in a local buffer until it returns (`urls: Vec<String>` in `providers/wayback.rs:194`, `seen: HashSet<String>` in `providers/arquivo.rs`, …). The runner's shared URL map only ever receives a provider's URLs *after* `fetch_urls` returns, so everything paged in before the deadline died with the future.

**Fix.** Ending a run is now cooperative. `StopSignal` (`src/progress/mod.rs`) is a run-wide flag carried by every `ProgressReporter` the runner hands to a provider; at the deadline the runner raises it and waits `STOP_GRACE` (2s) for in-flight fetches to return before cancelling whatever is left. A provider that notices takes the path it already has for a mid-walk failure — `mark_partial()` and `break`, returning what it collected. The runner also treats any result landing after a stop request as partial, since it cannot be assumed complete.

**Test.** `runner::tests::test_max_time_keeps_the_urls_a_provider_already_collected` — a paginating mock provider under `--max-time 1`; asserts its URLs survive the deadline and are reported partial. Verified this test fails (`URLs collected before the deadline must survive it`) with the stop signal disabled.

⚠️ **This is the runner half.** Providers must consult the signal for the URLs to actually be recovered — see "Out-of-scope findings" below for the exact 3-line change each one needs. Until then the accounting fix (#2) applies and the behaviour is unchanged from today.

## 2. `--stats` reported an aborted provider as an instant clean pass

**Symptom.** After a 90s deadline, the provider that was cut off mid-pagination showed `0 urls · 0 partial · 0 errors · 0ms` — indistinguishable from a provider that finished instantly with nothing to say.

**Repro / before → after.**
```
urx example.com --providers wayback --stats --no-progress --no-cache --max-time 15

before:  Wayback Machine     0         0        0         0ms
after:   Wayback Machine     0         1        0      17.02s  (aborted)
```

**Root cause.** `src/runner/mod.rs` updated `ProviderStats` only *after* `fetch_urls` resolved. A cancelled task never gets there, so its row stayed at the `Default` zeros.

**Fix.** Per-provider `done`/`finished` bookkeeping now lives outside the spawned task (a cancelled task can't report anything). On timeout/interrupt, every provider that did not run to completion is charged `max(recorded, real wall time)`, flagged `aborted`, and has each unfinished domain counted as partial. `src/app/report.rs` renders the flag as a trailing `(aborted)` marker; the table is now built by a testable `render_provider_stats`.

**Tests.** `runner::tests::test_max_time_charges_the_aborted_provider_real_elapsed_time`, `app::report::tests::test_stats_table_flags_a_provider_that_was_cut_off`.

## 3. `--check-status` followed redirects, making `--include-status 30x` unmatchable

**Symptom.** A URL answering `301` was printed as `https://host/old - 200 OK` — the status of a *different* URL. And the documented filter (`README.md:286`, `docs/content/guide/examples.md:196`) matched nothing, ever:
```
urx example.com --check-status --include-status 200,30x   # 30x can never match
```

**Root cause.** `StatusChecker` built its client with `HttpClientConfig::build_client`, and reqwest follows up to 10 redirects by default, so the 3xx never reached `should_include_status` (`src/testers/status_checker.rs:74`).

**Fix.** Added `HttpClientConfig::build_client_no_redirect` (`src/network/client.rs`) — a new method rather than a new field, so no provider's struct literal changes — and the status checker uses it. Providers keep following redirects. Also saves a redirect chain (or loop) per checked URL.

**Tests.** `status_checker::tests::test_redirects_are_reported_not_followed` (mockito, with `expect(0)` on the redirect target), `..::test_include_status_30x_matches_a_redirect`, `network::client::tests::test_redirect_policy_differs_between_the_two_builders`.

## 4. `--retries 0` still slept 500ms per failing URL

**Symptom.** Measured with a probe: one attempt against a closed port took **523ms**.

**Root cause.** Both testers slept the 500ms back-off after the *final* attempt too (`status_checker.rs`, `link_extractor.rs`: `Err(e) => { …; sleep(500ms); continue; }`). Paid once per unreachable URL — over a large `--check-status` run at `--parallel 5`, minutes of pure latency, and "no retries" still cost half a second.

**Fix.** Back off only when another attempt follows.

**Tests.** `test_no_retries_means_no_backoff_wait` in both testers (asserts < 400ms).

## 5. `--subs` was silently dropped by `--network-scope testers`

**Symptom.** `urx example.com --subs --network-scope testers` queried the apex only, with no warning.

**Root cause.** `apply_network_settings_to_provider` (`src/runner/mod.rs`) called `with_subdomains` *after* the scope guard, so `NetworkScope::Testers` returned before applying it. Subdomain inclusion decides *what* is searched; `--network-scope` is documented as controlling where *network settings* (proxy / timeout / TLS / rate limit) apply.

**Fix.** Apply `with_subdomains` before the guard.

**Test.** `runner::tests::test_subdomain_inclusion_is_not_a_network_setting` (all three scopes).

## 6. Verbose runner output went to stdout, corrupting piped results

**Symptom.**
```
urx example.com --providers wayback -v --no-progress > urls.txt
# urls.txt contained "Adding Wayback Machine provider", "  - Robots.txt: Found 0 URLs for example.com",
# "Domain completed: example.com (1/1)", … mixed into the URL list
```
Worse without `--no-progress`: those writes bypassed `MultiProgress`, desyncing its line tracking so `clear()` left stale bars behind — the exact hazard `ProgressManager::note`'s own doc comment warns about.

**Root cause.** `src/runner/mod.rs` and `src/tester_manager/mod.rs` used bare `println!`/`eprintln!` from inside spawned tasks.

**Fix.** Added `Notifier` (`src/progress/mod.rs`), a cloneable `Send + Sync` handle over the same sink `ProgressManager::note` uses, and routed every per-domain / per-URL diagnostic through it (stderr, and through the live region while it is up). `add_provider`'s config dump becomes `eprintln!` — it runs before any bar is drawn.

**Test.** `runner::tests::test_verbose_progress_lines_never_touch_stdout`, using a new test-only capturing `ProgressManager`.

---

## Verified as *not* broken

- **`--rate-limit` sharing.** Each provider builds one `RateLimiter` in `with_rate_limit`; the runner clones the provider once and shares it via `Arc` across all concurrent domain futures, and `RateLimiter`'s `Arc<Mutex<Option<Instant>>>` is shared by clones. The README claim ("a provider's `--rate-limit` is shared across them") holds.
- **`--parallel`.** Really is per-provider domain concurrency (`buffer_unordered(effective_parallel)`); `--parallel 1` is strictly sequential (existing test). No unbounded task spawning — the tester stage streams 10-URL chunks through `buffer_unordered(parallel)`.
- **Invalid `--network-scope` / `--parallel 0` / unknown `--rate-limit-by` id** are all rejected by clap validators already.
- **Progress bars** are drawn on stderr by `MultiProgress`; hidden under `--no-progress`/`--silent`; no division by zero, and the test bar's position is clamped with `.min(total)`.
- **`--extract-links` body cap** (10 MiB) holds — existing test passes.

## Out-of-scope findings

1. **[a3-api-providers] Providers must consult the new stop signal to complete fix #1.** Each cursor-walking loop needs, right after a page is collected:
   ```rust
   if let Some(r) = &reporter {
       if r.stop_requested() { r.mark_partial(); break; }
   }
   ```
   Sites: `wayback.rs:~243`, `arquivo.rs:~200`, `commoncrawl.rs:~275`, `otx.rs:~330`, `urlscan.rs:~268`, `vt.rs:~280`, `zoomeye.rs:~262`, `github.rs:~278` — i.e. wherever `mark_partial()` is already called. Without this the runner's 2s grace window expires and the hard abort still loses the buffer.
2. **[utils owner] `utils::verbose_print` prints to stdout** (`src/utils/mod.rs:9`), so `-v > file` is still contaminated by lines from `main.rs`, `app/pipeline.rs`, `app/caching.rs` and `app/selection.rs` ("Using provider-based concurrency…", "Total unique URLs after filtering: …"). One-line fix: `println!` → `eprintln!`. I fixed only the call sites I own.
3. **[caching owner] `--stats` prints nothing at all on a fully-cached run.** `urx example.com --providers wayback --stats` served entirely from the sqlite cache returns 860k URLs and an empty stats table (`app/caching.rs:191` assigns `fresh_run.stats`, which is empty when no provider ran). It should say the results came from cache rather than silently omit the section.
4. **[providers owner] `providers::otx::tests::test_fetch_urls_with_nonexistent_domain` is a live-network flake.** It calls `otx.alienvault.com` and asserts an error; it fails intermittently under full-suite parallelism (and stretches the suite from ~5s to ~90s). It passes in isolation. Should be a mockito test.
5. **[cli owner] `--rate-limit 0` / negative values are silently ignored** (no validator; `RateLimiter::new` returns `None` = unlimited). Compare `--parallel`/`--timeout`, which reject 0 loudly.
6. **[cli owner] `--max-time` help text** should mention the short grace window: the process may run ~2s past the deadline while in-flight fetches hand back partial results.
