### PR TITLE
fix(cdx): stop silent truncation in the wayback, arquivo and cc index walks

### DIFF
--- a/src/providers/arquivo.rs
+++ b/src/providers/arquivo.rs
@@ -10,13 +10,23 @@ use crate::network::client::{get_with_retry, HttpClientConfig};
 use crate::network::RateLimiter;
 use crate::progress::ProgressReporter;
 
-/// Hard ceiling on the number of CDX pages walked for one domain. Arquivo.pt's
-/// CDX server paginates large result sets into ZipNum blocks via `page=`, but a
-/// domain small enough to fit in a single block ignores `page` and returns the
-/// full set on every request. We stop as soon as a page contributes no new URLs
-/// (see the fetch loop), so this ceiling is only a runaway backstop — at tens of
-/// thousands of rows per page it covers far more URLs than any real domain has.
+/// Hard ceiling on the number of CDX pages walked for one domain. Arquivo.pt
+/// accepts `page=` but was measured to ignore it — `page=0` and `page=1` come
+/// back byte-identical for both a five-row domain and a capped 100k-row one. We
+/// stop as soon as a page contributes no new URLs (see the fetch loop), so this
+/// ceiling is only a runaway backstop in case a future deployment does start
+/// honouring the parameter.
 const MAX_PAGES: usize = 1_000;
+
+/// Rows to request per page. Arquivo.pt caps a `limit`-less response at 100,000
+/// rows *silently*: the body simply stops, with no marker and no cursor to
+/// resume from. Asking for that same bound explicitly is what makes the cap
+/// detectable — a page that comes back holding exactly `ROW_LIMIT` rows was
+/// truncated, and anything shorter is the complete result set.
+///
+/// Raising it does not help: `limit=300000` made the server stream so slowly
+/// that a 300-second request delivered only 59k rows before timing out.
+const ROW_LIMIT: usize = 100_000;
 
 /// One row of Arquivo.pt's CDX `output=json` response. Each line of the body is
 /// a standalone JSON object (CDXJ / NDJSON); we only need the captured URL.
@@ -59,6 +69,8 @@ pub struct ArquivoProvider {
     filters: ArchiveFilters,
     #[cfg(test)]
     base_url: String,
+    #[cfg(test)]
+    row_limit: usize,
 }
 
 impl ArquivoProvider {
@@ -76,6 +88,8 @@ impl ArquivoProvider {
             filters: ArchiveFilters::default(),
             #[cfg(test)]
             base_url: "https://arquivo.pt".to_string(),
+            #[cfg(test)]
+            row_limit: ROW_LIMIT,
         }
     }
 
