### PR TITLE
fix(providers): let --max-time keep the URLs a provider already collected

### DIFF
--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -111,6 +111,21 @@ impl StopSignal {
     pub fn is_stopped(&self) -> bool {
         self.0.load(Ordering::Relaxed)
     }
+
+    /// Resolve once a stop has been requested, so a provider can race this
+    /// against an in-flight request instead of only checking between pages.
+    ///
+    /// Checking between pages is not enough on its own: a Wayback CDX slice of
+    /// `limit=50000` takes tens of seconds, far longer than the runner's grace
+    /// window, so a deadline landing mid-page was never noticed and the whole
+    /// buffer died with the cancelled future. Polling rather than notifying
+    /// keeps [`StopSignal`] a plain flag usable from synchronous code; the
+    /// interval is negligible against any network fetch it races.
+    pub async fn stopped(&self) {
+        while !self.is_stopped() {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
 }
 
 /// A small, cloneable handle that providers use to surface fine-grained
@@ -162,6 +177,11 @@ impl ProgressReporter {
     /// [`mark_partial`]: ProgressReporter::mark_partial
     pub fn stop_requested(&self) -> bool {
         self.stop.is_stopped()
+    }
+
+    /// Resolve once the run asks this fetch to stop. See [`StopSignal::stopped`].
+    pub async fn stopped(&self) {
+        self.stop.stopped().await
     }
 
     /// Replace the trailing status detail, keeping the stable prefix.

--- a/src/providers/arquivo.rs
+++ b/src/providers/arquivo.rs
@@ -235,7 +235,25 @@ impl Provider for ArquivoProvider {
                 if let Some(rl) = &limiter {
                     rl.acquire().await;
                 }
-                let text = match get_with_retry(&client, &url, self.retries).await {
+                // Race the request against the stop signal, for the same
+                // reason wayback does: one page is large enough that a deadline
+                // landing mid-request would otherwise go unnoticed until after
+                // the runner's grace window had closed and thrown the buffer
+                // away.
+                let fetched = match &reporter {
+                    Some(r) => tokio::select! {
+                        biased;
+                        _ = r.stopped() => None,
+                        res = get_with_retry(&client, &url, self.retries) => Some(res),
+                    },
+                    None => Some(get_with_retry(&client, &url, self.retries).await),
+                };
+                let Some(result) = fetched else {
+                    // Stopped mid-request: keep the pages already walked.
+                    truncated = true;
+                    break;
+                };
+                let text = match result {
                     Ok(text) => text,
                     Err(e) => {
                         // Best effort: a mid-walk failure shouldn't discard the
@@ -264,6 +282,13 @@ impl Provider for ArquivoProvider {
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", seen.len()));
+                    // The run asked us to stop (--max-time elapsed, or Ctrl-C).
+                    // Hand back the pages already walked instead of losing them
+                    // to the hard cancel after the runner's grace window.
+                    if r.stop_requested() {
+                        truncated = true;
+                        break;
+                    }
                 }
 
                 // Short page ⇒ the server gave us everything it had for this

--- a/src/providers/arquivo.rs
+++ b/src/providers/arquivo.rs
@@ -356,6 +356,7 @@ impl Provider for ArquivoProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::StopSignal;
 
     #[test]
     fn test_new_provider() {
@@ -670,6 +671,93 @@ mod tests {
         );
         assert!(reporter.is_partial());
         // Exactly two requests: page 0 (new rows) then page 1 (all duplicates).
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_stop_request_keeps_the_pages_already_walked() {
+        // The runner raises a stop at the --max-time deadline and gives fetches
+        // a short grace window to hand back what they have. Without this the
+        // hard cancel that follows dropped the whole `seen` buffer, so
+        // --max-time returned nothing at all. The stop is raised from page
+        // zero's own handler, so it lands exactly when that page is served.
+        let mut server = mockito::Server::new_async().await;
+        let stop = StopSignal::default();
+
+        let flip = stop.clone();
+        let page0 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body_from_request(move |_| {
+                flip.request_stop();
+                b"{\"url\":\"http://example.com/a\"}\n{\"url\":\"http://example.com/b\"}\n".to_vec()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        // A full page means rows remain, so without the stop the walk would ask
+        // for page 1. It must not.
+        let page1 = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/c\"}\n")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+        provider.with_row_limit(2); // 2 rows == limit ⇒ the page was capped
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop.clone());
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        assert!(reporter.is_partial());
+        page0.assert();
+        page1.assert();
+    }
+
+    #[tokio::test]
+    async fn test_stop_before_the_first_request_issues_none() {
+        // A stop already pending must not fire off a request whose result can
+        // only be thrown away.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/wayback/cdx")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("{\"url\":\"http://example.com/a\"}\n")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut provider = ArquivoProvider::new();
+        provider.with_base_url(server.url());
+
+        let stop = StopSignal::default();
+        stop.request_stop();
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop);
+
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter))
+            .await
+            .unwrap();
+
+        assert!(urls.is_empty());
         mock.assert();
     }
 

--- a/src/providers/commoncrawl.rs
+++ b/src/providers/commoncrawl.rs
@@ -262,7 +262,25 @@ impl Provider for CommonCrawlProvider {
                     rl.acquire().await;
                 }
                 let page_url = format!("{query_base}&page={page}");
-                match get_with_retry(&client, &page_url, self.retries).await {
+                // Race the request against the stop signal so a deadline
+                // landing mid-page is noticed inside the runner's grace window
+                // rather than after the hard cancel has discarded the buffer.
+                let fetched = match &reporter {
+                    Some(r) => tokio::select! {
+                        biased;
+                        _ = r.stopped() => None,
+                        res = get_with_retry(&client, &page_url, self.retries) => Some(res),
+                    },
+                    None => Some(get_with_retry(&client, &page_url, self.retries).await),
+                };
+                let Some(result) = fetched else {
+                    // Stopped mid-request: keep the pages already walked.
+                    if let Some(r) = &reporter {
+                        r.mark_partial();
+                    }
+                    break;
+                };
+                match result {
                     Ok(text) => {
                         consecutive_failures = 0;
                         // Common Crawl returns one JSON object per line.
@@ -273,6 +291,16 @@ impl Provider for CommonCrawlProvider {
                         }
                         if let Some(r) = &reporter {
                             r.detail(format!("{} URLs…", urls.len()));
+                            // The run asked us to stop (--max-time elapsed, or
+                            // Ctrl-C). Hand back the pages already walked
+                            // instead of losing them to the hard cancel after
+                            // the runner's grace window.
+                            if r.stop_requested() {
+                                if page + 1 < pages {
+                                    r.mark_partial();
+                                }
+                                break;
+                            }
                         }
                     }
                     Err(e) => {
@@ -399,6 +427,7 @@ impl Provider for MockCommonCrawlProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::StopSignal;
 
     #[test]
     fn test_new_provider() {
@@ -829,6 +858,68 @@ mod tests {
 
         let q = provider.query_base("CC-MAIN-2026-17", "example.com");
         assert!(!q.contains("filter="), "{q}");
+    }
+
+    #[tokio::test]
+    async fn test_stop_request_keeps_the_pages_already_walked() {
+        // Companion to the wayback case: the page walk must hand back what it
+        // has when the run asks it to stop, instead of letting the runner's
+        // hard cancel drop the whole buffer. The stop is raised from the
+        // page-zero handler, so it lands exactly once that page has been
+        // served -- no sleeps, no race.
+        let mut server = mockito::Server::new_async().await;
+        let stop = StopSignal::default();
+
+        let _probe = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "showNumPages".into(),
+                "true".into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"pages": 3, "pageSize": 5, "blocks": 12}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let flip = stop.clone();
+        let page0 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "0".into()))
+            .with_status(200)
+            .with_body_from_request(move |_| {
+                flip.request_stop();
+                b"{\"url\": \"https://example.com/a\"}".to_vec()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        // Pages after the stop must never be requested.
+        let page1 = server
+            .mock("GET", "/CC-MAIN-2026-17-index")
+            .match_query(mockito::Matcher::UrlEncoded("page".into(), "1".into()))
+            .with_status(200)
+            .with_body("{\"url\": \"https://example.com/b\"}")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut provider = CommonCrawlProvider::new();
+        provider.base_url = server.url();
+        provider.with_retries(0);
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop.clone());
+
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(urls, vec!["https://example.com/a".to_string()]);
+        // Pages 1 and 2 were never walked, so the crawl is incomplete.
+        assert!(reporter.is_partial());
+        page0.assert();
+        page1.assert();
     }
 
     #[tokio::test]

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -243,6 +243,14 @@ impl Provider for GitHubProvider {
                                         // No more results — stop paginating.
                                         break 'pages;
                                     }
+                                    // The run asked us to stop (--max-time
+                                    // elapsed, or Ctrl-C). Keep the pages
+                                    // already walked instead of losing them to
+                                    // the hard cancel after the grace window.
+                                    if reporter.as_ref().is_some_and(|r| r.stop_requested()) {
+                                        truncated = true;
+                                        break 'pages;
+                                    }
                                     break;
                                 }
                                 Err(e) => {

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -336,6 +336,16 @@ impl Provider for OTXProvider {
                     break;
                 }
 
+                // The run asked us to stop (--max-time elapsed, or Ctrl-C).
+                // Hand back the pages already walked instead of losing them to
+                // the hard cancel after the runner's grace window.
+                if let Some(r) = &reporter {
+                    if r.stop_requested() {
+                        r.mark_partial();
+                        break;
+                    }
+                }
+
                 page += 1;
                 if page >= OTX_MAX_PAGES {
                     break;

--- a/src/providers/otx.rs
+++ b/src/providers/otx.rs
@@ -392,6 +392,7 @@ impl Provider for OTXProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::StopSignal;
 
     #[test]
     fn test_preview_text_multibyte_boundary() {
@@ -742,6 +743,67 @@ mod tests {
         let result = provider.fetch_urls("example.com").await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_stop_request_keeps_the_pages_already_walked() {
+        // The runner raises a stop at the --max-time deadline; without the walk
+        // consulting it, the hard cancel that follows the grace window dropped
+        // every page already collected. The stop is raised from page one's own
+        // handler, so it lands exactly when that page has been served.
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let stop = StopSignal::default();
+
+        // A full page, so `has_next` aside the walk would ask for page 2.
+        let rows: Vec<String> = (0..OTX_RESULTS_LIMIT)
+            .map(|i| format!(r#"{{"url":"http://example.com/{i}"}}"#))
+            .collect();
+        let flip = stop.clone();
+        let body = format!(
+            r#"{{ "has_next": true, "url_list": [{}] }}"#,
+            rows.join(",")
+        );
+        let _page1 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=1",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request(move |_| {
+                flip.request_stop();
+                body.clone().into_bytes()
+            })
+            .create();
+        // Page two must never be requested once the stop is pending.
+        let page2 = server
+            .mock(
+                "GET",
+                "/api/v1/indicators/domain/example.com/url_list?limit=200&page=2",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{ "has_next": false, "url_list": [{"url":"http://example.com/late"}] }"#)
+            .expect(0)
+            .create();
+
+        let mut provider = OTXProvider::new();
+        provider.with_base_url(url);
+        provider.with_retries(0);
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop.clone());
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .expect("page one must survive the deadline");
+
+        assert_eq!(urls.len(), OTX_RESULTS_LIMIT as usize);
+        assert!(!urls.contains(&"http://example.com/late".to_string()));
+        // Stopping early leaves the crawl incomplete, not cleanly finished.
+        assert!(reporter.is_partial());
+        page2.assert();
     }
 
     #[tokio::test]

--- a/src/providers/urlscan.rs
+++ b/src/providers/urlscan.rs
@@ -291,6 +291,13 @@ impl Provider for UrlscanProvider {
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", all_urls.len()));
+                    // The run asked us to stop (--max-time elapsed, or
+                    // Ctrl-C). Hand back the pages already walked instead of
+                    // losing them to the hard cancel after the grace window.
+                    if r.stop_requested() {
+                        r.mark_partial();
+                        break;
+                    }
                 }
 
                 if !more {

--- a/src/providers/vt.rs
+++ b/src/providers/vt.rs
@@ -292,6 +292,13 @@ impl Provider for VirusTotalProvider {
                 }
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", urls.len()));
+                    // The run asked us to stop (--max-time elapsed, or
+                    // Ctrl-C). Hand back the pages already walked instead of
+                    // losing them to the hard cancel after the grace window.
+                    if r.stop_requested() {
+                        r.mark_partial();
+                        break;
+                    }
                 }
 
                 match page.meta.cursor {

--- a/src/providers/wayback.rs
+++ b/src/providers/wayback.rs
@@ -220,7 +220,25 @@ impl Provider for WaybackMachineProvider {
                 if let Some(rl) = &limiter {
                     rl.acquire().await;
                 }
-                let text = match get_with_retry(&client, &url, self.retries).await {
+                // Race the request against the stop signal. Checking only
+                // between pages is not enough: one CDX slice takes tens of
+                // seconds, so a deadline landing mid-page went unnoticed until
+                // long after the runner's grace window had closed and the hard
+                // cancel had thrown the buffer away.
+                let fetched = match &reporter {
+                    Some(r) => tokio::select! {
+                        biased;
+                        _ = r.stopped() => None,
+                        res = get_with_retry(&client, &url, self.retries) => Some(res),
+                    },
+                    None => Some(get_with_retry(&client, &url, self.retries).await),
+                };
+                let Some(result) = fetched else {
+                    // Stopped mid-request: keep the pages already walked.
+                    truncated = true;
+                    break;
+                };
+                let text = match result {
                     Ok(text) => text,
                     Err(e) => {
                         // Best effort: a mid-cursor failure shouldn't discard
@@ -244,6 +262,13 @@ impl Provider for WaybackMachineProvider {
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", urls.len()));
+                    // The run asked us to stop (--max-time elapsed, or Ctrl-C).
+                    // Hand back the pages already walked instead of losing them
+                    // to the hard cancel after the runner's grace window.
+                    if r.stop_requested() {
+                        truncated = true;
+                        break;
+                    }
                 }
 
                 // No resume key ⇒ the server said this was the last slice, so
@@ -316,6 +341,7 @@ impl Provider for WaybackMachineProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::StopSignal;
     // Removed unused import: std::time::Duration
 
     #[test]
@@ -504,6 +530,103 @@ mod tests {
         assert_eq!(urls[1], "http://example.com/page2");
 
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_stop_request_keeps_the_pages_already_walked() {
+        // Regression: `--max-time` is documented as returning "whatever URLs
+        // have been collected so far". The runner raises a stop signal at the
+        // deadline, but the walk never consulted it, so the hard cancel that
+        // followed the grace window dropped the provider's whole local buffer
+        // -- a 90s run over a domain with 860k captures returned zero URLs.
+        //
+        // The stop is raised from the page-one handler, so it lands exactly
+        // once that page has been served: no sleeps, no race.
+        let mut server = mockito::Server::new_async().await;
+        let stop = StopSignal::default();
+
+        let flip = stop.clone();
+        let page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("url".into(), "example.com/*".into()),
+                mockito::Matcher::UrlEncoded("showResumeKey".into(), "true".into()),
+            ]))
+            .with_status(200)
+            .with_body_from_request(move |_| {
+                flip.request_stop();
+                b"http://example.com/a\nhttp://example.com/b\n\nKEY2\n".to_vec()
+            })
+            .expect(1)
+            .create_async()
+            .await;
+        // The continuation carries a resume key, so without the stop the walk
+        // would follow it. It must never be requested.
+        let page2 = server
+            .mock("GET", "/cdx/search/cdx")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "resumeKey".into(),
+                "KEY2".into(),
+            ))
+            .with_status(200)
+            .with_body("http://example.com/c\n")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop.clone());
+
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter.clone()))
+            .await
+            .unwrap();
+
+        // Page one survives the deadline instead of dying with the future.
+        assert_eq!(
+            urls,
+            vec![
+                "http://example.com/a".to_string(),
+                "http://example.com/b".to_string(),
+            ]
+        );
+        // ...and the walk is reported as incomplete, not as a clean crawl.
+        assert!(reporter.is_partial());
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
+    async fn test_stop_before_the_first_request_issues_none() {
+        // A stop already pending when the fetch starts must not fire off a
+        // request that can only be thrown away.
+        let mut server = mockito::Server::new_async().await;
+        let page1 = server
+            .mock("GET", "/cdx/search/cdx")
+            .with_status(200)
+            .with_body("http://example.com/a\n")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut provider = WaybackMachineProvider::new();
+        provider.with_base_url(server.url());
+
+        let stop = StopSignal::default();
+        stop.request_stop();
+        let reporter = ProgressReporter::new(indicatif::ProgressBar::hidden(), "test · ")
+            .with_stop_signal(stop);
+
+        let urls = provider
+            .fetch_urls_with_progress("example.com", Some(reporter))
+            .await
+            .unwrap();
+
+        assert!(urls.is_empty());
+        page1.assert();
     }
 
     #[tokio::test]

--- a/src/providers/zoomeye.rs
+++ b/src/providers/zoomeye.rs
@@ -285,6 +285,13 @@ impl Provider for ZoomEyeProvider {
 
                 if let Some(r) = &reporter {
                     r.detail(format!("{} URLs…", all_urls.len()));
+                    // The run asked us to stop (--max-time elapsed, or Ctrl-C).
+                    // Hand back the pages already walked instead of losing them
+                    // to the hard cancel after the runner's grace window.
+                    if r.stop_requested() {
+                        r.mark_partial();
+                        break;
+                    }
                 }
 
                 // Check if there are more pages. `rows_received` is what the


### PR DESCRIPTION
Completes the `--max-time` data-loss fix started in #360.

## The gap

#360 made ending a run cooperative: the runner raises a `StopSignal` at the deadline and waits a 2s grace window (`STOP_GRACE`) for in-flight fetches to hand back what they have, before cancelling whatever is left. It said so itself:

> ⚠️ **This is the runner half.** Providers must consult the signal for the URLs to actually be recovered.

No provider consulted it. So the grace window always expired, the hard cancel followed, and each provider's local buffer (`urls: Vec<String>` in `wayback.rs`, `seen: HashSet<String>` in `arquivo.rs`, …) died with the dropped future. `--max-time` is documented as proceeding "with whatever URLs have been collected so far" and returned nothing at all.

## The fix

Wire all eight paginating providers to the signal at the point each one already uses for a mid-walk failure — `mark_partial()` and `break`, returning the pages walked so far:

`wayback.rs`, `commoncrawl.rs`, `arquivo.rs`, `otx.rs`, `vt.rs`, `urlscan.rs`, `zoomeye.rs`, `github.rs`.

**Checking between pages is not enough on its own.** One Wayback CDX slice is `limit=50000` and takes tens of seconds — far longer than the 2s grace window — so a deadline landing mid-request went unnoticed until well after the hard cancel. The three CDX providers, whose walks run for minutes, therefore also race the request itself against the signal:

```rust
let fetched = match &reporter {
    Some(r) => tokio::select! {
        biased;
        _ = r.stopped() => None,
        res = get_with_retry(&client, &url, self.retries) => Some(res),
    },
    None => Some(get_with_retry(&client, &url, self.retries).await),
};
```

`StopSignal::stopped()` (new) resolves once a stop is requested. It polls at 50 ms rather than notifying, which keeps `StopSignal` a plain flag usable from synchronous code; the interval is negligible against any network fetch it races. The API providers page in hundreds of rows, so the between-page check is timely enough there and they are left alone.

## Tests

- `wayback::test_stop_request_keeps_the_pages_already_walked` — page one is served and the stop is raised **from that page's own mockito handler**, so it lands exactly when the page has been delivered: no sleeps, no race. Asserts page one's URLs come back, the continuation (whose resume key the walk would otherwise follow) is never requested, and the result is flagged partial.
- `wayback::test_stop_before_the_first_request_issues_none` — a stop already pending must not fire off a request that can only be thrown away.
- `commoncrawl::test_stop_request_keeps_the_pages_already_walked` — same shape for the `page=N` walk.

I verified the first test is not vacuous by removing the production check and re-running it:

```
assertion `left == right` failed
  left: ["http://example.com/a", "http://example.com/b", "http://example.com/c"]
 right: ["http://example.com/a", "http://example.com/b"]
```

## Verification

```
cargo fmt --all --check                                    # clean
cargo clippy --all-targets -- -D warnings                  # clean
cargo clippy --all-targets --features redis-cache -- -D warnings   # clean
cargo test --bin urx                                       # 703 passed; 0 failed; 2 ignored
```

## A note on live verification

I could not get a trustworthy end-to-end measurement against `web.archive.org`. The same command (`urx example.com --providers wayback --no-cache --max-time N`) returned 860,295 URLs over 673 s on one run and finished in 59 s having collected nothing on another — the CDX endpoint's throughput and rate limiting vary by an order of magnitude between runs. What the live runs do show consistently is the runner-side half from #360 working: the provider is now charged real elapsed time and flagged `(aborted)` instead of `0ms`. The recovery of the buffer itself is pinned by the deterministic mockito tests above rather than by a live run.

https://claude.ai/code/session_01GP1rxkjBMXU1wVqbxC7Hch
