### PR TITLE
fix(build): restore the build after a semantic merge conflict between #359 and #360

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,8 @@ async fn collect_urls(
                 error_count: 0,
                 partial_count: 0,
                 elapsed,
+                // Reading local files has no deadline to be cut off by.
+                aborted: false,
             }],
         });
     }


### PR DESCRIPTION
`main` does not compile. Restoring it.

## What happened

- **#359** added a `ProviderStats` literal in `collect_urls` for the `--files` path, so `--stats` no longer prints nothing when input comes from a file.
- **#360** added the `aborted` field to `ProviderStats`, so a provider cut off by `--max-time` is no longer reported as a clean instant pass.

Neither PR touched the other's lines, so git merged both without a conflict and CI was green on each — each ran against a base that did not yet contain the other. The combination does not build:

```
error[E0063]: missing field `aborted` in initializer of `ProviderStats`
   --> src/main.rs:101:25
    |
101 |             stats: vec![ProviderStats {
    |                         ^^^^^^^^^^^^^ missing `aborted`
```

A textbook semantic merge conflict, and my mistake as the one merging: I checked each PR against its own base and did not rebuild `main` after the second merge landed.

## Fix

Initialise `aborted: false` in that literal. Reading local files has no deadline to be cut off by, so `false` is the honest value, not a placeholder.

## Verification

```
cargo build                                   # clean
cargo fmt --all --check                       # clean
cargo clippy --all-targets -- -D warnings     # clean
cargo test --bin urx                          # 700 passed; 0 failed; 2 ignored
```

https://claude.ai/code/session_01GP1rxkjBMXU1wVqbxC7Hch