@@ -91,6 +105,26 @@ impl ArquivoProvider {
     pub fn with_base_url(&mut self, url: String) -> &mut Self {
         self.base_url = url;
         self
+    }
+
+    /// Shrink the per-page row bound so a test can exercise the truncated-page
+    /// path without a mock body of a hundred thousand rows.
+    #[cfg(test)]
+    pub fn with_row_limit(&mut self, rows: usize) -> &mut Self {
+        self.row_limit = rows;
+        self
+    }
+
+    /// Rows requested per page. See [`ROW_LIMIT`].
+    fn row_limit(&self) -> usize {
+        #[cfg(test)]
+        {
+            self.row_limit
+        }
+        #[cfg(not(test))]
+        {
+            ROW_LIMIT
+        }
     }
 
     /// Build an `HttpClientConfig` from the current provider settings.
@@ -121,13 +155,16 @@ impl ArquivoProvider {
     /// `/*` matches the host and all of its paths — the same wildcard forms the
     /// Wayback provider uses, which Arquivo's CDX server honours as well.
     ///
-    /// `collapse=urlkey` is essential, not just an optimisation: Arquivo returns
-    /// one row per *capture*, and popular URLs accumulate thousands of captures
-    /// (observed ~3.7× row inflation). Without collapsing, a single
-    /// heavily-recaptured URL can fill an entire `page`, which the walk would
-    /// see as "no new URLs" and stop early — silently under-collecting every URL
-    /// that sorts after it. Collapsing adjacent duplicate urlkeys yields ~one row
-    /// per unique URL per page, so a non-final page always carries new URLs.
+    /// `fl=url` asks for just the captured URL, which is the only field
+    /// [`parse_records`] reads. It matters at this scale: a full-record page of
+    /// a large domain is ~25 MB where the same rows as `fl=url` are ~6 MB, and
+    /// that whole body is buffered in memory before parsing.
+    ///
+    /// `collapse=urlkey` is sent because it is the correct request for a
+    /// capture-level index — Arquivo returns one row per *capture*, so popular
+    /// URLs repeat for thousands of rows — but the live server was measured to
+    /// ignore it (`limit=3` returns three rows sharing one urlkey). Nothing here
+    /// may assume the rows are collapsed.
     fn query_base(&self, domain: &str) -> String {
         let host = if self.include_subdomains {
             format!("*.{domain}")
@@ -135,7 +172,7 @@ impl ArquivoProvider {
             domain.to_string()
         };
         let mut url = format!(
-            "{}/wayback/cdx?url={host}/*&output=json&collapse=urlkey",
+            "{}/wayback/cdx?url={host}/*&output=json&fl=url&collapse=urlkey",
             self.base_url()
         );
         url.push_str(&self.filters.query_params(CdxDialect::Pywb));
@@ -169,22 +206,31 @@ impl Provider for ArquivoProvider {
                 r.detail("fetching…");
             }
 
-            // Walk the `page=` cursor. Arquivo only paginates result sets that
-            // span multiple ZipNum blocks; a domain that fits in a single block
-            // ignores `page` and returns the full set on every request. So we
-            // stop as soon as a page adds no new URLs (rather than waiting for an
-            // empty page, which never comes for small domains). `seen` is the
-            // single source of truth: it dedups across pages and its growth
-            // drives the no-progress stop condition.
+            // Walk the `page=` cursor. Arquivo accepts `page` but was measured
+            // to ignore it, so in practice this loop runs once — and that is the
+            // point of the explicit `limit`: a page holding fewer rows than we
+            // asked for is provably the complete result set, so we stop without
+            // spending a second request re-downloading the identical body. Only
+            // a page the server truncated is worth a follow-up, and if that
+            // follow-up adds nothing then `page` is not advancing and the rest
+            // of the result set is unreachable — a partial, not a clean, crawl.
+            //
+            // `seen` is the single source of truth: it dedups across pages and
+            // its growth drives the no-progress stop condition.
+            let row_limit = self.row_limit();
             let mut seen: HashSet<String> = HashSet::new();
             let mut page = 0usize;
+            let mut truncated = false;
 
             loop {
                 if page >= MAX_PAGES {
+                    // Only reachable after a truncated page, i.e. with rows the
+                    // server still has and we have not read.
+                    truncated = true;
                     break;
                 }
 
-                let url = format!("{query_base}&page={page}");
+                let url = format!("{query_base}&limit={row_limit}&page={page}");
 
                 if let Some(rl) = &limiter {
                     rl.acquire().await;
@@ -208,6 +254,11 @@ impl Provider for ArquivoProvider {
                     }
                 };
 
+                // Row count, not URL count: rows the server sent that we could
+                // not parse, or that were duplicate captures of a URL we already
+                // have, still count against `limit`. Only the raw row total says
+                // whether the server truncated us.
+                let rows = text.lines().filter(|l| !l.trim().is_empty()).count();
                 let before = seen.len();
                 seen.extend(parse_records(&text));
 
@@ -215,13 +266,26 @@ impl Provider for ArquivoProvider {
                     r.detail(format!("{} URLs…", seen.len()));
                 }
 
-                // No new URLs ⇒ either this was the last page, or the server is
-                // ignoring `page` and re-serving the same rows. Either way, stop.
+                // Short page ⇒ the server gave us everything it had for this
+                // query. Done, and complete.
+                if rows < row_limit {
+                    break;
+                }
+
+                // The page was capped, so rows remain. Adding no new URLs means
+                // `page` did not move us past them and never will.
                 if seen.len() == before {
+                    truncated = true;
                     break;
                 }
 
                 page += 1;
+            }
+
+            if truncated {
+                if let Some(r) = &reporter {
+                    r.mark_partial();
+                }
             }
 
             let mut urls: Vec<String> = seen.into_iter().collect();
@@ -368,7 +432,7 @@ mod tests {
         let provider = ArquivoProvider::new();
         assert_eq!(
             provider.query_base("example.com"),
-            "https://arquivo.pt/wayback/cdx?url=example.com/*&output=json&collapse=urlkey"
+            "https://arquivo.pt/wayback/cdx?url=example.com/*&output=json&fl=url&collapse=urlkey"
         );
     }
 
@@ -378,7 +442,7 @@ mod tests {
         provider.with_subdomains(true);
         assert_eq!(
             provider.query_base("example.com"),
-            "https://arquivo.pt/wayback/cdx?url=*.example.com/*&output=json&collapse=urlkey"
+            "https://arquivo.pt/wayback/cdx?url=*.example.com/*&output=json&fl=url&collapse=urlkey"
         );
     }
 
@@ -404,14 +468,17 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_urls_integration() {
         let mut server = mockito::Server::new_async().await;
-        // Page 0 carries results (with a duplicate to prove dedup); page 1 is
-        // empty, which terminates the walk.
+        // Page 0 carries results (with a duplicate to prove dedup) and comes
+        // back short of the requested `limit`, so it is provably the whole
+        // result set and no second page is requested.
         let page0 = server
             .mock("GET", "/wayback/cdx")
             .match_query(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
                 mockito::Matcher::UrlEncoded("output".into(), "json".into()),
+                mockito::Matcher::UrlEncoded("fl".into(), "url".into()),
                 mockito::Matcher::UrlEncoded("collapse".into(), "urlkey".into()),
+                mockito::Matcher::UrlEncoded("limit".into(), ROW_LIMIT.to_string()),
                 mockito::Matcher::UrlEncoded("page".into(), "0".into()),
             ]))
             .with_status(200)
@@ -429,18 +496,23 @@ mod tests {
             .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
             .with_status(200)
             .with_body("")
-            .expect(1)
+            .expect(0)
             .create_async()
             .await;
 
         let mut provider = ArquivoProvider::new();
         provider.with_base_url(server.url());
 
-        let urls = provider.fetch_urls("example.com").await.unwrap();
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
 
         assert_eq!(urls.len(), 2);
         assert_eq!(urls[0], "http://example.com/page1");
         assert_eq!(urls[1], "http://example.com/page2");
+        assert!(!reporter.is_partial());
 
         page0.assert();
         page1.assert();
@@ -512,8 +584,15 @@ mod tests {
 
         let mut provider = ArquivoProvider::new();
         provider.with_base_url(server.url());
+        // Two rows per page is a full page here, so each page looks truncated
+        // and the walk keeps going until a short one.
+        provider.with_row_limit(2);
 
-        let urls = provider.fetch_urls("example.com").await.unwrap();
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
 
         assert_eq!(
             urls,
@@ -523,16 +602,20 @@ mod tests {
                 "http://example.com/c".to_string(),
             ]
         );
+        // Page 2 was short, so the walk reached the real end.
+        assert!(!reporter.is_partial());
         page0.assert();
         page1.assert();
         page2.assert();
     }
 
     #[tokio::test]
-    async fn test_fetch_urls_stops_when_page_param_ignored() {
-        // A small domain fits in one ZipNum block, so Arquivo ignores `page` and
-        // re-serves the same rows. The walk must stop after the first repeat
-        // (page 1 adds no new URLs) instead of looping forever.
+    async fn test_truncated_page_that_repeats_is_reported_partial() {
+        // Arquivo ignores `page`: a truncated page 0 and page 1 come back with
+        // the identical rows. The walk must stop after the first repeat instead
+        // of looping forever — and, because the server told us (by filling the
+        // page to the limit) that it still had rows we never reached, the result
+        // must be flagged partial rather than passed off as a full crawl.
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/wayback/cdx")
@@ -545,6 +628,89 @@ mod tests {
 
         let mut provider = ArquivoProvider::new();
         provider.with_base_url(server.url());
+        provider.with_row_limit(2); // both pages come back full ⇒ truncated
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        assert!(reporter.is_partial());
+        // Exactly two requests: page 0 (new rows) then page 1 (all duplicates).
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_short_page_costs_only_one_request() {
+        // `page` is ignored by the live server, so a follow-up page re-downloads
+        // the identical body — up to ~25 MB on a large domain — for nothing. A
+        // page shorter than the requested limit is provably complete, so there
+        // is no follow-up to make.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n{\"url\":\"http://example.com/b\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_row_limit(10); // 2 rows < 10 ⇒ that was everything
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(urls.len(), 2);
+        assert!(!reporter.is_partial());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_captures_still_count_against_the_row_limit() {
+        // Arquivo ignores `collapse=urlkey` and returns one row per capture, so
+        // a page can be full of rows while adding few unique URLs. Truncation
+        // must be judged on rows received, not on URLs collected, or a page of
+        // repeats reads as "short" and the rest of the domain is dropped.
+        let mut server = mockito::Server::new_async().await;
+        let page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            // Three rows, one unique URL — a capture-level index doing its thing.
+            .with_body(
+                "{\"url\":\"http://example.com/a\"}\n\
+                 {\"url\":\"http://example.com/a\"}\n\
+                 {\"url\":\"http://example.com/a\"}\n",
+            )
+            .expect(1)
+            .create_async()
+            .await;
+        let page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/b\"}\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_row_limit(3);
 
         let urls = provider.fetch_urls("example.com").await.unwrap();
 
@@ -555,8 +721,8 @@ mod tests {
                 "http://example.com/b".to_string(),
             ]
         );
-        // Exactly two requests: page 0 (new rows) then page 1 (all duplicates).
-        mock.assert();
+        page0.assert();
+        page1.assert();
     }
 
     #[tokio::test]
@@ -621,6 +787,7 @@ mod tests {
         let mut provider = ArquivoProvider::new();
         provider.with_base_url(server.url());
         provider.with_retries(0); // fail fast, don't sleep through back-off
+        provider.with_row_limit(2); // page 0 comes back full ⇒ page 1 is fetched
 
         let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
         let urls = provider
@@ -669,6 +836,9 @@ mod tests {
 
         let mut provider = ArquivoProvider::new();
         provider.with_base_url(server.url());
+        // One row fills a page here, so page 0 looks truncated and page 1 is
+        // fetched — which is what gives the limiter something to pace.
+        provider.with_row_limit(1);
         // 5 req/s ⇒ a 200ms minimum gap between page requests.
         provider.with_rate_limit(Some(5.0));
 

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -20,6 +20,12 @@ pub(crate) const LATEST_INDEX_ALIAS: &str = "latest";
 /// covers far more captures than any real domain has.
 const CC_MAX_PAGES: usize = 10_000;
 
+/// How many pages in a row may fail before we give up on the whole walk.
+/// A single failed page is skipped (they are independently addressable), but a
+/// run of them means the index is unhealthy and continuing would only add
+/// requests and back-off delay to an already-doomed fetch.
+const MAX_CONSECUTIVE_PAGE_FAILURES: usize = 3;
+
 /// Validate that a Common Crawl index identifier matches the expected
 /// `CC-MAIN-YYYY-WW` shape before we splice it into a URL path. This guards
 /// against a hostile or corrupted `collinfo.json` causing path manipulation.
@@ -250,6 +256,7 @@ impl Provider for CommonCrawlProvider {
             let pages = pages.min(CC_MAX_PAGES);
 
             let mut urls = Vec::new();
+            let mut consecutive_failures = 0usize;
             for page in 0..pages {
                 if let Some(rl) = &limiter {
                     rl.acquire().await;
@@ -257,6 +264,7 @@ impl Provider for CommonCrawlProvider {
                 let page_url = format!("{query_base}&page={page}");
                 match get_with_retry(&client, &page_url, self.retries).await {
                     Ok(text) => {
+                        consecutive_failures = 0;
                         // Common Crawl returns one JSON object per line.
                         for line in text.lines() {
                             if let Ok(record) = serde_json::from_str::<CCRecord>(line) {
@@ -268,17 +276,28 @@ impl Provider for CommonCrawlProvider {
                         }
                     }
                     Err(e) => {
-                        // Nothing collected yet (e.g. a not-found domain whose
-                        // first page 404s) is a hard failure, matching the old
-                        // single-request behaviour. A mid-pagination failure
-                        // keeps what we have and flags the result as partial.
-                        if urls.is_empty() {
+                        // A failure on the very first page (e.g. the 404 the
+                        // index returns for a domain it has no captures for) is
+                        // a hard failure, matching the old single-request
+                        // behaviour.
+                        if page == 0 {
                             return Err(e);
                         }
+                        // Later pages are *independently addressable* — `page=N`
+                        // is a direct block address, not a cursor — so one bad
+                        // page says nothing about the rest. Skipping it costs a
+                        // slice; abandoning the walk here used to throw away
+                        // every remaining page (on a 266-page domain, a single
+                        // hiccup on page 5 discarded 98% of the result).
                         if let Some(r) = &reporter {
                             r.mark_partial();
                         }
-                        break;
+                        consecutive_failures += 1;
+                        if consecutive_failures >= MAX_CONSECUTIVE_PAGE_FAILURES {
+                            // The index itself is unhealthy rather than one page
+                            // being unlucky; stop hammering it.
+                            break;
+                        }
                     }
                 }
             }
@@ -810,5 +829,154 @@ mod tests {
 
         let q = provider.query_base("CC-MAIN-2026-17", "example.com");
         assert!(!q.contains("filter="), "{q}");
+    }
+
+    #[tokio::test]
+    async fn test_one_failed_page_does_not_abandon_the_rest() {
+        // Common Crawl's `page=N` is a direct block address, not a cursor, so a
+        // failure on one page tells us nothing about the pages after it. The
+        // walk used to `break` here, discarding every remaining page — on a
+        // 266-page domain one transient 503 cost 98% of the result.
+        let mut server = mockito::Server::new_async().await;
+
+        let _probe = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showNumPages".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"pages": 3, "pageSize": 5, "blocks": 12}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let page0 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/a\"}")
+            .expect(1)
+            .create_async()
+            .await;
+        let page1 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "2".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/c\"}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = CommonCrawlProvider::new();
+        provider.base_url = server.url();
+        provider.with_retries(0); // fail fast, don't sleep through back-off
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        // Page 2 is still fetched even though page 1 failed.
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/a".to_string(),
+                "https://example.com/c".to_string(),
+            ]
+        );
+        // ...and the gap is reported rather than passed off as a clean crawl.
+        assert!(reporter.is_partial());
+        page0.assert();
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_walk_gives_up_after_repeated_page_failures() {
+        // A run of failures means the index is unhealthy, not that one page was
+        // unlucky — stop instead of walking every remaining page.
+        let mut server = mockito::Server::new_async().await;
+
+        let _probe = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showNumPages".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"pages": 20, "pageSize": 5, "blocks": 100}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let _page0 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/a\"}")
+            .expect(1)
+            .create_async()
+            .await;
+        // Pages 1.. all fail; only MAX_CONSECUTIVE_PAGE_FAILURES of them are
+        // attempted before the walk stops.
+        let failing = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .expect(MAX_CONSECUTIVE_PAGE_FAILURES)
+            .create_async()
+            .await;
+
+        let mut provider = CommonCrawlProvider::new();
+        provider.base_url = server.url();
+        provider.with_retries(0);
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(urls, vec!["https://example.com/a".to_string()]);
+        assert!(reporter.is_partial());
+        failing.assert();
+    }
+
+    #[tokio::test]
+    async fn test_first_page_failure_is_still_fatal() {
+        // A domain the index has no captures for answers page 0 with a 404;
+        // that must stay an error rather than an empty success.
+        let mut server = mockito::Server::new_async().await;
+
+        let _probe = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showNumPages".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"pages": 2, "pageSize": 5, "blocks": 6}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let _page0 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::Any)
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut provider = CommonCrawlProvider::new();
+        provider.base_url = server.url();
+        provider.with_retries(0);
+
+        assert!(provider.fetch_urls("example.com").await.is_err());
     }
 }

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -191,11 +192,22 @@ impl Provider for WaybackMachineProvider {
             // fast requests instead of one unbounded request that times out.
             let mut urls: Vec<String> = Vec::new();
             let mut resume_key: Option<String> = None;
+            // Every cursor position we have already requested. A key we have
+            // seen before means the cursor is stuck or cycling, which is the
+            // only way this walk can fail to terminate — comparing against just
+            // the previous key misses cycles of length two or more.
+            let mut seen_keys: HashSet<String> = HashSet::new();
             let mut pages = 0usize;
+            // Set when we stop while the server was still advertising more
+            // results, so a truncated crawl is never reported as a clean one.
+            let mut truncated = false;
 
             loop {
                 pages += 1;
                 if pages > MAX_PAGES {
+                    // We only get here holding a resume key, i.e. with results
+                    // left on the server.
+                    truncated = true;
                     break;
                 }
 
@@ -228,21 +240,34 @@ impl Provider for WaybackMachineProvider {
                 };
 
                 let (page_urls, next_key) = split_page(&text);
-                let got = page_urls.len();
                 urls.extend(page_urls);
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", urls.len()));
                 }
 
-                // Continue only when the cursor actually advanced: a new resume
-                // key AND a non-empty page. Otherwise we've reached the end (or
-                // a stuck cursor) and must stop to avoid looping forever.
+                // No resume key ⇒ the server said this was the last slice, so
+                // the walk is complete. A key means more results remain: follow
+                // it whenever it is one we have not used yet. A *new* key is
+                // progress even when the page carried no rows — a server-side
+                // `filter=` can empty an entire slice — while a key we have
+                // already requested means the cursor is not advancing, and
+                // continuing would just re-fetch the same slices forever.
                 match next_key {
-                    Some(key) if got > 0 && resume_key.as_deref() != Some(key.as_str()) => {
+                    None => break,
+                    Some(key) => {
+                        if !seen_keys.insert(key.clone()) {
+                            truncated = true;
+                            break;
+                        }
                         resume_key = Some(key);
                     }
-                    _ => break,
+                }
+            }
+
+            if truncated {
+                if let Some(r) = &reporter {
+                    r.mark_partial();
                 }
             }
 
@@ -850,5 +875,177 @@ mod tests {
         assert!(q.contains("&from=20200101000000"), "{q}");
         // Multiple exclusions fold into one negated alternation on this dialect.
         assert!(q.contains("&filter=!statuscode:%28404%7C500%29"), "{q}");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_follows_a_new_key_past_an_empty_page() {
+        // A slice can come back with zero rows and still carry a resume key —
+        // a server-side `filter=` predicate can reject every capture in it.
+        // The key is the server saying "more results remain", so the walk must
+        // follow it instead of treating the empty page as the end.
+        let mut server = mockito::Server::new_async().await;
+        let empty = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showResumeKey".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body("\nKEY2\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/a\nhttp://example.com/b\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        // The walk ran to the server's own end, so nothing is missing.
+        assert!(!reporter.is_partial());
+        empty.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_stops_on_a_cycling_cursor() {
+        // A cursor that alternates A → B → A → B never repeats the *previous*
+        // key, so a one-step comparison never fires and the walk runs until the
+        // MAX_PAGES backstop (10k requests at the archive). Any key we have
+        // already requested must end the walk immediately.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let requests = Arc::new(AtomicUsize::new(0));
+        let counter = requests.clone();
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .expect_at_least(1)
+            .with_body_from_request(move |req| {
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                let next = if req.path_and_query().contains("resumeKey=A") {
+                    "B"
+                } else {
+                    "A"
+                };
+                format!("http://example.com/{n}\n\n{next}\n").into_bytes()
+            })
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        // First page (key A), second page (key B), third page hands back A —
+        // already used, so we stop there.
+        assert_eq!(requests.load(Ordering::SeqCst), 3);
+        assert_eq!(urls.len(), 3);
+        // The server still claimed more results, so this is not a clean crawl.
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_urls_stops_on_a_stalled_cursor_and_flags_partial() {
+        // The degenerate case of the same bug: the server keeps handing back
+        // the identical key. One repeat is enough to stop.
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("http://example.com/a\n\nSTUCK\n")
+            .expect(2)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(urls, vec!["http://example.com/a".to_string()]);
+        assert!(reporter.is_partial());
+    }
+
+    #[tokio::test]
+    async fn test_complete_walk_is_not_flagged_partial() {
+        // The happy path must stay clean: the last page carries no resume key.
+        let mut server = mockito::Server::new_async().await;
+        let _page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showResumeKey".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/a\n\nKEY2\n")
+            .expect(1)
+            .create_async()
+            .await;
+        let _page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/b\n")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ");
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        assert!(!reporter.is_partial());
     }
 }


### PR DESCRIPTION
Three defects in the CDX-backed providers (`wayback`, `arquivo`, `cc`). Each was found by probing the live index servers, each is reproduced by a `mockito` regression test that fails on `main` and passes here, and each is a case of urx silently handing back an incomplete result while reporting it as a clean crawl.

Files touched: `src/providers/wayback.rs`, `src/providers/arquivo.rs`, `src/providers/commoncrawl.rs`. Nothing outside the CDX provider area.

---

## Bug 1 — wayback: the cursor guard misses cycles, and an empty slice ends the walk

**Symptom.** Two ways the resume-key walk goes wrong, both ending in a result reported as complete:

* A cursor that cycles (`A → B → A → B …`) is never caught, so urx issues 10,000 requests to `web.archive.org` and then returns as a clean success.
* A slice that comes back with zero rows *but a resume key* ends the walk immediately, dropping every result after it — again as a clean success, not a partial.

**Repro.** Both are in the new tests. As a direct measurement of the first, against a `mockito` server that alternates the key on every request:

```
EXPLORE cycling-cursor => 10000 urls, 10000 requests, 67.37s
```

67 s against a local mock; against archive.org, with its rate limiting and the retry/back-off in `get_with_retry`, that is hours of hammering one host for one domain.

**Root cause.** `src/providers/wayback.rs:245` (pre-fix):

```rust
Some(key) if got > 0 && resume_key.as_deref() != Some(key.as_str()) => { … }
_ => break,
```

Two problems in one arm. The loop guard compares the new key only with the *immediately previous* one, so any cycle of length ≥ 2 slips through and the walk runs to the `MAX_PAGES = 10_000` backstop. And `got > 0` treats an empty page as the end of the result set, when the resume key the server sent alongside it means exactly the opposite — a server-side `filter=` can empty a whole slice while results remain behind it. Neither stop, nor the `MAX_PAGES` stop, called `mark_partial()`, so all of it surfaced as a complete crawl.

**Fix.** Keep every key we have requested in a `HashSet`; a repeat of *any* of them ends the walk. Follow a genuinely new key even when the page it came with was empty. Set a `truncated` flag on every stop that happens while the server is still advertising more results, and `mark_partial()` on the way out.

Tests: `test_fetch_urls_stops_on_a_cycling_cursor` (asserts exactly 3 requests, and partial), `test_fetch_urls_follows_a_new_key_past_an_empty_page`, `test_fetch_urls_stops_on_a_stalled_cursor_and_flags_partial`, `test_complete_walk_is_not_flagged_partial` (the happy path stays clean). The first three fail on `main`.

**Live check.** `urx hahwul.com --providers wayback` returns 4836 URLs, `partial 0` — byte-identical to a direct unpaginated `curl` of the CDX API (4836 unique rows). The multi-page path is unaffected: `urx example.com --providers wayback --no-cache` walks the cursor to the end and returns **860,295 URLs, `partial 0`, `errors 0`** in 991 s, matching the count seen on `main`.

---

## Bug 2 — arquivo: every domain fetched twice, results past the server's row cap dropped silently

**Symptom.** `urx sapo.pt --providers arquivo --stats` reported **40,416 URLs, `partial 0`** in 75 s, having downloaded the same ~25 MB body twice. The real result set is far larger — the last row returned is still on the root path's query strings.

**Repro / ground truth**, straight from the live server:

```
$ curl -s "https://arquivo.pt/wayback/cdx?url=sapo.pt/*&output=json&collapse=urlkey&page=0" -o p0
$ curl -s "https://arquivo.pt/wayback/cdx?url=sapo.pt/*&output=json&collapse=urlkey&page=1" -o p1
$ wc -l p0 p1 ; cmp -s p0 p1 && echo identical
  100000 p0
  100000 p1
identical
```

* `page=` is **ignored** — page 0 and page 1 are byte-identical, for a 5-row domain as well as this one.
* `collapse=urlkey` is **ignored** — `&limit=3` returns three rows sharing the urlkey `pt,sapo)/`.
* A `limit`-less response is **silently capped at 100,000 rows**: the body just stops, with no marker and no cursor.
* `offset=` and `showNumPages=` are ignored too; `limit=` and `fl=` are honoured.

**Root cause.** `src/providers/arquivo.rs:172` and the walk at `:209`. The provider walked `page=0,1,2,…` and stopped when a page added no new URLs, on the documented assumption that "`collapse=urlkey` yields ~one row per unique URL per page, so a non-final page always carries new URLs". Both halves of that assumption are false against the live server. What actually happened every run: page 0 hits the hidden 100k-row cap, page 1 re-downloads the identical body, it adds nothing, the walk stops — and because nothing failed, the truncated result was reported as complete.

**Fix.** Send an explicit `&limit=ROW_LIMIT` (100,000 — the server's own effective cap, so no extra load). That single change makes the cap *legible*: a page shorter than the limit is provably the entire result set, so we stop without the wasted duplicate request; a page filled to the limit means rows remain, so if the follow-up page adds nothing, `page` is not advancing and we `mark_partial()` instead of claiming a full crawl. Truncation is judged on **rows received**, not URLs collected, since an un-collapsed capture-level index sends many rows per URL. Also send `fl=url` — the only field `parse_records` reads — which cuts a large page from ~25 MB to ~6 MB.

`ROW_LIMIT` is not raised: `limit=300000` makes the server stream so slowly that a 300 s request delivered only 59k rows before timing out.

**Result** (`--no-cache`, same command):

| | before | after |
|---|---|---|
| `sapo.pt` | 75 s, 40,416 URLs, `partial 0` | 27 s, 40,392 URLs, `partial 1` |
| `hahwul.com` | 2 requests | 1 request, 5 URLs, `partial 0` |

Tests: `test_short_page_costs_only_one_request`, `test_truncated_page_that_repeats_is_reported_partial`, `test_duplicate_captures_still_count_against_the_row_limit`. Existing pagination tests were updated to the corrected behaviour via a `#[cfg(test)]` `with_row_limit()` so the truncated-page path is exercised without a 100k-row mock body.

---

## Bug 3 — commoncrawl: one failed page abandons every page after it

**Symptom.** A single transient failure mid-walk discards the entire remainder of the result set. `*.wikipedia.org` spans 266 pages (`{"pages": 266, "pageSize": 5, "blocks": 1328}`); one 503 on page 5 returns ~2% of the data.

**Root cause.** `src/providers/commoncrawl.rs:277` (pre-fix) — the error arm ended in `break`. That is the right shape for the Wayback *cursor* (you cannot skip a cursor position), but Common Crawl's `page=N` is a **direct block address**, not a cursor: page N+1 does not depend on page N. Confirmed against the live index — an out-of-range page answers `400 {"message": "Page 7 invalid: First Page is 0, Last Page is 0"}`, i.e. pages are addressed, not walked.

**Fix.** Skip the failed page, `mark_partial()`, and continue to the next one. Give up only after `MAX_CONSECUTIVE_PAGE_FAILURES = 3` failures in a row, which is the case where the index is unhealthy rather than one page unlucky. A failure on page 0 stays fatal (that is the 404 the index returns for a domain it has no captures for) — the guard is now `page == 0` rather than `urls.is_empty()`, which is what it always meant.

Tests: `test_one_failed_page_does_not_abandon_the_rest`, `test_walk_gives_up_after_repeated_page_failures` (both fail on `main`), `test_first_page_failure_is_still_fatal`.

**Live check.** `urx github.io --subs --providers cc --cc-index latest` walks all 34 pages: 415,196 URLs, `partial 0`, `errors 0`.

---

## Verified as correct — checked live, no change made

Things the brief flagged as suspect that turned out to be right, recorded so nobody re-investigates:

* **Wayback resume keys are base64url** (`eJxLzs_VyUjMKC_N0dQ3MjA00Tew0Dcw1S8u…`), so `encode_resume_key`'s percent-encoding is correct, not a double-encode.
* **`--subs` matches correctly** on all three: `url=*.example.com/*` includes the apex host as well as subdomains (CC returned `www.hahwul.com` plus 8 subdomains; the non-subs query returned only `www.hahwul.com`).
* **The pywb dialect really is exact-match.** `filter=status:(200|404)` on the CC index matched nothing on one attempt and returned `504 Gateway Time-out` on another — exactly the failure mode `filters.rs` documents. Dropping a multi-value positive list on `CdxDialect::Pywb` (rather than sending it) is right, and repeated `filter=!status:…` params are genuinely AND-ed.
* **`--to YYYYMM` padding to day 31 is safe.** `to=20260931235959` returns the same rows as `to=20260930235959` on CC; both servers compare timestamps as strings.
* **Common Crawl `showNumPages`/`page` is correct** as implemented, and `{"pages": 0}` for an uncaptured domain is handled.

## Out-of-scope findings

Not fixed here — outside the CDX provider files.

1. **`src/network/client.rs:106` `read_body_capped` truncates silently.** At `MAX_RESPONSE_BYTES` (128 MB) it stops reading and returns `Ok`, so an over-large body is parsed as if complete — likely cutting the final line mid-JSON. Every CDX provider reads through this. It should signal truncation to the caller so the provider can `mark_partial()`, the same way the in-provider truncation paths now do.
2. **`--providers arquivo` still runs Robots.txt and Sitemap.** `urx hahwul.com --providers arquivo --stats` lists all three in the stats table. Whether the keyless crawl providers are meant to be exempt from `--providers` is a `src/app/selection.rs` question.
3. **`--stats` prints nothing on a cache hit.** `urx hahwul.com --providers arquivo --stats` prints the provider table on the first run and no table at all on the second (cached) run, with no indication the result came from cache. `--no-cache` restores it. Likely `src/app/caching.rs` short-circuiting before the stats block.
